### PR TITLE
feat: implement config filesystem utilities

### DIFF
--- a/src/config-paths.ts
+++ b/src/config-paths.ts
@@ -1,0 +1,77 @@
+import { mkdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { isAbsolute, join, resolve } from "node:path";
+
+export type ConfigPathOptions = {
+  homeDir?: string;
+  draftRoot?: string;
+};
+
+export type ConfigPaths = {
+  configDir: string;
+  configFile: string;
+  projectsFile: string;
+  historyDir: string;
+  formatHistoryFile: string;
+  globalDraftsDir: string;
+  logsDir: string;
+  defaultDraftRoot: string;
+  requiredDirectories: string[];
+};
+
+export function expandHomePath(path: string, homeDir: string = homedir()): string {
+  if (path === "~") {
+    return homeDir;
+  }
+
+  if (path.startsWith("~/")) {
+    return join(homeDir, path.slice(2));
+  }
+
+  return path;
+}
+
+export function resolveConfigPaths(options: ConfigPathOptions = {}): ConfigPaths {
+  const homeDir = options.homeDir ?? homedir();
+  const configDir = join(homeDir, ".uncommitted");
+  const historyDir = join(configDir, "history");
+  const defaultDraftRoot = resolvePath(
+    options.draftRoot ?? "~/Uncommitted/drafts",
+    homeDir
+  );
+
+  const paths = {
+    configDir,
+    configFile: join(configDir, "config.json"),
+    projectsFile: join(configDir, "projects.json"),
+    historyDir,
+    formatHistoryFile: join(historyDir, "formats.json"),
+    globalDraftsDir: join(configDir, "drafts"),
+    logsDir: join(configDir, "logs"),
+    defaultDraftRoot
+  };
+
+  return {
+    ...paths,
+    requiredDirectories: [
+      paths.configDir,
+      paths.historyDir,
+      paths.globalDraftsDir,
+      paths.logsDir,
+      paths.defaultDraftRoot
+    ]
+  };
+}
+
+export async function ensureConfigDirectories(paths: ConfigPaths): Promise<void> {
+  const directories = new Set(paths.requiredDirectories);
+
+  await Promise.all(
+    Array.from(directories, (directory) => mkdir(directory, { recursive: true }))
+  );
+}
+
+function resolvePath(path: string, homeDir: string): string {
+  const expanded = expandHomePath(path, homeDir);
+  return isAbsolute(expanded) ? expanded : resolve(expanded);
+}

--- a/src/config-paths.ts
+++ b/src/config-paths.ts
@@ -73,5 +73,5 @@ export async function ensureConfigDirectories(paths: ConfigPaths): Promise<void>
 
 function resolvePath(path: string, homeDir: string): string {
   const expanded = expandHomePath(path, homeDir);
-  return isAbsolute(expanded) ? expanded : resolve(expanded);
+  return isAbsolute(expanded) ? expanded : resolve(homeDir, expanded);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,9 @@ export { getHelpText, runCli } from "./cli.js";
 export type { CliIo } from "./cli.js";
 export { commands, isKnownCommand } from "./commands.js";
 export type { Command } from "./commands.js";
+export {
+  ensureConfigDirectories,
+  expandHomePath,
+  resolveConfigPaths
+} from "./config-paths.js";
+export type { ConfigPathOptions, ConfigPaths } from "./config-paths.js";

--- a/tests/config-paths.test.ts
+++ b/tests/config-paths.test.ts
@@ -43,6 +43,14 @@ describe("config path utilities", () => {
     ).toBe(join(homeDir, "custom-drafts"));
   });
 
+  it("resolves relative draft roots from the home directory", () => {
+    const homeDir = "/tmp/uncommitted-home";
+
+    expect(
+      resolveConfigPaths({ homeDir, draftRoot: "relative-drafts" }).defaultDraftRoot
+    ).toBe(join(homeDir, "relative-drafts"));
+  });
+
   it("creates required directories recursively", async () => {
     const root = await mkTestRoot();
     const paths = resolveConfigPaths({

--- a/tests/config-paths.test.ts
+++ b/tests/config-paths.test.ts
@@ -1,0 +1,71 @@
+import { mkdir, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  ensureConfigDirectories,
+  expandHomePath,
+  resolveConfigPaths
+} from "../src/config-paths.js";
+
+describe("config path utilities", () => {
+  it("resolves global config file paths from a provided home directory", () => {
+    const homeDir = "/tmp/uncommitted-home";
+
+    const paths = resolveConfigPaths({ homeDir });
+
+    expect(paths.configDir).toBe(join(homeDir, ".uncommitted"));
+    expect(paths.configFile).toBe(join(homeDir, ".uncommitted", "config.json"));
+    expect(paths.projectsFile).toBe(join(homeDir, ".uncommitted", "projects.json"));
+    expect(paths.historyDir).toBe(join(homeDir, ".uncommitted", "history"));
+    expect(paths.formatHistoryFile).toBe(
+      join(homeDir, ".uncommitted", "history", "formats.json")
+    );
+  });
+
+  it("expands tilde-prefixed paths without hardcoding a user home", () => {
+    const homeDir = "/tmp/someone";
+
+    expect(expandHomePath("~", homeDir)).toBe(homeDir);
+    expect(expandHomePath("~/Uncommitted/drafts", homeDir)).toBe(
+      join(homeDir, "Uncommitted", "drafts")
+    );
+    expect(expandHomePath("/var/tmp/uncommitted", homeDir)).toBe("/var/tmp/uncommitted");
+  });
+
+  it("resolves the default and configured draft roots", () => {
+    const homeDir = "/tmp/uncommitted-home";
+
+    expect(resolveConfigPaths({ homeDir }).defaultDraftRoot).toBe(
+      join(homeDir, "Uncommitted", "drafts")
+    );
+    expect(
+      resolveConfigPaths({ homeDir, draftRoot: "~/custom-drafts" }).defaultDraftRoot
+    ).toBe(join(homeDir, "custom-drafts"));
+  });
+
+  it("creates required directories recursively", async () => {
+    const root = await mkTestRoot();
+    const paths = resolveConfigPaths({
+      homeDir: join(root, "home"),
+      draftRoot: "~/draft-output"
+    });
+
+    await ensureConfigDirectories(paths);
+
+    await expectDirectory(paths.configDir);
+    await expectDirectory(paths.historyDir);
+    await expectDirectory(paths.globalDraftsDir);
+    await expectDirectory(paths.logsDir);
+    await expectDirectory(paths.defaultDraftRoot);
+  });
+});
+
+async function mkTestRoot(): Promise<string> {
+  const root = join(process.cwd(), "node_modules", ".tmp", "config-paths");
+  await mkdir(root, { recursive: true });
+  return root;
+}
+
+async function expectDirectory(path: string): Promise<void> {
+  await expect(stat(path).then((stats) => stats.isDirectory())).resolves.toBe(true);
+}


### PR DESCRIPTION
# Goal

Implement shared config filesystem utilities for resolving Uncommitted storage paths and creating required directories.

## Related Issue

Closes #5.

## Acceptance Criteria

- [x] Config directory paths resolve correctly
- [x] `~` expansion works
- [x] Required directories can be created
- [x] Path helpers are covered by unit tests
- [x] Utilities avoid hardcoding user-specific absolute paths

## Implementation Notes

- Added typed config path helpers for `~/.uncommitted`, `config.json`, `projects.json`, `history/formats.json`, draft root, logs, and global drafts.
- Added `expandHomePath` and `ensureConfigDirectories` helpers.
- Exported the helpers from the package entrypoint for later init/project/doctor work.

## Validation

- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`

## Remaining Risk

No known remaining risk. CLI commands are intentionally unchanged for this utility-only issue.
