### PR TITLE
feat: implement project add command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,10 +5,16 @@ import process from "node:process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { commands, isKnownCommand } from "./commands.js";
 import { runInitCommand } from "./init-command.js";
+import { addProject, ProjectAddError } from "./project-add.js";
 
 export type CliIo = {
   stdout: (message: string) => void;
   stderr: (message: string) => void;
+};
+
+export type CliOptions = {
+  cwd?: string;
+  homeDir?: string;
 };
 
 const defaultIo: CliIo = {
@@ -33,7 +39,11 @@ Options:
 `;
 }
 
-export async function runCli(args: string[], io: CliIo = defaultIo): Promise<number> {
+export async function runCli(
+  args: string[],
+  io: CliIo = defaultIo,
+  options: CliOptions = {}
+): Promise<number> {
   const normalizedArgs = args[0] === "--" ? args.slice(1) : args;
   const [command, ...commandArgs] = normalizedArgs;
 
@@ -59,8 +69,40 @@ export async function runCli(args: string[], io: CliIo = defaultIo): Promise<num
     }
   }
 
+  const [subcommand, value] = commandArgs;
+
+  if (command === "project" && subcommand === "add") {
+    return await runProjectAdd(value, io, options);
+  }
+
   io.stderr(`Command not implemented yet: ${command}`);
   return 1;
+}
+
+async function runProjectAdd(
+  path: string | undefined,
+  io: CliIo,
+  options: CliOptions
+): Promise<number> {
+  try {
+    const result = await addProject(path ?? ".", options);
+
+    if (result.status === "already-registered") {
+      io.stdout(`Project already registered: ${result.project.id}`);
+    } else {
+      io.stdout(`Project registered: ${result.project.id}`);
+    }
+
+    io.stdout(result.project.root);
+    return 0;
+  } catch (error) {
+    if (error instanceof ProjectAddError) {
+      io.stderr(error.message);
+      return error.code === "not-git-repository" ? 2 : 1;
+    }
+
+    throw error;
+  }
 }
 
 export function isDirectRun(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -98,7 +98,7 @@ async function runProjectAdd(
   } catch (error) {
     if (error instanceof ProjectAddError) {
       io.stderr(error.message);
-      return error.code === "not-git-repository" ? 2 : 1;
+      return 2;
     }
 
     throw error;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { getHelpText, runCli } from "./cli.js";
-export type { CliIo } from "./cli.js";
+export type { CliIo, CliOptions } from "./cli.js";
 export { commands, isKnownCommand } from "./commands.js";
 export type { Command } from "./commands.js";
 export {
@@ -15,3 +15,11 @@ export type {
   InitCommandResult,
   InitConfig
 } from "./init-command.js";
+export { addProject, ProjectAddError } from "./project-add.js";
+export type {
+  AddProjectOptions,
+  AddProjectResult,
+  ProjectAddErrorCode,
+  ProjectRecord,
+  ProjectsFile
+} from "./project-add.js";

--- a/src/project-add.ts
+++ b/src/project-add.ts
@@ -1,0 +1,228 @@
+import { execFile } from "node:child_process";
+import { constants } from "node:fs";
+import { access, mkdir, readFile, realpath, writeFile } from "node:fs/promises";
+import { basename, join, resolve } from "node:path";
+import process from "node:process";
+import { promisify } from "node:util";
+import { resolveConfigPaths } from "./config-paths.js";
+
+const execFileAsync = promisify(execFile);
+
+export type ProjectAddErrorCode =
+  | "path-not-found"
+  | "not-git-repository"
+  | "invalid-projects-file"
+  | "project-id-conflict";
+
+export class ProjectAddError extends Error {
+  constructor(
+    message: string,
+    public readonly code: ProjectAddErrorCode
+  ) {
+    super(message);
+    this.name = "ProjectAddError";
+  }
+}
+
+export type ProjectRecord = {
+  schemaVersion: 1;
+  id: string;
+  name: string;
+  root: string;
+  gitRoot: string;
+  enabled: boolean;
+  createdAt: string;
+};
+
+export type ProjectsFile = {
+  schemaVersion: 1;
+  projects: ProjectRecord[];
+};
+
+export type AddProjectOptions = {
+  cwd?: string;
+  homeDir?: string;
+  now?: () => string;
+};
+
+export type AddProjectResult = {
+  status: "added" | "already-registered";
+  project: ProjectRecord;
+  projectsFile: string;
+  projectFile: string;
+};
+
+export async function addProject(
+  inputPath: string = ".",
+  options: AddProjectOptions = {}
+): Promise<AddProjectResult> {
+  const cwd = options.cwd ?? process.cwd();
+  const resolvedInput = resolve(cwd, inputPath);
+  const existingInput = await resolveExistingPath(resolvedInput);
+  const gitRoot = await findGitRoot(existingInput);
+  const paths = resolveConfigPaths({ homeDir: options.homeDir });
+  const projectsFile = await readProjectsFile(paths.projectsFile);
+  const existingProject = projectsFile.projects.find(
+    (project) => project.gitRoot === gitRoot
+  );
+  const projectFile = join(gitRoot, ".uncommitted", "project.json");
+
+  if (existingProject) {
+    await ensureProjectFile(projectFile, existingProject);
+
+    return {
+      status: "already-registered",
+      project: existingProject,
+      projectsFile: paths.projectsFile,
+      projectFile
+    };
+  }
+
+  const project = createProjectRecord(gitRoot, options.now);
+  const idConflict = projectsFile.projects.find(
+    (registeredProject) => registeredProject.id === project.id
+  );
+
+  if (idConflict) {
+    throw new ProjectAddError(
+      `Project id conflict: ${project.id} is already used by ${idConflict.gitRoot}`,
+      "project-id-conflict"
+    );
+  }
+
+  const nextProjectsFile: ProjectsFile = {
+    schemaVersion: 1,
+    projects: [...projectsFile.projects, project]
+  };
+
+  await mkdir(join(gitRoot, ".uncommitted"), { recursive: true });
+  await mkdir(paths.configDir, { recursive: true });
+  await writeJson(projectFile, project);
+  await writeJson(paths.projectsFile, nextProjectsFile);
+
+  return {
+    status: "added",
+    project,
+    projectsFile: paths.projectsFile,
+    projectFile
+  };
+}
+
+function createProjectRecord(
+  gitRoot: string,
+  now: (() => string) | undefined
+): ProjectRecord {
+  const name = basename(gitRoot);
+
+  return {
+    schemaVersion: 1,
+    id: slugProjectId(name),
+    name,
+    root: gitRoot,
+    gitRoot,
+    enabled: true,
+    createdAt: now ? now() : new Date().toISOString()
+  };
+}
+
+async function resolveExistingPath(path: string): Promise<string> {
+  try {
+    await access(path, constants.F_OK);
+    return await realpath(path);
+  } catch {
+    throw new ProjectAddError(`Path does not exist: ${path}`, "path-not-found");
+  }
+}
+
+async function findGitRoot(path: string): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync("git", [
+      "-C",
+      path,
+      "rev-parse",
+      "--show-toplevel"
+    ]);
+    return await realpath(stdout.trim());
+  } catch {
+    throw new ProjectAddError(`Not a Git repository: ${path}`, "not-git-repository");
+  }
+}
+
+async function readProjectsFile(path: string): Promise<ProjectsFile> {
+  try {
+    const parsed = JSON.parse(await readFile(path, "utf8")) as unknown;
+
+    if (isProjectsFile(parsed)) {
+      return parsed;
+    }
+
+    throw new ProjectAddError(
+      `Invalid projects file: ${path}`,
+      "invalid-projects-file"
+    );
+  } catch (error) {
+    if (error instanceof ProjectAddError) {
+      throw error;
+    }
+
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return { schemaVersion: 1, projects: [] };
+    }
+
+    throw new ProjectAddError(
+      `Invalid projects file: ${path}`,
+      "invalid-projects-file"
+    );
+  }
+}
+
+async function ensureProjectFile(
+  projectFile: string,
+  project: ProjectRecord
+): Promise<void> {
+  await mkdir(join(project.gitRoot, ".uncommitted"), { recursive: true });
+  await writeJson(projectFile, project);
+}
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function slugProjectId(name: string): string {
+  const slug = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  return slug || "project";
+}
+
+function isProjectsFile(value: unknown): value is ProjectsFile {
+  if (!isRecord(value) || value.schemaVersion !== 1 || !Array.isArray(value.projects)) {
+    return false;
+  }
+
+  return value.projects.every(isProjectRecord);
+}
+
+function isProjectRecord(value: unknown): value is ProjectRecord {
+  return (
+    isRecord(value) &&
+    value.schemaVersion === 1 &&
+    typeof value.id === "string" &&
+    typeof value.name === "string" &&
+    typeof value.root === "string" &&
+    typeof value.gitRoot === "string" &&
+    typeof value.enabled === "boolean" &&
+    typeof value.createdAt === "string"
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,9 +1,13 @@
-import { mkdtemp, symlink, writeFile } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
 import { isDirectRun, runCli } from "../src/cli.js";
+
+const execFileAsync = promisify(execFile);
 
 function createIo() {
   const stdout: string[] = [];
@@ -53,6 +57,36 @@ describe("cli", () => {
     expect(exitCode).toBe(2);
     expect(stdout).toEqual([]);
     expect(stderr.join("\n")).toContain("Not a Git repository");
+  });
+
+  it("returns config exit code when project add path is missing", async () => {
+    const { io, stdout, stderr } = createIo();
+    const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-project-add-"));
+
+    const exitCode = await runCli(["project", "add", join(directory, "missing")], io, {
+      homeDir: join(directory, "home")
+    });
+
+    expect(exitCode).toBe(2);
+    expect(stdout).toEqual([]);
+    expect(stderr.join("\n")).toContain("Path does not exist");
+  });
+
+  it("returns config exit code when project add finds invalid projects file", async () => {
+    const { io, stdout, stderr } = createIo();
+    const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-project-add-"));
+    const repoDir = join(directory, "repo");
+    const homeDir = join(directory, "home");
+
+    await execFileAsync("git", ["init", repoDir]);
+    await mkdir(join(homeDir, ".uncommitted"), { recursive: true });
+    await writeFile(join(homeDir, ".uncommitted", "projects.json"), "nope", "utf8");
+
+    const exitCode = await runCli(["project", "add", repoDir], io, { homeDir });
+
+    expect(exitCode).toBe(2);
+    expect(stdout).toEqual([]);
+    expect(stderr.join("\n")).toContain("Invalid projects file");
   });
 
   it("reports unknown commands", async () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -42,6 +42,19 @@ describe("cli", () => {
     expect(stderr.join("\n")).toContain("Command not implemented yet: note");
   });
 
+  it("routes project add to the project registration handler", async () => {
+    const { io, stdout, stderr } = createIo();
+    const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-project-add-"));
+
+    const exitCode = await runCli(["project", "add", directory], io, {
+      homeDir: join(directory, "home")
+    });
+
+    expect(exitCode).toBe(2);
+    expect(stdout).toEqual([]);
+    expect(stderr.join("\n")).toContain("Not a Git repository");
+  });
+
   it("reports unknown commands", async () => {
     const { io, stdout, stderr } = createIo();
 

--- a/tests/project-add.test.ts
+++ b/tests/project-add.test.ts
@@ -1,0 +1,165 @@
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, realpath, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+import { addProject, ProjectAddError } from "../src/project-add.js";
+
+const execFileAsync = promisify(execFile);
+
+describe("project add", () => {
+  it("registers the current Git repository", async () => {
+    const { homeDir, repoDir } = await createGitRepoFixture("current-repo");
+
+    const result = await addProject(".", {
+      cwd: repoDir,
+      homeDir,
+      now: () => "2026-05-03T00:00:00.000Z"
+    });
+
+    expect(result.status).toBe("added");
+    expect(result.project).toEqual({
+      schemaVersion: 1,
+      id: "current-repo",
+      name: "current-repo",
+      root: repoDir,
+      gitRoot: repoDir,
+      enabled: true,
+      createdAt: "2026-05-03T00:00:00.000Z"
+    });
+
+    await expectDirectory(join(repoDir, ".uncommitted"));
+    await expectProjectFile(repoDir, result.project);
+    await expectProjectsFile(homeDir, [result.project]);
+  });
+
+  it("registers an explicit path by its Git root", async () => {
+    const { homeDir, repoDir } = await createGitRepoFixture("explicit-repo");
+    const nestedDir = join(repoDir, "packages", "cli");
+    await mkdir(nestedDir, { recursive: true });
+
+    const result = await addProject(nestedDir, {
+      cwd: join(await createTempRoot(), "elsewhere"),
+      homeDir,
+      now: () => "2026-05-03T00:00:00.000Z"
+    });
+
+    expect(result.status).toBe("added");
+    expect(result.project.root).toBe(repoDir);
+    expect(result.project.gitRoot).toBe(repoDir);
+    await expectProjectFile(repoDir, result.project);
+    await expectProjectsFile(homeDir, [result.project]);
+  });
+
+  it("does not register the same Git root twice", async () => {
+    const { homeDir, repoDir } = await createGitRepoFixture("duplicate-repo");
+
+    const first = await addProject(".", {
+      cwd: repoDir,
+      homeDir,
+      now: () => "2026-05-03T00:00:00.000Z"
+    });
+    const second = await addProject(repoDir, {
+      cwd: await createTempRoot(),
+      homeDir,
+      now: () => "2026-05-04T00:00:00.000Z"
+    });
+
+    expect(second.status).toBe("already-registered");
+    expect(second.project).toEqual(first.project);
+    await expectProjectsFile(homeDir, [first.project]);
+  });
+
+  it("fails clearly for non-Git directories", async () => {
+    const root = await createTempRoot();
+    const homeDir = join(root, "home");
+    const directory = join(root, "plain-dir");
+    await mkdir(directory, { recursive: true });
+
+    await expect(addProject(directory, { homeDir })).rejects.toMatchObject({
+      code: "not-git-repository",
+      message: expect.stringContaining("Not a Git repository")
+    });
+  });
+
+  it("fails clearly when another root already owns the generated project id", async () => {
+    const root = await createTempRoot();
+    const homeDir = join(root, "home");
+    const firstRepo = await initGitRepo(join(root, "same-name"));
+    const secondRepo = await initGitRepo(join(root, "parent", "same-name"));
+
+    await addProject(firstRepo, {
+      homeDir,
+      now: () => "2026-05-03T00:00:00.000Z"
+    });
+
+    await expect(addProject(secondRepo, { homeDir })).rejects.toMatchObject({
+      code: "project-id-conflict",
+      message: expect.stringContaining("Project id conflict")
+    });
+  });
+
+  it("uses a typed project add error", async () => {
+    const root = await createTempRoot();
+
+    await expect(addProject(join(root, "missing"))).rejects.toBeInstanceOf(
+      ProjectAddError
+    );
+  });
+});
+
+async function createGitRepoFixture(name: string): Promise<{
+  homeDir: string;
+  repoDir: string;
+}> {
+  const root = await createTempRoot();
+  const repoDir = await initGitRepo(join(root, name));
+
+  return {
+    homeDir: join(root, "home"),
+    repoDir
+  };
+}
+
+async function createTempRoot(): Promise<string> {
+  const root = join(tmpdir(), `uncommitted-project-add-${randomUUID()}`);
+  await mkdir(root, { recursive: true });
+  return root;
+}
+
+async function initGitRepo(repoDir: string): Promise<string> {
+  await mkdir(repoDir, { recursive: true });
+  await execFileAsync("git", ["init", repoDir]);
+  return await realpath(repoDir);
+}
+
+async function expectDirectory(path: string): Promise<void> {
+  await expect(stat(path).then((stats) => stats.isDirectory())).resolves.toBe(true);
+}
+
+async function expectProjectFile(
+  repoDir: string,
+  expected: Record<string, unknown>
+): Promise<void> {
+  await expectJsonFile(join(repoDir, ".uncommitted", "project.json"), expected);
+}
+
+async function expectProjectsFile(
+  homeDir: string,
+  projects: Record<string, unknown>[]
+): Promise<void> {
+  await expectJsonFile(join(homeDir, ".uncommitted", "projects.json"), {
+    schemaVersion: 1,
+    projects
+  });
+}
+
+async function expectJsonFile(path: string, expected: unknown): Promise<void> {
+  await expect(readJson(path)).resolves.toEqual(expected);
+}
+
+async function readJson(path: string): Promise<unknown> {
+  return JSON.parse(await readFile(path, "utf8")) as unknown;
+}


### PR DESCRIPTION
# Goal

Implement `uncommitted project add` so a local Git repository can be registered as an Uncommitted project.

## Related Issue

Closes #8.

## Acceptance Criteria

- [x] `uncommitted project add .` works inside a Git repository
- [x] Explicit paths work
- [x] Non-Git directories fail with a clear error
- [x] Duplicate Git roots are not registered twice
- [x] `.uncommitted/project.json` matches the MVP schema
- [x] Global `projects.json` is updated correctly
- [x] Unit tests cover success and failure cases

## Implementation Notes

- Added `addProject` with input path resolution, Git root detection, local project metadata writes, and global project registry updates.
- Prevented duplicate registration by Git root and surfaced generated project id conflicts clearly.
- Routed only `project add`; other project subcommands remain out of scope.

## Validation

- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`

## Remaining Risk

- This branch was built in parallel with the init branch and edits the same CLI/export test files, so it should be rebased after the init branch merges.
