### PR TITLE
docs: add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,82 @@
+name: Bug report
+description: Report a reproducible defect with expected behavior.
+title: "fix: "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What should be fixed, and what outcome should users get?
+      placeholder: Describe the corrected behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: observed-behavior
+    attributes:
+      label: Observed behavior
+      description: What happened instead?
+      placeholder: Describe the current broken behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: What should have happened?
+      placeholder: Describe the intended behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: How can someone reproduce the issue?
+      value: |
+        1. Run:
+        2. Observe:
+        3. Expected:
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What should be included in the fix?
+      placeholder: List the concrete work that belongs in this issue.
+    validations:
+      required: true
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of scope
+      description: What should not be included in the fix?
+      placeholder: List related work that should wait for another issue.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: What must be true before this bug is fixed?
+      value: |
+        - [ ]
+        - [ ]
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include relevant OS, Node.js, pnpm, or CLI details.
+      placeholder: macOS version, Node.js version, pnpm version, command used.
+    validations:
+      required: false
+  - type: textarea
+    id: implementation-notes
+    attributes:
+      label: Implementation notes
+      description: Add technical context, suspected cause, constraints, or suggested approach.
+      placeholder: Note any relevant files, commands, edge cases, or decisions.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,47 @@
+name: Feature request
+description: Plan a scoped feature or enhancement.
+title: "feat: "
+labels: ["feature"]
+body:
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What user or project outcome should this feature create?
+      placeholder: Describe the intended outcome.
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What should be included in this change?
+      placeholder: List the concrete work that belongs in this issue.
+    validations:
+      required: true
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of scope
+      description: What should not be included in this change?
+      placeholder: List related work that should wait for another issue.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: What must be true before this issue is complete?
+      value: |
+        - [ ]
+        - [ ]
+    validations:
+      required: true
+  - type: textarea
+    id: implementation-notes
+    attributes:
+      label: Implementation notes
+      description: Add technical context, constraints, dependencies, or suggested approach.
+      placeholder: Note any relevant files, commands, edge cases, or decisions.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+# Goal
+
+<!-- What user or project outcome does this PR create? -->
+
+## Scope
+
+<!-- What is included in this PR? -->
+
+## Out Of Scope
+
+<!-- What related work is intentionally left out? -->
+
+## Acceptance Criteria
+
+- [ ]
+- [ ]
+
+## Implementation Notes
+
+<!-- Summarize important technical choices, constraints, or follow-up context. -->
+
+## Validation
+
+<!-- List checks run, for example: pnpm test, pnpm lint, pnpm typecheck, pnpm build. -->
+
+## Remaining Risk
+
+<!-- Note any known limitations, skipped checks, or review focus areas. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,13 +2,9 @@
 
 <!-- What user or project outcome does this PR create? -->
 
-## Scope
+## Related Issue
 
-<!-- What is included in this PR? -->
-
-## Out Of Scope
-
-<!-- What related work is intentionally left out? -->
+<!-- Link the issue this PR addresses, for example: Closes #123. -->
 
 ## Acceptance Criteria
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,12 @@ Allowed read-only GitHub commands: `gh issue view <number>`, `gh issue list`, `g
 
 These require explicit user approval: `gh issue create`, `gh issue edit`, `gh issue close`, `gh pr create`, `gh pr merge`, `git push`.
 
+Template rules:
+- When creating GitHub issues, follow `.github/ISSUE_TEMPLATE/feature.yml` or `.github/ISSUE_TEMPLATE/bug.yml` and include goal, scope, out-of-scope, acceptance criteria, and implementation notes.
+- When creating PRs with `gh pr create`, use `.github/pull_request_template.md` as the body template, for example `gh pr create --template .github/pull_request_template.md`.
+- Do not use ad hoc `--body` text unless the user explicitly asks for a custom PR body; `--body` bypasses the PR template.
+- Fill the PR template's related issue section with `Closes #<issue-number>` when the PR should close an issue on merge.
+
 Branch and commit rules:
 - The user normally creates branches, commits, pushes, and PRs.
 - Codex may do those actions only when explicitly asked.


### PR DESCRIPTION
# Goal

Add GitHub contribution templates so future issues and pull requests are easier to plan, review, and validate consistently.

## Related Issue

Closes #3

## Acceptance Criteria

- [x] `.github/ISSUE_TEMPLATE/feature.yml` exists.
- [x] `.github/ISSUE_TEMPLATE/bug.yml` exists.
- [x] `.github/pull_request_template.md` exists.
- [x] Template fields include goal, scope, out-of-scope, acceptance criteria, and implementation notes.

## Implementation Notes

- Added feature and bug GitHub Issue Forms.
- Added a PR template with goal, related issue, acceptance criteria, implementation notes, validation, and remaining risk sections.
- Updated AGENTS.md so future issue and PR creation uses the repository templates instead of ad hoc PR bodies.
- Skipped separate label documentation per follow-up scope clarification.

## Validation

- Confirmed required template paths exist.
- Confirmed issue templates include goal, scope, out-of-scope, acceptance criteria, and implementation notes.
- Confirmed the PR template has the requested Related Issue section and no Scope or Out Of Scope sections.
- Ran `rg -n "[[:blank:]]+$" .github` with no matches.
- Ran `git diff --check --cached` before each commit.

## Remaining Risk

Runtime checks were not run because this PR only adds GitHub metadata templates and AGENTS.md guidance.
