### PR TITLE
feat: implement manual note command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { commands, isKnownCommand } from "./commands.js";
 import { formatDoctorReport, runDoctorCommand } from "./doctor-command.js";
 import { runInitCommand } from "./init-command.js";
+import { NoteCommandError, recordManualNote } from "./note-command.js";
 import { addProject, ProjectAddError } from "./project-add.js";
 
 export type CliIo = {
@@ -16,6 +17,7 @@ export type CliIo = {
 export type CliOptions = {
   cwd?: string;
   homeDir?: string;
+  now?: () => string;
 };
 
 const defaultIo: CliIo = {
@@ -82,8 +84,32 @@ export async function runCli(
     return await runProjectAdd(value, io, options);
   }
 
+  if (command === "note") {
+    return await runNote(commandArgs, io, options);
+  }
+
   io.stderr(`Command not implemented yet: ${command}`);
   return 1;
+}
+
+async function runNote(
+  args: string[],
+  io: CliIo,
+  options: CliOptions
+): Promise<number> {
+  try {
+    const result = await recordManualNote(args, options);
+
+    io.stdout(`Note saved for ${result.event.date}.`);
+    return 0;
+  } catch (error) {
+    if (error instanceof NoteCommandError) {
+      io.stderr(error.message);
+      return error.code === "empty-note" ? 1 : 2;
+    }
+
+    throw error;
+  }
 }
 
 async function runProjectAdd(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -97,6 +97,11 @@ async function runNote(
   io: CliIo,
   options: CliOptions
 ): Promise<number> {
+  if (args[0] === "list") {
+    io.stderr("Command not implemented yet: note list");
+    return 1;
+  }
+
   try {
     const result = await recordManualNote(args, options);
 

--- a/src/note-command.ts
+++ b/src/note-command.ts
@@ -1,0 +1,170 @@
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, realpath, appendFile } from "node:fs/promises";
+import { join } from "node:path";
+import process from "node:process";
+import { promisify } from "node:util";
+import { resolveConfigPaths } from "./config-paths.js";
+import type { ProjectRecord, ProjectsFile } from "./project-add.js";
+
+const execFileAsync = promisify(execFile);
+
+export type NoteCommandErrorCode =
+  | "empty-note"
+  | "project-not-registered"
+  | "invalid-projects-file";
+
+export class NoteCommandError extends Error {
+  constructor(
+    message: string,
+    public readonly code: NoteCommandErrorCode
+  ) {
+    super(message);
+    this.name = "NoteCommandError";
+  }
+}
+
+export type ManualNoteEvent = {
+  schemaVersion: 1;
+  id: string;
+  timestamp: string;
+  date: string;
+  projectId: string;
+  text: string;
+  source: "manual";
+};
+
+export type RecordManualNoteOptions = {
+  cwd?: string;
+  homeDir?: string;
+  now?: () => string;
+  createId?: () => string;
+};
+
+export type RecordManualNoteResult = {
+  event: ManualNoteEvent;
+  eventFile: string;
+};
+
+export async function recordManualNote(
+  args: string[],
+  options: RecordManualNoteOptions = {}
+): Promise<RecordManualNoteResult> {
+  const text = args.join(" ").trim();
+
+  if (!text) {
+    throw new NoteCommandError(
+      'Note is empty. Pass text like: uncommitted note "fixed a bug".',
+      "empty-note"
+    );
+  }
+
+  const project = await resolveCurrentProject(options);
+  const timestamp = options.now ? options.now() : new Date().toISOString();
+  const date = timestamp.slice(0, 10);
+  const event: ManualNoteEvent = {
+    schemaVersion: 1,
+    id: options.createId ? options.createId() : randomUUID(),
+    timestamp,
+    date,
+    projectId: project.id,
+    text,
+    source: "manual"
+  };
+  const eventsDir = join(project.root, ".uncommitted", "events", "manual");
+  const eventFile = join(eventsDir, `${date}.jsonl`);
+
+  await mkdir(eventsDir, { recursive: true });
+  await appendFile(eventFile, `${JSON.stringify(event)}\n`, "utf8");
+
+  return { event, eventFile };
+}
+
+async function resolveCurrentProject(
+  options: RecordManualNoteOptions
+): Promise<ProjectRecord> {
+  const cwd = options.cwd ?? process.cwd();
+  const gitRoot = await findGitRoot(cwd);
+  const paths = resolveConfigPaths({ homeDir: options.homeDir });
+  const projectsFile = await readProjectsFile(paths.projectsFile);
+  const project = projectsFile.projects.find(
+    (registeredProject) => registeredProject.enabled && registeredProject.gitRoot === gitRoot
+  );
+
+  if (!project) {
+    throw new NoteCommandError(
+      "Run inside a registered project.",
+      "project-not-registered"
+    );
+  }
+
+  return project;
+}
+
+async function findGitRoot(path: string): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync("git", [
+      "-C",
+      path,
+      "rev-parse",
+      "--show-toplevel"
+    ]);
+    return await realpath(stdout.trim());
+  } catch {
+    throw new NoteCommandError(
+      "Run inside a registered project.",
+      "project-not-registered"
+    );
+  }
+}
+
+async function readProjectsFile(path: string): Promise<ProjectsFile> {
+  try {
+    const parsed = JSON.parse(await readFile(path, "utf8")) as unknown;
+
+    if (isProjectsFile(parsed)) {
+      return parsed;
+    }
+
+    throw new NoteCommandError("Invalid projects file.", "invalid-projects-file");
+  } catch (error) {
+    if (error instanceof NoteCommandError) {
+      throw error;
+    }
+
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return { schemaVersion: 1, projects: [] };
+    }
+
+    throw new NoteCommandError("Invalid projects file.", "invalid-projects-file");
+  }
+}
+
+function isProjectsFile(value: unknown): value is ProjectsFile {
+  if (!isRecord(value) || value.schemaVersion !== 1 || !Array.isArray(value.projects)) {
+    return false;
+  }
+
+  return value.projects.every(isProjectRecord);
+}
+
+function isProjectRecord(value: unknown): value is ProjectRecord {
+  return (
+    isRecord(value) &&
+    value.schemaVersion === 1 &&
+    typeof value.id === "string" &&
+    typeof value.name === "string" &&
+    typeof value.root === "string" &&
+    typeof value.gitRoot === "string" &&
+    typeof value.enabled === "boolean" &&
+    typeof value.createdAt === "string"
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -39,11 +39,25 @@ describe("cli", () => {
   it("routes known commands to placeholder handlers", async () => {
     const { io, stdout, stderr } = createIo();
 
-    const exitCode = await runCli(["note"], io);
+    const exitCode = await runCli(["collect"], io);
 
     expect(exitCode).toBe(1);
     expect(stdout).toEqual([]);
-    expect(stderr.join("\n")).toContain("Command not implemented yet: note");
+    expect(stderr.join("\n")).toContain("Command not implemented yet: collect");
+  });
+
+  it("routes note to the manual note handler", async () => {
+    const { io, stdout, stderr } = createIo();
+    const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-note-"));
+
+    const exitCode = await runCli(["note", "remember this"], io, {
+      homeDir: join(directory, "home"),
+      cwd: directory
+    });
+
+    expect(exitCode).toBe(2);
+    expect(stdout).toEqual([]);
+    expect(stderr.join("\n")).toContain("Run inside a registered project.");
   });
 
   it("routes project add to the project registration handler", async () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,11 +1,12 @@
 import { execFile } from "node:child_process";
-import { mkdir, mkdtemp, symlink, writeFile } from "node:fs/promises";
+import { access, mkdir, mkdtemp, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
 import { isDirectRun, runCli } from "../src/cli.js";
+import { addProject } from "../src/project-add.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -58,6 +59,32 @@ describe("cli", () => {
     expect(exitCode).toBe(2);
     expect(stdout).toEqual([]);
     expect(stderr.join("\n")).toContain("Run inside a registered project.");
+  });
+
+  it("does not save note list as a manual note", async () => {
+    const { io, stdout, stderr } = createIo();
+    const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-note-list-"));
+    const repoDir = join(directory, "repo");
+    const homeDir = join(directory, "home");
+
+    await execFileAsync("git", ["init", repoDir]);
+    await addProject(repoDir, {
+      homeDir,
+      now: () => "2026-05-06T00:00:00.000Z"
+    });
+
+    const exitCode = await runCli(["note", "list"], io, {
+      cwd: repoDir,
+      homeDir,
+      now: () => "2026-05-06T10:15:30.000Z"
+    });
+
+    await expect(
+      access(join(repoDir, ".uncommitted", "events", "manual", "2026-05-06.jsonl"))
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    expect(exitCode).toBe(1);
+    expect(stdout).toEqual([]);
+    expect(stderr.join("\n")).toContain("Command not implemented yet: note list");
   });
 
   it("routes project add to the project registration handler", async () => {

--- a/tests/note-command.test.ts
+++ b/tests/note-command.test.ts
@@ -1,0 +1,102 @@
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, realpath } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+import { addProject } from "../src/project-add.js";
+import { NoteCommandError, recordManualNote } from "../src/note-command.js";
+
+const execFileAsync = promisify(execFile);
+
+describe("note command", () => {
+  it("appends a manual note JSONL event for the current registered project", async () => {
+    const { homeDir, repoDir } = await createRegisteredProject("note-success");
+    const nestedDir = join(repoDir, "packages", "cli");
+    await mkdir(nestedDir, { recursive: true });
+
+    const result = await recordManualNote(["fixed the flaky setup"], {
+      cwd: nestedDir,
+      homeDir,
+      now: () => "2026-05-06T10:15:30.000Z",
+      createId: () => "note-1"
+    });
+
+    expect(result).toEqual({
+      eventFile: join(repoDir, ".uncommitted", "events", "manual", "2026-05-06.jsonl"),
+      event: {
+        schemaVersion: 1,
+        id: "note-1",
+        timestamp: "2026-05-06T10:15:30.000Z",
+        date: "2026-05-06",
+        projectId: "note-success",
+        text: "fixed the flaky setup",
+        source: "manual"
+      }
+    });
+
+    const lines = (
+      await readFile(result.eventFile, "utf8")
+    ).trimEnd().split("\n");
+
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0]) as unknown).toEqual(result.event);
+    expect(lines[0]).not.toContain(repoDir);
+    expect(lines[0]).not.toContain(homeDir);
+  });
+
+  it("rejects empty or whitespace-only notes", async () => {
+    await expect(recordManualNote(["  \t "], {})).rejects.toMatchObject({
+      code: "empty-note",
+      message: "Note is empty. Pass text like: uncommitted note \"fixed a bug\"."
+    });
+  });
+
+  it("fails clearly outside a registered project", async () => {
+    const root = await createTempRoot("note-unregistered");
+    const repoDir = await initGitRepo(join(root, "repo"));
+
+    await expect(
+      recordManualNote(["worked on tests"], {
+        cwd: repoDir,
+        homeDir: join(root, "home")
+      })
+    ).rejects.toMatchObject({
+      code: "project-not-registered",
+      message: "Run inside a registered project."
+    });
+  });
+
+  it("uses a typed note command error", async () => {
+    await expect(recordManualNote([], {})).rejects.toBeInstanceOf(NoteCommandError);
+  });
+});
+
+async function createRegisteredProject(name: string): Promise<{
+  homeDir: string;
+  repoDir: string;
+}> {
+  const root = await createTempRoot(name);
+  const repoDir = await initGitRepo(join(root, name));
+  const homeDir = join(root, "home");
+
+  await addProject(repoDir, {
+    homeDir,
+    now: () => "2026-05-06T00:00:00.000Z"
+  });
+
+  return { homeDir, repoDir };
+}
+
+async function createTempRoot(name: string): Promise<string> {
+  const root = join(tmpdir(), `uncommitted-${name}-${randomUUID()}`);
+  await mkdir(root, { recursive: true });
+  return root;
+}
+
+async function initGitRepo(repoDir: string): Promise<string> {
+  await mkdir(repoDir, { recursive: true });
+  await execFileAsync("git", ["init", repoDir]);
+  return await realpath(repoDir);
+}


### PR DESCRIPTION
# Goal

Implement `uncommitted note "..."` so users can record manual daily notes for a registered project in local JSONL storage.

## Related Issue

Closes #14.

## Acceptance Criteria

- [x] `uncommitted note "..."` appends a manual note event for the current date.
- [x] Manual notes are stored as JSONL under `.uncommitted/events/manual/`.
- [x] Empty notes fail with a short actionable error.
- [x] Running outside a registered project fails clearly.
- [x] Stored note events avoid user-specific absolute paths.
- [x] Unit tests cover successful note persistence and invalid input.

## Implementation Notes

- Added a focused `note-command` module for resolving the current registered Git project and writing manual note events.
- Wired `uncommitted note` through the CLI while keeping `note list` out of scope.
- Stored event records with structured fields including id, timestamp, date, project id, text, and source.

## Validation

- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`

## Remaining Risk

- `uncommitted note list` is intentionally not implemented here and remains issue #15.
