### PR TITLE
feat: implement safe Git activity collector

### DIFF
--- a/src/git-activity-collector.ts
+++ b/src/git-activity-collector.ts
@@ -1,0 +1,297 @@
+import { execFile } from "node:child_process";
+import { constants } from "node:fs";
+import { access, realpath } from "node:fs/promises";
+import { basename } from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export type GitActivityCollectionErrorCode =
+  | "path-not-found"
+  | "not-git-repository";
+
+export class GitActivityCollectionError extends Error {
+  constructor(
+    message: string,
+    public readonly code: GitActivityCollectionErrorCode
+  ) {
+    super(message);
+    this.name = "GitActivityCollectionError";
+  }
+}
+
+export type GitActivityStats = {
+  filesChanged: number;
+  insertions: number;
+  deletions: number;
+};
+
+export type GitActivityCommit = {
+  hash: string;
+  shortHash: string;
+  authorName: string;
+  authoredAt: string;
+  subject: string;
+  stats: GitActivityStats;
+};
+
+export type DirtyFileStatus =
+  | "modified"
+  | "added"
+  | "deleted"
+  | "renamed"
+  | "copied"
+  | "untracked"
+  | "other";
+
+export type DirtyFileSummary = {
+  path: string;
+  status: DirtyFileStatus;
+};
+
+export type DirtyStatusTotals = Record<DirtyFileStatus, number>;
+
+export type GitActivity = {
+  schemaVersion: 1;
+  targetDate: string;
+  repository: {
+    rootName: string;
+    gitRoot?: never;
+  };
+  commits: GitActivityCommit[];
+  totals: GitActivityStats & {
+    commits: number;
+  };
+  dirty: {
+    files: DirtyFileSummary[];
+    totals: DirtyStatusTotals;
+  };
+};
+
+export type CollectGitActivityOptions = {
+  projectRoot: string;
+  targetDate: string;
+};
+
+type ParsedCommit = GitActivityCommit;
+
+export async function collectGitActivity(
+  options: CollectGitActivityOptions
+): Promise<GitActivity> {
+  const gitRoot = await findGitRoot(options.projectRoot);
+  const commits = await collectCommits(gitRoot, options.targetDate);
+  const dirty = await collectDirtyStatus(gitRoot);
+  const totals = commits.reduce(
+    (accumulator, commit) => ({
+      commits: accumulator.commits + 1,
+      filesChanged: accumulator.filesChanged + commit.stats.filesChanged,
+      insertions: accumulator.insertions + commit.stats.insertions,
+      deletions: accumulator.deletions + commit.stats.deletions
+    }),
+    { commits: 0, filesChanged: 0, insertions: 0, deletions: 0 }
+  );
+
+  return {
+    schemaVersion: 1,
+    targetDate: options.targetDate,
+    repository: {
+      rootName: basename(gitRoot)
+    },
+    commits,
+    totals,
+    dirty
+  };
+}
+
+async function findGitRoot(path: string): Promise<string> {
+  try {
+    await access(path, constants.F_OK);
+  } catch {
+    throw new GitActivityCollectionError(
+      "Path does not exist.",
+      "path-not-found"
+    );
+  }
+
+  try {
+    const { stdout } = await execFileAsync("git", [
+      "-C",
+      path,
+      "rev-parse",
+      "--show-toplevel"
+    ]);
+
+    return await realpath(stdout.trim());
+  } catch {
+    throw new GitActivityCollectionError(
+      "Not a Git repository.",
+      "not-git-repository"
+    );
+  }
+}
+
+async function collectCommits(
+  gitRoot: string,
+  targetDate: string
+): Promise<ParsedCommit[]> {
+  const { start, end } = getDateWindow(targetDate);
+  const { stdout } = await execFileAsync("git", [
+    "-C",
+    gitRoot,
+    "log",
+    `--since=${start}`,
+    `--before=${end}`,
+    "--date=iso-strict",
+    "--pretty=format:%H%x1f%h%x1f%an%x1f%ad%x1f%s",
+    "--numstat"
+  ]);
+
+  return parseGitLog(stdout);
+}
+
+function parseGitLog(stdout: string): ParsedCommit[] {
+  const commits: ParsedCommit[] = [];
+  let currentCommit: ParsedCommit | undefined;
+
+  for (const line of stdout.split("\n")) {
+    if (!line.trim()) {
+      continue;
+    }
+
+    const fields = line.split("\u001f");
+
+    if (fields.length === 5) {
+      currentCommit = {
+        hash: fields[0],
+        shortHash: fields[1],
+        authorName: redactSensitiveText(fields[2]),
+        authoredAt: fields[3],
+        subject: redactSensitiveText(fields[4]),
+        stats: {
+          filesChanged: 0,
+          insertions: 0,
+          deletions: 0
+        }
+      };
+      commits.push(currentCommit);
+      continue;
+    }
+
+    if (!currentCommit) {
+      continue;
+    }
+
+    const [insertions, deletions] = line.split("\t");
+
+    currentCommit.stats.filesChanged += 1;
+    currentCommit.stats.insertions += parseNumstatValue(insertions);
+    currentCommit.stats.deletions += parseNumstatValue(deletions);
+  }
+
+  return commits;
+}
+
+async function collectDirtyStatus(
+  gitRoot: string
+): Promise<GitActivity["dirty"]> {
+  const { stdout } = await execFileAsync("git", [
+    "-C",
+    gitRoot,
+    "status",
+    "--porcelain"
+  ]);
+  const files = stdout
+    .split("\n")
+    .filter(Boolean)
+    .map(parseDirtyStatusLine);
+  const totals = createEmptyDirtyTotals();
+
+  for (const file of files) {
+    totals[file.status] += 1;
+  }
+
+  return { files, totals };
+}
+
+function parseDirtyStatusLine(line: string): DirtyFileSummary {
+  const statusCode = line.slice(0, 2);
+  const rawPath = line.slice(3);
+  const path = rawPath.includes(" -> ") ? rawPath.split(" -> ").at(-1) ?? rawPath : rawPath;
+
+  return {
+    path,
+    status: mapDirtyStatus(statusCode)
+  };
+}
+
+function mapDirtyStatus(statusCode: string): DirtyFileStatus {
+  if (statusCode === "??") {
+    return "untracked";
+  }
+
+  if (statusCode.includes("R")) {
+    return "renamed";
+  }
+
+  if (statusCode.includes("C")) {
+    return "copied";
+  }
+
+  if (statusCode.includes("A")) {
+    return "added";
+  }
+
+  if (statusCode.includes("D")) {
+    return "deleted";
+  }
+
+  if (statusCode.includes("M")) {
+    return "modified";
+  }
+
+  return "other";
+}
+
+function createEmptyDirtyTotals(): DirtyStatusTotals {
+  return {
+    modified: 0,
+    added: 0,
+    deleted: 0,
+    renamed: 0,
+    copied: 0,
+    untracked: 0,
+    other: 0
+  };
+}
+
+function parseNumstatValue(value: string | undefined): number {
+  if (!value || value === "-") {
+    return 0;
+  }
+
+  return Number.parseInt(value, 10);
+}
+
+function getDateWindow(targetDate: string): { start: string; end: string } {
+  const startDate = new Date(`${targetDate}T00:00:00.000Z`);
+  const endDate = new Date(startDate);
+  endDate.setUTCDate(startDate.getUTCDate() + 1);
+
+  return {
+    start: startDate.toISOString(),
+    end: endDate.toISOString()
+  };
+}
+
+function redactSensitiveText(value: string): string {
+  return value
+    .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, "[redacted-email]")
+    .replace(
+      /\b(?:https?|ssh|git):\/\/\S+|git@[\w.-]+:[^\s]+/g,
+      "[redacted-url]"
+    )
+    .replace(
+      /(^|\s)\/(?:Users|home|private|tmp|var|Volumes)\/\S+/g,
+      "$1[redacted-path]"
+    );
+}

