### PR TITLE
feat: implement doctor command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import { realpathSync } from "node:fs";
 import process from "node:process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { commands, isKnownCommand } from "./commands.js";
+import { formatDoctorReport, runDoctorCommand } from "./doctor-command.js";
 import { runInitCommand } from "./init-command.js";
 import { addProject, ProjectAddError } from "./project-add.js";
 
@@ -67,6 +68,12 @@ export async function runCli(
       io.stderr(error instanceof Error ? error.message : "Init failed.");
       return 1;
     }
+  }
+
+  if (command === "doctor") {
+    const result = await runDoctorCommand(options);
+    io.stdout(formatDoctorReport(result.report));
+    return result.exitCode;
   }
 
   const [subcommand, value] = commandArgs;

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -5,6 +5,7 @@ export type Command = {
 
 export const commands: Command[] = [
   { name: "init", summary: "Initialize Uncommitted config." },
+  { name: "doctor", summary: "Check local environment setup." },
   { name: "project", summary: "Manage registered projects." },
   { name: "note", summary: "Record and list manual notes." },
   { name: "collect", summary: "Collect activity from local sources." },

--- a/src/doctor-command.ts
+++ b/src/doctor-command.ts
@@ -269,6 +269,21 @@ function createAiApiKeyCheck(
   env: Record<string, string | undefined>
 ): DoctorCheck {
   const normalizedProvider = aiProvider.trim().toLowerCase();
+  const providerIsSupported = Object.prototype.hasOwnProperty.call(
+    aiProviderEnvKeys,
+    normalizedProvider
+  );
+
+  if (!providerIsSupported) {
+    return {
+      id: "ai-api-key",
+      label: "AI API key",
+      status: "fail",
+      message: `Unsupported AI provider: ${normalizedProvider}.`,
+      exitCode: 2
+    };
+  }
+
   const envKey = aiProviderEnvKeys[normalizedProvider];
 
   if (!envKey) {

--- a/src/doctor-command.ts
+++ b/src/doctor-command.ts
@@ -1,0 +1,353 @@
+import { execFile } from "node:child_process";
+import { constants } from "node:fs";
+import { access, readFile } from "node:fs/promises";
+import process from "node:process";
+import { promisify } from "node:util";
+import { resolveConfigPaths } from "./config-paths.js";
+
+const execFileAsync = promisify(execFile);
+const minimumNodeVersion = "22.13.0";
+
+export type DoctorStatus = "pass" | "warn" | "fail";
+
+export type DoctorCheck = {
+  id: string;
+  label: string;
+  status: DoctorStatus;
+  message: string;
+  detail?: string;
+};
+
+export type DoctorReport = {
+  checks: DoctorCheck[];
+};
+
+export type CommandCheckResult = {
+  ok: boolean;
+  detail: string;
+};
+
+export type DoctorOptions = {
+  homeDir?: string;
+  env?: Record<string, string | undefined>;
+  nodeVersion?: string;
+  checkCommand?: (command: string, args: string[]) => Promise<CommandCheckResult>;
+  checkAccess?: (path: string, mode: number) => Promise<boolean>;
+};
+
+type DoctorConfig = {
+  schemaVersion: 1;
+  draftRoot: string;
+  aiProvider: string;
+};
+
+const aiProviderEnvKeys: Record<string, string | undefined> = {
+  none: undefined,
+  ollama: undefined,
+  openai: "OPENAI_API_KEY",
+  anthropic: "ANTHROPIC_API_KEY",
+  google: "GOOGLE_API_KEY",
+  mistral: "MISTRAL_API_KEY",
+  openrouter: "OPENROUTER_API_KEY"
+};
+
+const directoryLabels: Record<string, string> = {
+  configDir: "Config directory",
+  historyDir: "Format history directory",
+  globalDraftsDir: "Global drafts directory",
+  logsDir: "Logs directory",
+  defaultDraftRoot: "Configured draft root"
+};
+
+const directoryIds: Record<string, string> = {
+  configDir: "directory-config",
+  historyDir: "directory-history",
+  globalDraftsDir: "directory-global-drafts",
+  logsDir: "directory-logs",
+  defaultDraftRoot: "directory-draft-root"
+};
+
+export async function runDoctorCommand(
+  options: DoctorOptions = {}
+): Promise<{ report: DoctorReport; exitCode: number }> {
+  const report = await createDoctorReport(options);
+
+  return {
+    report,
+    exitCode: getDoctorExitCode(report)
+  };
+}
+
+export async function createDoctorReport(
+  options: DoctorOptions = {}
+): Promise<DoctorReport> {
+  const env = options.env ?? process.env;
+  const paths = resolveConfigPaths({ homeDir: options.homeDir });
+  const { config, check } = await readConfig(paths.configFile);
+  const configuredPaths = resolveConfigPaths({
+    homeDir: options.homeDir,
+    draftRoot: config?.draftRoot
+  });
+
+  const checks: DoctorCheck[] = [
+    check,
+    createNodeCheck(options.nodeVersion ?? process.version),
+    await createGitCheck(options.checkCommand ?? defaultCheckCommand),
+    ...(await createDirectoryChecks(
+      configuredPaths,
+      options.checkAccess ?? defaultCheckAccess
+    ))
+  ];
+
+  if (config) {
+    checks.push(createAiApiKeyCheck(config.aiProvider, env));
+  }
+
+  return { checks };
+}
+
+export function getDoctorExitCode(report: DoctorReport): number {
+  return report.checks.some((check) => check.status === "fail") ? 1 : 0;
+}
+
+export function formatDoctorReport(report: DoctorReport): string {
+  const lines = ["Uncommitted Doctor", ""];
+
+  for (const check of report.checks) {
+    lines.push(`[${check.status}] ${check.label}: ${check.message}`);
+
+    if (check.detail) {
+      lines.push(`  ${check.detail}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+async function readConfig(
+  configFile: string
+): Promise<{ config?: DoctorConfig; check: DoctorCheck }> {
+  try {
+    const parsed = JSON.parse(await readFile(configFile, "utf8")) as unknown;
+
+    if (!isDoctorConfig(parsed)) {
+      return {
+        check: {
+          id: "config",
+          label: "Global config",
+          status: "fail",
+          message: `Config file is invalid: ${configFile}`
+        }
+      };
+    }
+
+    return {
+      config: parsed,
+      check: {
+        id: "config",
+        label: "Global config",
+        status: "pass",
+        message: "Config file found.",
+        detail: configFile
+      }
+    };
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return {
+        check: {
+          id: "config",
+          label: "Global config",
+          status: "fail",
+          message: `Config file is missing: ${configFile}`
+        }
+      };
+    }
+
+    return {
+      check: {
+        id: "config",
+        label: "Global config",
+        status: "fail",
+        message: `Config file is invalid: ${configFile}`
+      }
+    };
+  }
+}
+
+function createNodeCheck(nodeVersion: string): DoctorCheck {
+  const normalizedVersion = nodeVersion.replace(/^v/, "");
+
+  if (compareNodeVersions(normalizedVersion, minimumNodeVersion) < 0) {
+    return {
+      id: "node",
+      label: "Node.js",
+      status: "fail",
+      message: `Node.js v${minimumNodeVersion} or newer is required.`,
+      detail: `Current version: ${nodeVersion}`
+    };
+  }
+
+  return {
+    id: "node",
+    label: "Node.js",
+    status: "pass",
+    message: `Node.js ${nodeVersion} is supported.`
+  };
+}
+
+async function createGitCheck(
+  checkCommand: (command: string, args: string[]) => Promise<CommandCheckResult>
+): Promise<DoctorCheck> {
+  const result = await checkCommand("git", ["--version"]);
+
+  if (!result.ok) {
+    return {
+      id: "git",
+      label: "Git",
+      status: "fail",
+      message: "Git is not installed or not available on PATH.",
+      detail: result.detail
+    };
+  }
+
+  return {
+    id: "git",
+    label: "Git",
+    status: "pass",
+    message: "Git is available.",
+    detail: result.detail
+  };
+}
+
+async function createDirectoryChecks(
+  paths: ReturnType<typeof resolveConfigPaths>,
+  checkAccess: (path: string, mode: number) => Promise<boolean>
+): Promise<DoctorCheck[]> {
+  const pathEntries = [
+    ["configDir", paths.configDir],
+    ["historyDir", paths.historyDir],
+    ["globalDraftsDir", paths.globalDraftsDir],
+    ["logsDir", paths.logsDir],
+    ["defaultDraftRoot", paths.defaultDraftRoot]
+  ] as const;
+
+  return await Promise.all(
+    pathEntries.map(async ([key, path]) => {
+      const writable = await checkAccess(path, constants.W_OK);
+
+      if (!writable) {
+        return {
+          id: directoryIds[key],
+          label: directoryLabels[key],
+          status: "fail",
+          message: `Directory is not writable: ${path}`
+        };
+      }
+
+      return {
+        id: directoryIds[key],
+        label: directoryLabels[key],
+        status: "pass",
+        message: `Directory is writable: ${path}`
+      };
+    })
+  );
+}
+
+function createAiApiKeyCheck(
+  aiProvider: string,
+  env: Record<string, string | undefined>
+): DoctorCheck {
+  const normalizedProvider = aiProvider.trim().toLowerCase();
+  const envKey = aiProviderEnvKeys[normalizedProvider];
+
+  if (!envKey) {
+    return {
+      id: "ai-api-key",
+      label: "AI API key",
+      status: "pass",
+      message: `No API key required for provider: ${normalizedProvider}.`
+    };
+  }
+
+  if (!env[envKey]) {
+    return {
+      id: "ai-api-key",
+      label: "AI API key",
+      status: "warn",
+      message: `${envKey} is not set.`
+    };
+  }
+
+  return {
+    id: "ai-api-key",
+    label: "AI API key",
+    status: "pass",
+    message: `${envKey} is set.`
+  };
+}
+
+async function defaultCheckCommand(
+  command: string,
+  args: string[]
+): Promise<CommandCheckResult> {
+  try {
+    const { stdout } = await execFileAsync(command, args);
+
+    return { ok: true, detail: stdout.trim() };
+  } catch (error) {
+    return {
+      ok: false,
+      detail: error instanceof Error ? error.message : `${command} failed.`
+    };
+  }
+}
+
+async function defaultCheckAccess(path: string, mode: number): Promise<boolean> {
+  try {
+    await access(path, mode);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function compareNodeVersions(a: string, b: string): number {
+  const aParts = parseVersionParts(a);
+  const bParts = parseVersionParts(b);
+
+  for (let index = 0; index < 3; index += 1) {
+    if (aParts[index] > bParts[index]) {
+      return 1;
+    }
+
+    if (aParts[index] < bParts[index]) {
+      return -1;
+    }
+  }
+
+  return 0;
+}
+
+function parseVersionParts(version: string): [number, number, number] {
+  const [major = "0", minor = "0", patch = "0"] = version.split(".");
+
+  return [Number(major) || 0, Number(minor) || 0, Number(patch) || 0];
+}
+
+function isDoctorConfig(value: unknown): value is DoctorConfig {
+  return (
+    isRecord(value) &&
+    value.schemaVersion === 1 &&
+    typeof value.draftRoot === "string" &&
+    typeof value.aiProvider === "string"
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}

--- a/src/doctor-command.ts
+++ b/src/doctor-command.ts
@@ -16,6 +16,7 @@ export type DoctorCheck = {
   status: DoctorStatus;
   message: string;
   detail?: string;
+  exitCode?: number;
 };
 
 export type DoctorReport = {
@@ -107,7 +108,13 @@ export async function createDoctorReport(
 }
 
 export function getDoctorExitCode(report: DoctorReport): number {
-  return report.checks.some((check) => check.status === "fail") ? 1 : 0;
+  const failedCheck = report.checks.find((check) => check.status === "fail");
+
+  if (!failedCheck) {
+    return 0;
+  }
+
+  return failedCheck.exitCode ?? 1;
 }
 
 export function formatDoctorReport(report: DoctorReport): string {
@@ -136,7 +143,8 @@ async function readConfig(
           id: "config",
           label: "Global config",
           status: "fail",
-          message: `Config file is invalid: ${configFile}`
+          message: `Config file is invalid: ${configFile}`,
+          exitCode: 2
         }
       };
     }
@@ -158,7 +166,8 @@ async function readConfig(
           id: "config",
           label: "Global config",
           status: "fail",
-          message: `Config file is missing: ${configFile}`
+          message: `Config file is missing: ${configFile}`,
+          exitCode: 2
         }
       };
     }
@@ -168,7 +177,8 @@ async function readConfig(
         id: "config",
         label: "Global config",
         status: "fail",
-        message: `Config file is invalid: ${configFile}`
+        message: `Config file is invalid: ${configFile}`,
+        exitCode: 2
       }
     };
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,19 @@ export type { CliIo, CliOptions } from "./cli.js";
 export { commands, isKnownCommand } from "./commands.js";
 export type { Command } from "./commands.js";
 export {
+  createDoctorReport,
+  formatDoctorReport,
+  getDoctorExitCode,
+  runDoctorCommand
+} from "./doctor-command.js";
+export type {
+  CommandCheckResult,
+  DoctorCheck,
+  DoctorOptions,
+  DoctorReport,
+  DoctorStatus
+} from "./doctor-command.js";
+export {
   ensureConfigDirectories,
   expandHomePath,
   resolveConfigPaths

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -59,6 +59,20 @@ describe("cli", () => {
     expect(stderr.join("\n")).toContain("Not a Git repository");
   });
 
+  it("routes doctor to the environment report handler", async () => {
+    const { io, stdout, stderr } = createIo();
+    const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-doctor-"));
+
+    const exitCode = await runCli(["doctor"], io, {
+      homeDir: join(directory, "home")
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toEqual([]);
+    expect(stdout.join("\n")).toContain("Uncommitted Doctor");
+    expect(stdout.join("\n")).toContain("[fail] Global config");
+  });
+
   it("returns config exit code when project add path is missing", async () => {
     const { io, stdout, stderr } = createIo();
     const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-project-add-"));

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -67,7 +67,7 @@ describe("cli", () => {
       homeDir: join(directory, "home")
     });
 
-    expect(exitCode).toBe(1);
+    expect(exitCode).toBe(2);
     expect(stderr).toEqual([]);
     expect(stdout.join("\n")).toContain("Uncommitted Doctor");
     expect(stdout.join("\n")).toContain("[fail] Global config");

--- a/tests/doctor-command.test.ts
+++ b/tests/doctor-command.test.ts
@@ -98,6 +98,29 @@ describe("doctor command", () => {
     expect(getDoctorExitCode(report)).toBe(0);
   });
 
+  it("fails when the configured AI provider is unsupported", async () => {
+    const homeDir = await createHomeWithConfig({
+      aiProvider: "typo-provider",
+      draftRoot: "~/Uncommitted/drafts"
+    });
+
+    const report = await createDoctorReport({
+      homeDir,
+      env: {},
+      nodeVersion: "v22.13.0",
+      checkCommand: async () => ({ ok: true, detail: "git version 2.49.0" })
+    });
+
+    expect(report.checks).toContainEqual(
+      expect.objectContaining({
+        id: "ai-api-key",
+        status: "fail",
+        message: "Unsupported AI provider: typo-provider."
+      })
+    );
+    expect(getDoctorExitCode(report)).toBe(2);
+  });
+
   it("fails when a required directory is not writable", async () => {
     const homeDir = await createHomeWithConfig();
     const blockedDirectory = join(homeDir, ".uncommitted", "logs");

--- a/tests/doctor-command.test.ts
+++ b/tests/doctor-command.test.ts
@@ -1,0 +1,175 @@
+import { constants } from "node:fs";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  createDoctorReport,
+  formatDoctorReport,
+  getDoctorExitCode
+} from "../src/doctor-command.js";
+
+describe("doctor command", () => {
+  it("creates a passing environment report", async () => {
+    const homeDir = await createHomeWithConfig({
+      aiProvider: "openai",
+      draftRoot: "~/Uncommitted/drafts"
+    });
+
+    const report = await createDoctorReport({
+      homeDir,
+      env: { OPENAI_API_KEY: "test-key" },
+      nodeVersion: "v22.13.0",
+      checkCommand: async () => ({ ok: true, detail: "git version 2.49.0" })
+    });
+
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "config", status: "pass" }),
+        expect.objectContaining({ id: "node", status: "pass" }),
+        expect.objectContaining({ id: "git", status: "pass" }),
+        expect.objectContaining({ id: "ai-api-key", status: "pass" })
+      ])
+    );
+    expect(getDoctorExitCode(report)).toBe(0);
+    expect(formatDoctorReport(report)).toContain("[pass] Git");
+  });
+
+  it("reports missing config as a blocking failure", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "uncommitted-doctor-missing-config-"));
+
+    const report = await createDoctorReport({
+      homeDir,
+      env: {},
+      nodeVersion: "v22.13.0",
+      checkCommand: async () => ({ ok: true, detail: "git version 2.49.0" })
+    });
+
+    expect(report.checks).toContainEqual(
+      expect.objectContaining({
+        id: "config",
+        status: "fail",
+        message: expect.stringContaining("Config file is missing")
+      })
+    );
+    expect(getDoctorExitCode(report)).toBe(1);
+  });
+
+  it("reports missing Git as a blocking failure", async () => {
+    const homeDir = await createHomeWithConfig();
+
+    const report = await createDoctorReport({
+      homeDir,
+      env: {},
+      nodeVersion: "v22.13.0",
+      checkCommand: async () => ({ ok: false, detail: "git was not found" })
+    });
+
+    expect(report.checks).toContainEqual(
+      expect.objectContaining({
+        id: "git",
+        status: "fail",
+        message: "Git is not installed or not available on PATH."
+      })
+    );
+    expect(getDoctorExitCode(report)).toBe(1);
+  });
+
+  it("reports missing AI API keys as warning-level", async () => {
+    const homeDir = await createHomeWithConfig({
+      aiProvider: "anthropic",
+      draftRoot: "~/Uncommitted/drafts"
+    });
+
+    const report = await createDoctorReport({
+      homeDir,
+      env: {},
+      nodeVersion: "v22.13.0",
+      checkCommand: async () => ({ ok: true, detail: "git version 2.49.0" })
+    });
+
+    expect(report.checks).toContainEqual(
+      expect.objectContaining({
+        id: "ai-api-key",
+        status: "warn",
+        message: "ANTHROPIC_API_KEY is not set."
+      })
+    );
+    expect(getDoctorExitCode(report)).toBe(0);
+  });
+
+  it("fails when a required directory is not writable", async () => {
+    const homeDir = await createHomeWithConfig();
+    const blockedDirectory = join(homeDir, ".uncommitted", "logs");
+
+    const report = await createDoctorReport({
+      homeDir,
+      env: {},
+      nodeVersion: "v22.13.0",
+      checkCommand: async () => ({ ok: true, detail: "git version 2.49.0" }),
+      checkAccess: async (path, mode) => {
+        if (path === blockedDirectory && mode === constants.W_OK) {
+          return false;
+        }
+
+        return true;
+      }
+    });
+
+    expect(report.checks).toContainEqual(
+      expect.objectContaining({
+        id: "directory-logs",
+        status: "fail",
+        message: expect.stringContaining("Directory is not writable")
+      })
+    );
+    expect(getDoctorExitCode(report)).toBe(1);
+  });
+
+  it("fails when Node.js is below the supported version", async () => {
+    const homeDir = await createHomeWithConfig();
+
+    const report = await createDoctorReport({
+      homeDir,
+      env: {},
+      nodeVersion: "v22.12.0",
+      checkCommand: async () => ({ ok: true, detail: "git version 2.49.0" })
+    });
+
+    expect(report.checks).toContainEqual(
+      expect.objectContaining({
+        id: "node",
+        status: "fail",
+        message: "Node.js v22.13.0 or newer is required."
+      })
+    );
+    expect(getDoctorExitCode(report)).toBe(1);
+  });
+});
+
+async function createHomeWithConfig(
+  overrides: Partial<{ aiProvider: string; draftRoot: string }> = {}
+): Promise<string> {
+  const homeDir = await mkdtemp(join(tmpdir(), "uncommitted-doctor-"));
+  const configDir = join(homeDir, ".uncommitted");
+  const draftRoot = join(homeDir, "Uncommitted", "drafts");
+
+  await mkdir(join(configDir, "history"), { recursive: true });
+  await mkdir(join(configDir, "drafts"), { recursive: true });
+  await mkdir(join(configDir, "logs"), { recursive: true });
+  await mkdir(draftRoot, { recursive: true });
+  await writeFile(
+    join(configDir, "config.json"),
+    `${JSON.stringify({
+      schemaVersion: 1,
+      draftRoot: overrides.draftRoot ?? draftRoot,
+      scheduleTime: "23:30",
+      aiProvider: overrides.aiProvider ?? "none",
+      persona: "wry coworker",
+      roastLevel: 2
+    })}\n`,
+    "utf8"
+  );
+
+  return homeDir;
+}

--- a/tests/doctor-command.test.ts
+++ b/tests/doctor-command.test.ts
@@ -35,7 +35,7 @@ describe("doctor command", () => {
     expect(formatDoctorReport(report)).toContain("[pass] Git");
   });
 
-  it("reports missing config as a blocking failure", async () => {
+  it("reports missing config as a config error", async () => {
     const homeDir = await mkdtemp(join(tmpdir(), "uncommitted-doctor-missing-config-"));
 
     const report = await createDoctorReport({
@@ -52,7 +52,7 @@ describe("doctor command", () => {
         message: expect.stringContaining("Config file is missing")
       })
     );
-    expect(getDoctorExitCode(report)).toBe(1);
+    expect(getDoctorExitCode(report)).toBe(2);
   });
 
   it("reports missing Git as a blocking failure", async () => {


### PR DESCRIPTION
# Goal

Implement `uncommitted doctor` so users can validate local setup and understand blocking setup problems before generating drafts.

## Related Issue

Closes #7.

## Acceptance Criteria

- [x] `uncommitted doctor` prints a structured environment report
- [x] Missing config is reported clearly
- [x] Missing Git is reported clearly
- [x] Missing AI API key is warning-level, not fatal
- [x] Command exits non-zero only for blocking failures
- [x] Unit tests cover report generation logic

## Implementation Notes

- Added a typed doctor report generator with pass/warn/fail checks.
- Checked global config, Node.js version, Git availability, required directory writability, configured draft root, and AI provider API key environment variables.
- Wired `doctor` into the CLI command registry and public exports.

## Validation

- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`

## Remaining Risk

Provider API key checks are limited to the current MVP provider names and environment variable conventions.
