### PR TITLE
feat: implement uncommitted init command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import { realpathSync } from "node:fs";
 import process from "node:process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { commands, isKnownCommand } from "./commands.js";
+import { runInitCommand } from "./init-command.js";
 
 export type CliIo = {
   stdout: (message: string) => void;
@@ -34,7 +35,7 @@ Options:
 
 export async function runCli(args: string[], io: CliIo = defaultIo): Promise<number> {
   const normalizedArgs = args[0] === "--" ? args.slice(1) : args;
-  const [command] = normalizedArgs;
+  const [command, ...commandArgs] = normalizedArgs;
 
   if (!command || command === "--help" || command === "-h") {
     io.stdout(getHelpText());
@@ -45,6 +46,17 @@ export async function runCli(args: string[], io: CliIo = defaultIo): Promise<num
     io.stderr(`Unknown command: ${command}`);
     io.stderr("Run `uncommitted --help`.");
     return 1;
+  }
+
+  if (command === "init") {
+    try {
+      await runInitCommand(commandArgs);
+      io.stdout("Initialized Uncommitted config.");
+      return 0;
+    } catch (error) {
+      io.stderr(error instanceof Error ? error.message : "Init failed.");
+      return 1;
+    }
   }
 
   io.stderr(`Command not implemented yet: ${command}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,10 @@ export {
   resolveConfigPaths
 } from "./config-paths.js";
 export type { ConfigPathOptions, ConfigPaths } from "./config-paths.js";
+export { runInitCommand } from "./init-command.js";
+export type {
+  InitAnswers,
+  InitCommandOptions,
+  InitCommandResult,
+  InitConfig
+} from "./init-command.js";

--- a/src/init-command.ts
+++ b/src/init-command.ts
@@ -1,0 +1,147 @@
+import { access, writeFile } from "node:fs/promises";
+import process from "node:process";
+import { createInterface } from "node:readline/promises";
+import { stdin as input, stdout as output } from "node:process";
+import { ensureConfigDirectories, resolveConfigPaths } from "./config-paths.js";
+
+export type InitAnswers = {
+  draftRoot?: string;
+  scheduleTime?: string;
+  aiProvider?: string;
+  persona?: string;
+  roastLevel?: string;
+};
+
+export type InitCommandOptions = {
+  homeDir?: string;
+  answers?: InitAnswers;
+};
+
+export type InitConfig = {
+  schemaVersion: 1;
+  draftRoot: string;
+  scheduleTime: string;
+  aiProvider: string;
+  persona: string;
+  roastLevel: number;
+};
+
+export type InitCommandResult = {
+  created: true;
+  config: InitConfig;
+};
+
+const defaultAnswers = {
+  draftRoot: "~/Uncommitted/drafts",
+  scheduleTime: "23:30",
+  aiProvider: "openai",
+  persona: "wry coworker",
+  roastLevel: "2"
+};
+
+export async function runInitCommand(
+  args: string[],
+  options: InitCommandOptions = {}
+): Promise<InitCommandResult> {
+  const force = parseInitArgs(args);
+  const answers = await resolveAnswers(options.answers);
+  const roastLevel = parseRoastLevel(answers.roastLevel);
+  const paths = resolveConfigPaths({
+    homeDir: options.homeDir,
+    draftRoot: answers.draftRoot
+  });
+
+  if (!force && (await pathExists(paths.configFile))) {
+    throw new Error("Config already exists. Rerun with --force to overwrite.");
+  }
+
+  await ensureConfigDirectories(paths);
+
+  const config: InitConfig = {
+    schemaVersion: 1,
+    draftRoot: paths.defaultDraftRoot,
+    scheduleTime: answers.scheduleTime,
+    aiProvider: answers.aiProvider,
+    persona: answers.persona,
+    roastLevel
+  };
+
+  await writeJson(paths.configFile, config);
+  await writeJson(paths.projectsFile, { schemaVersion: 1, projects: [] });
+  await writeJson(paths.formatHistoryFile, { schemaVersion: 1, formats: [] });
+
+  return { created: true, config };
+}
+
+function parseInitArgs(args: string[]): boolean {
+  let force = false;
+
+  for (const arg of args) {
+    if (arg === "--force") {
+      force = true;
+      continue;
+    }
+
+    throw new Error(`Unknown init option: ${arg}`);
+  }
+
+  return force;
+}
+
+async function resolveAnswers(answers: InitAnswers = {}): Promise<Required<InitAnswers>> {
+  if (Object.keys(answers).length > 0 || !process.stdin.isTTY) {
+    return {
+      draftRoot: answers.draftRoot ?? defaultAnswers.draftRoot,
+      scheduleTime: answers.scheduleTime ?? defaultAnswers.scheduleTime,
+      aiProvider: answers.aiProvider ?? defaultAnswers.aiProvider,
+      persona: answers.persona ?? defaultAnswers.persona,
+      roastLevel: answers.roastLevel ?? defaultAnswers.roastLevel
+    };
+  }
+
+  const readline = createInterface({ input, output });
+
+  try {
+    return {
+      draftRoot: await ask(readline, "Draft root", defaultAnswers.draftRoot),
+      scheduleTime: await ask(readline, "Schedule time", defaultAnswers.scheduleTime),
+      aiProvider: await ask(readline, "AI provider", defaultAnswers.aiProvider),
+      persona: await ask(readline, "Persona", defaultAnswers.persona),
+      roastLevel: await ask(readline, "Roast level 0-5", defaultAnswers.roastLevel)
+    };
+  } finally {
+    readline.close();
+  }
+}
+
+async function ask(
+  readline: ReturnType<typeof createInterface>,
+  label: string,
+  defaultValue: string
+): Promise<string> {
+  const answer = await readline.question(`${label} (${defaultValue}): `);
+  return answer.trim() || defaultValue;
+}
+
+function parseRoastLevel(value: string): number {
+  const parsed = Number(value);
+
+  if (!Number.isInteger(parsed) || parsed < 0 || parsed > 5) {
+    throw new Error("Roast level must be a number from 0 to 5.");
+  }
+
+  return parsed;
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`);
+}

--- a/src/init-command.ts
+++ b/src/init-command.ts
@@ -67,8 +67,8 @@ export async function runInitCommand(
   };
 
   await writeJson(paths.configFile, config);
-  await writeJson(paths.projectsFile, { schemaVersion: 1, projects: [] });
-  await writeJson(paths.formatHistoryFile, { schemaVersion: 1, formats: [] });
+  await writeJsonIfMissing(paths.projectsFile, { schemaVersion: 1, projects: [] });
+  await writeJsonIfMissing(paths.formatHistoryFile, { schemaVersion: 1, formats: [] });
 
   return { created: true, config };
 }