--- a/src/git-activity-collector.ts
+++ b/src/git-activity-collector.ts
@@ -216,12 +216,68 @@ async function collectDirtyStatus(
 function parseDirtyStatusLine(line: string): DirtyFileSummary {
   const statusCode = line.slice(0, 2);
   const rawPath = line.slice(3);
-  const path = rawPath.includes(" -> ") ? rawPath.split(" -> ").at(-1) ?? rawPath : rawPath;
+  const status = mapDirtyStatus(statusCode);
+  const path = extractCurrentDirtyPath(rawPath, status);
 
   return {
     path,
-    status: mapDirtyStatus(statusCode)
+    status
   };
+}
+
+function extractCurrentDirtyPath(rawPath: string, status: DirtyFileStatus): string {
+  if (status !== "renamed" && status !== "copied") {
+    return unquoteGitPath(rawPath);
+  }
+
+  const separatorIndex = findRenameSeparator(rawPath);
+  const currentPath =
+    separatorIndex === -1 ? rawPath : rawPath.slice(separatorIndex + " -> ".length);
+
+  return unquoteGitPath(currentPath);
+}
+
+function findRenameSeparator(rawPath: string): number {
+  let inQuote = false;
+  let escaped = false;
+  let separatorIndex = -1;
+
+  for (let index = 0; index < rawPath.length; index += 1) {
+    const char = rawPath[index];
+
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+
+    if (char === "\\") {
+      escaped = true;
+      continue;
+    }
+
+    if (char === "\"") {
+      inQuote = !inQuote;
+      continue;
+    }
+
+    if (!inQuote && rawPath.startsWith(" -> ", index)) {
+      separatorIndex = index;
+    }
+  }
+
+  return separatorIndex;
+}
+
+function unquoteGitPath(path: string): string {
+  if (!path.startsWith("\"") || !path.endsWith("\"")) {
+    return path;
+  }
+
+  try {
+    return JSON.parse(path) as string;
+  } catch {
+    return path;
+  }
 }
 
 function mapDirtyStatus(statusCode: string): DirtyFileStatus {

--- a/src/git-activity-collector.ts
+++ b/src/git-activity-collector.ts
@@ -347,7 +347,7 @@ function redactSensitiveText(value: string): string {
       "[redacted-url]"
     )
     .replace(
-      /(^|\s)\/(?:Users|home|private|tmp|var|Volumes)\/\S+/g,
+      /(^|[\s(["'])\/[^\s)"']+/g,
       "$1[redacted-path]"
     );
 }

--- a/tests/git-activity-collector.test.ts
+++ b/tests/git-activity-collector.test.ts
@@ -31,7 +31,7 @@ describe("Git activity collector", () => {
     await git(repoDir, ["add", "app.ts", "notes.md"]);
     await commit(
       repoDir,
-      "safe work by dev@example.com in /Users/someone/secret https://github.com/acme/private",
+      "safe work by dev@example.com in /Users/someone/secret and /workspace/app https://github.com/acme/private",
       "2026-05-05T10:00:00Z"
     );
 
@@ -83,7 +83,7 @@ describe("Git activity collector", () => {
       shortHash: expect.stringMatching(/^[0-9a-f]{7,}$/),
       authorName: "Fixture Dev",
       subject:
-        "safe work by [redacted-email] in [redacted-path] [redacted-url]",
+        "safe work by [redacted-email] in [redacted-path] and [redacted-path] [redacted-url]",
       stats: {
         filesChanged: 2,
         insertions: 2,
@@ -99,6 +99,7 @@ describe("Git activity collector", () => {
     const serialized = JSON.stringify(activity);
     expect(serialized).not.toContain(repoDir);
     expect(serialized).not.toContain("dev@example.com");
+    expect(serialized).not.toContain("/workspace/app");
     expect(serialized).not.toContain("github.com/acme/private");
     expect(serialized).not.toContain("git@github.com");
     expect(serialized).not.toContain("const target = 2");

--- a/tests/git-activity-collector.test.ts
+++ b/tests/git-activity-collector.test.ts
@@ -1,0 +1,201 @@
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { mkdir, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+import {
+  collectGitActivity,
+  GitActivityCollectionError
+} from "../src/git-activity-collector.js";
+
+const execFileAsync = promisify(execFile);
+
+describe("Git activity collector", () => {
+  it("collects date-scoped commit metadata, safe stats, and dirty status summaries", async () => {
+    const repoDir = await initGitRepo("collector-repo");
+    const nestedDir = join(repoDir, "packages", "cli");
+    await mkdir(nestedDir, { recursive: true });
+
+    await writeFile(join(repoDir, "app.ts"), "const base = 1;\n", "utf8");
+    await git(repoDir, ["add", "app.ts"]);
+    await commit(repoDir, "base commit", "2026-05-04T12:00:00Z");
+
+    await writeFile(
+      join(repoDir, "app.ts"),
+      "const base = 1;\nconst target = 2;\n",
+      "utf8"
+    );
+    await writeFile(join(repoDir, "notes.md"), "target note\n", "utf8");
+    await git(repoDir, ["add", "app.ts", "notes.md"]);
+    await commit(
+      repoDir,
+      "safe work by dev@example.com in /Users/someone/secret https://github.com/acme/private",
+      "2026-05-05T10:00:00Z"
+    );
+
+    await git(repoDir, [
+      "remote",
+      "add",
+      "origin",
+      "git@github.com:acme/private.git"
+    ]);
+    await writeFile(
+      join(repoDir, "app.ts"),
+      "const base = 1;\nconst target = 2;\nconst dirty = 3;\n",
+      "utf8"
+    );
+    await writeFile(join(repoDir, "scratch.txt"), "uncommitted secret\n", "utf8");
+
+    const activity = await collectGitActivity({
+      projectRoot: nestedDir,
+      targetDate: "2026-05-05"
+    });
+
+    expect(activity).toMatchObject({
+      schemaVersion: 1,
+      targetDate: "2026-05-05",
+      repository: {
+        rootName: basename(repoDir)
+      },
+      totals: {
+        commits: 1,
+        filesChanged: 2,
+        insertions: 2,
+        deletions: 0
+      },
+      dirty: {
+        totals: {
+          modified: 1,
+          added: 0,
+          deleted: 0,
+          renamed: 0,
+          copied: 0,
+          untracked: 1,
+          other: 0
+        }
+      }
+    });
+    expect(activity.repository.gitRoot).toBeUndefined();
+    expect(activity.commits).toHaveLength(1);
+    expect(activity.commits[0]).toMatchObject({
+      shortHash: expect.stringMatching(/^[0-9a-f]{7,}$/),
+      authorName: "Fixture Dev",
+      subject:
+        "safe work by [redacted-email] in [redacted-path] [redacted-url]",
+      stats: {
+        filesChanged: 2,
+        insertions: 2,
+        deletions: 0
+      }
+    });
+    expect(activity.commits[0]?.hash).toMatch(/^[0-9a-f]{40}$/);
+    expect(activity.dirty.files).toEqual([
+      { path: "app.ts", status: "modified" },
+      { path: "scratch.txt", status: "untracked" }
+    ]);
+
+    const serialized = JSON.stringify(activity);
+    expect(serialized).not.toContain(repoDir);
+    expect(serialized).not.toContain("dev@example.com");
+    expect(serialized).not.toContain("github.com/acme/private");
+    expect(serialized).not.toContain("git@github.com");
+    expect(serialized).not.toContain("const target = 2");
+    expect(serialized).not.toContain("uncommitted secret");
+  });
+
+  it("returns no commits for a quiet target date while still reporting dirty state", async () => {
+    const repoDir = await initGitRepo("quiet-repo");
+
+    await writeFile(join(repoDir, "app.ts"), "const base = 1;\n", "utf8");
+    await git(repoDir, ["add", "app.ts"]);
+    await commit(repoDir, "base commit", "2026-05-04T12:00:00Z");
+    await writeFile(join(repoDir, "scratch.txt"), "quiet dirty file\n", "utf8");
+
+    const activity = await collectGitActivity({
+      projectRoot: repoDir,
+      targetDate: "2026-05-05"
+    });
+
+    expect(activity.commits).toEqual([]);
+    expect(activity.totals).toEqual({
+      commits: 0,
+      filesChanged: 0,
+      insertions: 0,
+      deletions: 0
+    });
+    expect(activity.dirty.files).toEqual([
+      { path: "scratch.txt", status: "untracked" }
+    ]);
+  });
+
+  it("fails with collection errors for missing or non-Git roots", async () => {
+    const plainDir = await createTempRoot("plain-dir");
+    const missingDir = join(plainDir, "missing");
+
+    await expect(
+      collectGitActivity({
+        projectRoot: plainDir,
+        targetDate: "2026-05-05"
+      })
+    ).rejects.toMatchObject({
+      code: "not-git-repository",
+      message: expect.stringContaining("Not a Git repository")
+    });
+    await expect(
+      collectGitActivity({
+        projectRoot: missingDir,
+        targetDate: "2026-05-05"
+      })
+    ).rejects.toMatchObject({
+      code: "path-not-found",
+      message: expect.stringContaining("Path does not exist")
+    });
+    await expect(
+      collectGitActivity({
+        projectRoot: plainDir,
+        targetDate: "2026-05-05"
+      })
+    ).rejects.toBeInstanceOf(GitActivityCollectionError);
+  });
+});
+
+async function initGitRepo(name: string): Promise<string> {
+  const repoDir = await createTempRoot(name);
+  await git(repoDir, ["init", "."]);
+  await git(repoDir, ["config", "user.name", "Fixture Dev"]);
+  await git(repoDir, ["config", "user.email", "dev@example.com"]);
+  return await realpath(repoDir);
+}
+
+async function createTempRoot(name: string): Promise<string> {
+  const root = join(tmpdir(), `uncommitted-git-collector-${randomUUID()}`, name);
+  await rm(root, { force: true, recursive: true });
+  await mkdir(root, { recursive: true });
+  return root;
+}
+
+async function commit(
+  repoDir: string,
+  message: string,
+  date: string
+): Promise<void> {
+  await git(repoDir, ["commit", "-m", message], {
+    GIT_AUTHOR_DATE: date,
+    GIT_COMMITTER_DATE: date
+  });
+}
+
+async function git(
+  repoDir: string,
+  args: string[],
+  env: NodeJS.ProcessEnv = {}
+): Promise<void> {
+  await execFileAsync("git", ["-C", repoDir, ...args], {
+    env: {
+      ...process.env,
+      ...env
+    }
+  });
+}

--- a/tests/git-activity-collector.test.ts
+++ b/tests/git-activity-collector.test.ts
@@ -130,6 +130,25 @@ describe("Git activity collector", () => {
     ]);
   });
 
+  it("keeps arrows in added file names", async () => {
+    const repoDir = await initGitRepo("arrow-file-repo");
+
+    await writeFile(join(repoDir, "base.txt"), "base\n", "utf8");
+    await git(repoDir, ["add", "base.txt"]);
+    await commit(repoDir, "base commit", "2026-05-05T10:00:00Z");
+    await writeFile(join(repoDir, "a -> b.txt"), "dirty\n", "utf8");
+    await git(repoDir, ["add", "a -> b.txt"]);
+
+    const activity = await collectGitActivity({
+      projectRoot: repoDir,
+      targetDate: "2026-05-06"
+    });
+
+    expect(activity.dirty.files).toEqual([
+      { path: "a -> b.txt", status: "added" }
+    ]);
+  });
+
   it("fails with collection errors for missing or non-Git roots", async () => {
     const plainDir = await createTempRoot("plain-dir");
     const missingDir = join(plainDir, "missing");


### PR DESCRIPTION
# Goal

Implement a reusable safe Git activity collector that returns local repository activity for a target date without exposing raw code, diffs, private paths, emails, or remote URLs.

## Related Issue

Closes #16.

## Acceptance Criteria

- [x] Collector can read commit metadata for a specific date from a local Git repository.
- [x] Collector includes safe aggregate stats without raw diffs or raw code.
- [x] Collector includes dirty working tree file status summaries.
- [x] Private remote URLs and emails are not included in output.
- [x] Non-Git or missing repositories fail with a clear collection error.
- [x] Tests use isolated temporary Git repositories.

## Implementation Notes

- Added `collectGitActivity` as core collector behavior without CLI wiring.
- Uses local Git metadata, numstat totals, and porcelain status summaries only.
- Redacts sensitive text in commit subjects and omits repository roots and remote URLs from output.

## Validation

- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`

## Remaining Risk

- `uncommitted collect git` CLI integration and raw activity output are intentionally left for issue #17.