@@ -144,4 +144,12 @@ async function pathExists(path: string): Promise<boolean> {
 
 async function writeJson(path: string, value: unknown): Promise<void> {
   await writeFile(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function writeJsonIfMissing(path: string, value: unknown): Promise<void> {
+  if (await pathExists(path)) {
+    return;
+  }
+
+  await writeJson(path, value);
 }

--- a/src/init-command.ts
+++ b/src/init-command.ts
@@ -34,10 +34,19 @@ export type InitCommandResult = {
 const defaultAnswers = {
   draftRoot: "~/Uncommitted/drafts",
   scheduleTime: "23:30",
-  aiProvider: "openai",
+  aiProvider: "none",
   persona: "wry coworker",
   roastLevel: "2"
 };
+const supportedAiProviders = [
+  "none",
+  "openai",
+  "anthropic",
+  "google",
+  "ollama",
+  "mistral",
+  "openrouter"
+] as const;
 
 export async function runInitCommand(
   args: string[],
@@ -45,6 +54,8 @@ export async function runInitCommand(
 ): Promise<InitCommandResult> {
   const force = parseInitArgs(args);
   const answers = await resolveAnswers(options.answers);
+  const scheduleTime = parseScheduleTime(answers.scheduleTime);
+  const aiProvider = parseAiProvider(answers.aiProvider);
   const roastLevel = parseRoastLevel(answers.roastLevel);
   const paths = resolveConfigPaths({
     homeDir: options.homeDir,
@@ -60,8 +71,8 @@ export async function runInitCommand(
   const config: InitConfig = {
     schemaVersion: 1,
     draftRoot: paths.defaultDraftRoot,
-    scheduleTime: answers.scheduleTime,
-    aiProvider: answers.aiProvider,
+    scheduleTime,
+    aiProvider,
     persona: answers.persona,
     roastLevel
   };
@@ -105,7 +116,11 @@ async function resolveAnswers(answers: InitAnswers = {}): Promise<Required<InitA
     return {
       draftRoot: await ask(readline, "Draft root", defaultAnswers.draftRoot),
       scheduleTime: await ask(readline, "Schedule time", defaultAnswers.scheduleTime),
-      aiProvider: await ask(readline, "AI provider", defaultAnswers.aiProvider),
+      aiProvider: await ask(
+        readline,
+        "AI provider, or none to decide later",
+        defaultAnswers.aiProvider
+      ),
       persona: await ask(readline, "Persona", defaultAnswers.persona),
       roastLevel: await ask(readline, "Roast level 0-5", defaultAnswers.roastLevel)
     };
@@ -131,6 +146,28 @@ function parseRoastLevel(value: string): number {
   }
 
   return parsed;
+}
+
+function parseScheduleTime(value: string): string {
+  const normalized = value.trim();
+
+  if (!/^(?:[01]\d|2[0-3]):[0-5]\d$/.test(normalized)) {
+    throw new Error("Schedule time must use 24-hour HH:mm format.");
+  }
+
+  return normalized;
+}
+
+function parseAiProvider(value: string): string {
+  const normalized = value.trim().toLowerCase();
+
+  if (!supportedAiProviders.includes(normalized as (typeof supportedAiProviders)[number])) {
+    throw new Error(
+      `AI provider must be one of: ${supportedAiProviders.join(", ")}.`
+    );
+  }
+
+  return normalized;
 }
 
 async function pathExists(path: string): Promise<boolean> {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -35,11 +35,11 @@ describe("cli", () => {
   it("routes known commands to placeholder handlers", async () => {
     const { io, stdout, stderr } = createIo();
 
-    const exitCode = await runCli(["init"], io);
+    const exitCode = await runCli(["note"], io);
 
     expect(exitCode).toBe(1);
     expect(stdout).toEqual([]);
-    expect(stderr.join("\n")).toContain("Command not implemented yet: init");
+    expect(stderr.join("\n")).toContain("Command not implemented yet: note");
   });
 
   it("reports unknown commands", async () => {

--- a/tests/init-command.test.ts
+++ b/tests/init-command.test.ts
@@ -95,6 +95,81 @@ describe("init command", () => {
     expect(JSON.parse(await readFile(formatHistoryFile, "utf8"))).toEqual(existingFormats);
   });
 
+  it("normalizes supported AI providers", async () => {
+    const homeDir = await mkTestHome("provider-normalize");
+
+    await runInitCommand([], {
+      homeDir,
+      answers: {
+        aiProvider: " Anthropic "
+      }
+    });
+
+    const config = JSON.parse(
+      await readFile(join(homeDir, ".uncommitted", "config.json"), "utf8")
+    ) as { aiProvider: string };
+    expect(config.aiProvider).toBe("anthropic");
+  });
+
+  it("supports deciding the AI provider later", async () => {
+    const homeDir = await mkTestHome("provider-none");
+
+    await runInitCommand([], { homeDir });
+
+    const config = JSON.parse(
+      await readFile(join(homeDir, ".uncommitted", "config.json"), "utf8")
+    ) as { aiProvider: string };
+    expect(config.aiProvider).toBe("none");
+  });
+
+  it("supports Mistral and OpenRouter providers", async () => {
+    const mistralHome = await mkTestHome("provider-mistral");
+    const openrouterHome = await mkTestHome("provider-openrouter");
+
+    await runInitCommand([], {
+      homeDir: mistralHome,
+      answers: { aiProvider: "mistral" }
+    });
+    await runInitCommand([], {
+      homeDir: openrouterHome,
+      answers: { aiProvider: "OpenRouter" }
+    });
+
+    const mistralConfig = JSON.parse(
+      await readFile(join(mistralHome, ".uncommitted", "config.json"), "utf8")
+    ) as { aiProvider: string };
+    const openrouterConfig = JSON.parse(
+      await readFile(join(openrouterHome, ".uncommitted", "config.json"), "utf8")
+    ) as { aiProvider: string };
+
+    expect(mistralConfig.aiProvider).toBe("mistral");
+    expect(openrouterConfig.aiProvider).toBe("openrouter");
+  });
+
+  it("rejects unsupported AI providers", async () => {
+    const homeDir = await mkTestHome("provider");
+
+    await expect(
+      runInitCommand([], {
+        homeDir,
+        answers: { aiProvider: "adlkfjldkajf" }
+      })
+    ).rejects.toThrow(
+      "AI provider must be one of: none, openai, anthropic, google, ollama, mistral, openrouter."
+    );
+  });
+
+  it("rejects schedule times outside 24-hour HH:mm format", async () => {
+    const homeDir = await mkTestHome("schedule");
+
+    await expect(
+      runInitCommand([], {
+        homeDir,
+        answers: { scheduleTime: "25:00" }
+      })
+    ).rejects.toThrow("Schedule time must use 24-hour HH:mm format.");
+  });
+
   it("rejects roast levels outside the MVP range", async () => {
     const homeDir = await mkTestHome("roast");
 

--- a/tests/init-command.test.ts
+++ b/tests/init-command.test.ts
@@ -1,0 +1,87 @@
+import { mkdir, mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { runInitCommand } from "../src/init-command.js";
+
+describe("init command", () => {
+  it("creates global config files and directories", async () => {
+    const homeDir = await mkTestHome("creates");
+    const draftRoot = "~/diary-drafts";
+
+    const result = await runInitCommand([], {
+      homeDir,
+      answers: {
+        draftRoot,
+        scheduleTime: "23:30",
+        aiProvider: "openai",
+        persona: "dry coworker",
+        roastLevel: "3"
+      }
+    });
+
+    expect(result.created).toBe(true);
+    expect(JSON.parse(await readFile(join(homeDir, ".uncommitted", "config.json"), "utf8")))
+      .toEqual({
+        schemaVersion: 1,
+        draftRoot: join(homeDir, "diary-drafts"),
+        scheduleTime: "23:30",
+        aiProvider: "openai",
+        persona: "dry coworker",
+        roastLevel: 3
+      });
+    expect(JSON.parse(await readFile(join(homeDir, ".uncommitted", "projects.json"), "utf8")))
+      .toEqual({ schemaVersion: 1, projects: [] });
+    expect(JSON.parse(await readFile(join(homeDir, ".uncommitted", "history", "formats.json"), "utf8")))
+      .toEqual({ schemaVersion: 1, formats: [] });
+    await expectDirectory(join(homeDir, ".uncommitted", "drafts"));
+    await expectDirectory(join(homeDir, ".uncommitted", "logs"));
+    await expectDirectory(join(homeDir, "diary-drafts"));
+  });
+
+  it("does not overwrite existing config by default", async () => {
+    const homeDir = await mkTestHome("existing");
+    const configFile = join(homeDir, ".uncommitted", "config.json");
+    await mkdir(join(homeDir, ".uncommitted"), { recursive: true });
+    await writeFile(configFile, "{\"existing\":true}\n");
+
+    await expect(runInitCommand([], { homeDir })).rejects.toThrow(
+      "Config already exists. Rerun with --force to overwrite."
+    );
+    await expect(readFile(configFile, "utf8")).resolves.toBe("{\"existing\":true}\n");
+  });
+
+  it("overwrites existing config when forced", async () => {
+    const homeDir = await mkTestHome("force");
+    const configFile = join(homeDir, ".uncommitted", "config.json");
+    await mkdir(join(homeDir, ".uncommitted"), { recursive: true });
+    await writeFile(configFile, "{\"existing\":true}\n");
+
+    await runInitCommand(["--force"], {
+      homeDir,
+      answers: { roastLevel: "5" }
+    });
+
+    const config = JSON.parse(await readFile(configFile, "utf8")) as { roastLevel: number };
+    expect(config.roastLevel).toBe(5);
+  });
+
+  it("rejects roast levels outside the MVP range", async () => {
+    const homeDir = await mkTestHome("roast");
+
+    await expect(
+      runInitCommand([], {
+        homeDir,
+        answers: { roastLevel: "6" }
+      })
+    ).rejects.toThrow("Roast level must be a number from 0 to 5.");
+  });
+});
+
+async function mkTestHome(name: string): Promise<string> {
+  return mkdtemp(join(tmpdir(), `uncommitted-init-${name}-`));
+}
+
+async function expectDirectory(path: string): Promise<void> {
+  await expect(stat(path).then((stats) => stats.isDirectory())).resolves.toBe(true);
+}

--- a/tests/init-command.test.ts
+++ b/tests/init-command.test.ts
@@ -66,6 +66,35 @@ describe("init command", () => {
     expect(config.roastLevel).toBe(5);
   });
 
+  it("preserves existing registry and format history when forced", async () => {
+    const homeDir = await mkTestHome("force-preserves");
+    const configDir = join(homeDir, ".uncommitted");
+    const historyDir = join(configDir, "history");
+    const projectsFile = join(configDir, "projects.json");
+    const formatHistoryFile = join(historyDir, "formats.json");
+    const existingProjects = {
+      schemaVersion: 1,
+      projects: [{ id: "project-1", root: "/repo" }]
+    };
+    const existingFormats = {
+      schemaVersion: 1,
+      formats: [{ id: "format-1" }]
+    };
+
+    await mkdir(historyDir, { recursive: true });
+    await writeFile(join(configDir, "config.json"), "{\"existing\":true}\n");
+    await writeFile(projectsFile, `${JSON.stringify(existingProjects)}\n`);
+    await writeFile(formatHistoryFile, `${JSON.stringify(existingFormats)}\n`);
+
+    await runInitCommand(["--force"], {
+      homeDir,
+      answers: { roastLevel: "4" }
+    });
+
+    expect(JSON.parse(await readFile(projectsFile, "utf8"))).toEqual(existingProjects);
+    expect(JSON.parse(await readFile(formatHistoryFile, "utf8"))).toEqual(existingFormats);
+  });
+
   it("rejects roast levels outside the MVP range", async () => {
     const homeDir = await mkTestHome("roast");
 


### PR DESCRIPTION
# Goal

Implement `uncommitted init` so the CLI can create the initial global Uncommitted configuration files and directories.

## Related Issue

Closes #6.

## Acceptance Criteria

- [x] `uncommitted init` creates required files
- [x] Existing config is not overwritten by default
- [x] `uncommitted init --force` overwrites config intentionally
- [x] Roast level is stored as a number from 0 to 5
- [x] Generated config matches the MVP schema
- [x] Unit tests cover overwrite behavior

## Implementation Notes

- Added `runInitCommand` with schema-shaped config, project registry, and format-history JSON output.
- Reused config path helpers for home directory injection, draft-root expansion, and required directory creation.
- Routed only the `init` command in the CLI; unrelated commands remain placeholder handlers.

## Validation

- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`

## Remaining Risk

- This branch edits CLI routing files that also change in the parallel project-add branch, so the second merged branch may need a small rebase conflict resolution.
