### PR TITLE
feat: implement collect git command and raw activity output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 .DS_Store
 .omc/
+.uncommitted/

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,10 @@
 import { realpathSync } from "node:fs";
 import process from "node:process";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import {
+  collectGitForRegisteredProjects,
+  CollectGitCommandError
+} from "./collect-git-command.js";
 import { commands, isKnownCommand } from "./commands.js";
 import { formatDoctorReport, runDoctorCommand } from "./doctor-command.js";
 import { runInitCommand } from "./init-command.js";
@@ -88,8 +92,50 @@ export async function runCli(
     return await runNote(commandArgs, io, options);
   }
 
+  if (command === "collect") {
+    return await runCollect(commandArgs, io, options);
+  }
+
   io.stderr(`Command not implemented yet: ${command}`);
   return 1;
+}
+
+async function runCollect(
+  args: string[],
+  io: CliIo,
+  options: CliOptions
+): Promise<number> {
+  if (args.length !== 1 || args[0] !== "git") {
+    io.stderr("Usage: uncommitted collect git");
+    return 1;
+  }
+
+  try {
+    const result = await collectGitForRegisteredProjects(options);
+
+    if (result.successes.length > 0) {
+      io.stdout(`Collected Git activity for ${formatProjectCount(result.successes.length)}.`);
+
+      for (const success of result.successes) {
+        io.stdout(
+          `${success.projectId}: ${success.activity.totals.commits} commits, ${success.activity.dirty.files.length} dirty files.`
+        );
+      }
+    }
+
+    for (const failure of result.failures) {
+      io.stderr(`Failed to collect ${failure.projectId}: ${failure.message}`);
+    }
+
+    return result.failures.length > 0 ? 3 : 0;
+  } catch (error) {
+    if (error instanceof CollectGitCommandError) {
+      io.stderr(error.message);
+      return 3;
+    }
+
+    throw error;
+  }
 }
 
 async function runNote(
@@ -115,6 +161,10 @@ async function runNote(
 
     throw error;
   }
+}
+
+function formatProjectCount(count: number): string {
+  return `${count} ${count === 1 ? "project" : "projects"}`;
 }
 
 async function runProjectAdd(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -131,7 +131,7 @@ async function runCollect(
   } catch (error) {
     if (error instanceof CollectGitCommandError) {
       io.stderr(error.message);
-      return 3;
+      return error.code === "invalid-projects-file" ? 2 : 3;
     }
 
     throw error;

--- a/src/collect-git-command.ts
+++ b/src/collect-git-command.ts
@@ -1,0 +1,194 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  collectGitActivity,
+  GitActivityCollectionError,
+  type GitActivity
+} from "./git-activity-collector.js";
+import { resolveConfigPaths } from "./config-paths.js";
+import type { ProjectRecord, ProjectsFile } from "./project-add.js";
+
+export type CollectGitCommandErrorCode =
+  | "invalid-projects-file"
+  | "no-projects";
+
+export class CollectGitCommandError extends Error {
+  constructor(
+    message: string,
+    public readonly code: CollectGitCommandErrorCode
+  ) {
+    super(message);
+    this.name = "CollectGitCommandError";
+  }
+}
+
+export type CollectGitCommandOptions = {
+  homeDir?: string;
+  now?: () => string;
+};
+
+export type GitActivityEvent = {
+  schemaVersion: 1;
+  source: "git";
+  targetDate: string;
+  collectedAt: string;
+  project: {
+    id: string;
+    name: string;
+  };
+  activity: GitActivity;
+};
+
+export type CollectGitSuccess = {
+  projectId: string;
+  outputFile: string;
+  activity: GitActivity;
+};
+
+export type CollectGitFailure = {
+  projectId: string;
+  message: string;
+};
+
+export type CollectGitCommandResult = {
+  targetDate: string;
+  successes: CollectGitSuccess[];
+  failures: CollectGitFailure[];
+};
+
+export async function collectGitForRegisteredProjects(
+  options: CollectGitCommandOptions = {}
+): Promise<CollectGitCommandResult> {
+  const paths = resolveConfigPaths({ homeDir: options.homeDir });
+  const projectsFile = await readProjectsFile(paths.projectsFile);
+  const projects = projectsFile.projects.filter((project) => project.enabled);
+  const now = options.now ? options.now() : new Date().toISOString();
+  const targetDate = now.slice(0, 10);
+
+  if (projects.length === 0) {
+    throw new CollectGitCommandError(
+      "No registered projects. Run `uncommitted project add .` first.",
+      "no-projects"
+    );
+  }
+
+  const successes: CollectGitSuccess[] = [];
+  const failures: CollectGitFailure[] = [];
+
+  for (const project of projects) {
+    try {
+      const activity = await collectGitActivity({
+        projectRoot: project.gitRoot,
+        targetDate
+      });
+      const event: GitActivityEvent = {
+        schemaVersion: 1,
+        source: "git",
+        targetDate,
+        collectedAt: now,
+        project: {
+          id: project.id,
+          name: project.name
+        },
+        activity
+      };
+      const outputFile = await writeGitActivityEvent(project, targetDate, event);
+
+      successes.push({
+        projectId: project.id,
+        outputFile,
+        activity
+      });
+    } catch (error) {
+      failures.push({
+        projectId: project.id,
+        message: formatCollectionError(error)
+      });
+    }
+  }
+
+  return {
+    targetDate,
+    successes,
+    failures
+  };
+}
+
+async function writeGitActivityEvent(
+  project: ProjectRecord,
+  targetDate: string,
+  event: GitActivityEvent
+): Promise<string> {
+  const outputDir = join(project.root, ".uncommitted", "events", "git");
+  const outputFile = join(outputDir, `${targetDate}.json`);
+
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(outputFile, `${JSON.stringify(event, null, 2)}\n`, "utf8");
+
+  return outputFile;
+}
+
+async function readProjectsFile(path: string): Promise<ProjectsFile> {
+  try {
+    const parsed = JSON.parse(await readFile(path, "utf8")) as unknown;
+
+    if (isProjectsFile(parsed)) {
+      return parsed;
+    }
+
+    throw new CollectGitCommandError(
+      "Invalid projects file.",
+      "invalid-projects-file"
+    );
+  } catch (error) {
+    if (error instanceof CollectGitCommandError) {
+      throw error;
+    }
+
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return { schemaVersion: 1, projects: [] };
+    }
+
+    throw new CollectGitCommandError(
+      "Invalid projects file.",
+      "invalid-projects-file"
+    );
+  }
+}
+
+function formatCollectionError(error: unknown): string {
+  if (error instanceof GitActivityCollectionError) {
+    return error.message;
+  }
+
+  return "Collection failed.";
+}
+
+function isProjectsFile(value: unknown): value is ProjectsFile {
+  if (!isRecord(value) || value.schemaVersion !== 1 || !Array.isArray(value.projects)) {
+    return false;
+  }
+
+  return value.projects.every(isProjectRecord);
+}
+
+function isProjectRecord(value: unknown): value is ProjectRecord {
+  return (
+    isRecord(value) &&
+    value.schemaVersion === 1 &&
+    typeof value.id === "string" &&
+    typeof value.name === "string" &&
+    typeof value.root === "string" &&
+    typeof value.gitRoot === "string" &&
+    typeof value.enabled === "boolean" &&
+    typeof value.createdAt === "string"
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,18 @@ export type { CliIo, CliOptions } from "./cli.js";
 export { commands, isKnownCommand } from "./commands.js";
 export type { Command } from "./commands.js";
 export {
+  collectGitForRegisteredProjects,
+  CollectGitCommandError
+} from "./collect-git-command.js";
+export type {
+  CollectGitCommandErrorCode,
+  CollectGitCommandOptions,
+  CollectGitCommandResult,
+  CollectGitFailure,
+  CollectGitSuccess,
+  GitActivityEvent
+} from "./collect-git-command.js";
+export {
   createDoctorReport,
   formatDoctorReport,
   getDoctorExitCode,

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -120,6 +120,24 @@ describe("cli", () => {
     );
   });
 
+  it("returns config exit code when collect git finds invalid projects file", async () => {
+    const { io, stdout, stderr } = createIo();
+    const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-collect-invalid-"));
+    const homeDir = join(directory, "home");
+
+    await mkdir(join(homeDir, ".uncommitted"), { recursive: true });
+    await writeFile(join(homeDir, ".uncommitted", "projects.json"), "nope", "utf8");
+
+    const exitCode = await runCli(["collect", "git"], io, {
+      homeDir,
+      now: () => "2026-05-06T13:30:00.000Z"
+    });
+
+    expect(exitCode).toBe(2);
+    expect(stdout).toEqual([]);
+    expect(stderr.join("\n")).toContain("Invalid projects file.");
+  });
+
   it("preserves successful collect output when another project fails", async () => {
     const { io, stdout, stderr } = createIo();
     const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-collect-partial-"));

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,5 +1,12 @@
 import { execFile } from "node:child_process";
-import { access, mkdir, mkdtemp, symlink, writeFile } from "node:fs/promises";
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  readFile,
+  symlink,
+  writeFile
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -37,14 +44,141 @@ describe("cli", () => {
     expect(stdout.join("\n")).toContain("generate");
   });
 
-  it("routes known commands to placeholder handlers", async () => {
+  it("routes collect without a source to an actionable message", async () => {
     const { io, stdout, stderr } = createIo();
 
     const exitCode = await runCli(["collect"], io);
 
     expect(exitCode).toBe(1);
     expect(stdout).toEqual([]);
-    expect(stderr.join("\n")).toContain("Command not implemented yet: collect");
+    expect(stderr.join("\n")).toContain("Usage: uncommitted collect git");
+  });
+
+  it("collects today's Git activity for registered projects", async () => {
+    const { io, stdout, stderr } = createIo();
+    const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-collect-"));
+    const repoDir = join(directory, "repo");
+    const homeDir = join(directory, "home");
+
+    await initGitRepo(repoDir);
+    await writeFile(join(repoDir, "app.ts"), "const today = true;\n", "utf8");
+    await git(repoDir, ["add", "app.ts"]);
+    await commit(repoDir, "collect target", "2026-05-06T10:00:00Z");
+    await addProject(repoDir, {
+      homeDir,
+      now: () => "2026-05-06T00:00:00.000Z"
+    });
+
+    const exitCode = await runCli(["collect", "git"], io, {
+      homeDir,
+      now: () => "2026-05-06T13:30:00.000Z"
+    });
+    const outputFile = join(
+      repoDir,
+      ".uncommitted",
+      "events",
+      "git",
+      "2026-05-06.json"
+    );
+    const output = await readJson(outputFile);
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toEqual([]);
+    expect(stdout.join("\n")).toContain("Collected Git activity for 1 project.");
+    expect(output).toMatchObject({
+      schemaVersion: 1,
+      source: "git",
+      targetDate: "2026-05-06",
+      project: {
+        id: "repo",
+        name: "repo"
+      },
+      activity: {
+        totals: {
+          commits: 1,
+          filesChanged: 1
+        }
+      }
+    });
+    expect(JSON.stringify(output)).not.toContain(repoDir);
+    expect(JSON.stringify(output)).not.toContain("const today = true");
+  });
+
+  it("returns collection exit code for missing or empty project registry", async () => {
+    const { io, stdout, stderr } = createIo();
+    const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-collect-empty-"));
+
+    const exitCode = await runCli(["collect", "git"], io, {
+      homeDir: join(directory, "home"),
+      now: () => "2026-05-06T13:30:00.000Z"
+    });
+
+    expect(exitCode).toBe(3);
+    expect(stdout).toEqual([]);
+    expect(stderr.join("\n")).toContain(
+      "No registered projects. Run `uncommitted project add .` first."
+    );
+  });
+
+  it("preserves successful collect output when another project fails", async () => {
+    const { io, stdout, stderr } = createIo();
+    const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-collect-partial-"));
+    const repoDir = join(directory, "repo");
+    const homeDir = join(directory, "home");
+
+    await initGitRepo(repoDir);
+    await writeFile(join(repoDir, "app.ts"), "const partial = true;\n", "utf8");
+    await git(repoDir, ["add", "app.ts"]);
+    await commit(repoDir, "partial target", "2026-05-06T10:00:00Z");
+    const registered = await addProject(repoDir, {
+      homeDir,
+      now: () => "2026-05-06T00:00:00.000Z"
+    });
+    await writeFile(
+      join(homeDir, ".uncommitted", "projects.json"),
+      `${JSON.stringify(
+        {
+          schemaVersion: 1,
+          projects: [
+            registered.project,
+            {
+              schemaVersion: 1,
+              id: "missing-repo",
+              name: "missing-repo",
+              root: join(directory, "missing"),
+              gitRoot: join(directory, "missing"),
+              enabled: true,
+              createdAt: "2026-05-06T00:00:00.000Z"
+            }
+          ]
+        },
+        null,
+        2
+      )}\n`,
+      "utf8"
+    );
+
+    const exitCode = await runCli(["collect", "git"], io, {
+      homeDir,
+      now: () => "2026-05-06T13:30:00.000Z"
+    });
+    const output = await readJson(
+      join(repoDir, ".uncommitted", "events", "git", "2026-05-06.json")
+    );
+
+    expect(exitCode).toBe(3);
+    expect(stdout.join("\n")).toContain("Collected Git activity for 1 project.");
+    expect(stderr.join("\n")).toContain("Failed to collect missing-repo");
+    expect(output).toMatchObject({
+      project: {
+        id: "repo"
+      },
+      activity: {
+        totals: {
+          commits: 1
+        }
+      }
+    });
   });
 
   it("routes note to the manual note handler", async () => {
@@ -166,3 +300,37 @@ describe("cli", () => {
     expect(isDirectRun(linkedEntrypoint, pathToFileURL(realEntrypoint).href)).toBe(true);
   });
 });
+
+async function initGitRepo(repoDir: string): Promise<void> {
+  await execFileAsync("git", ["init", repoDir]);
+  await git(repoDir, ["config", "user.name", "Fixture Dev"]);
+  await git(repoDir, ["config", "user.email", "dev@example.com"]);
+}
+
+async function commit(
+  repoDir: string,
+  message: string,
+  date: string
+): Promise<void> {
+  await git(repoDir, ["commit", "-m", message], {
+    GIT_AUTHOR_DATE: date,
+    GIT_COMMITTER_DATE: date
+  });
+}
+
+async function git(
+  repoDir: string,
+  args: string[],
+  env: NodeJS.ProcessEnv = {}
+): Promise<void> {
+  await execFileAsync("git", ["-C", repoDir, ...args], {
+    env: {
+      ...process.env,
+      ...env
+    }
+  });
+}
+
+async function readJson(path: string): Promise<unknown> {
+  return JSON.parse(await readFile(path, "utf8")) as unknown;
+}


### PR DESCRIPTION
# Goal

Implement `uncommitted collect git` so registered local projects can produce safe raw Git activity output for later summary generation.

## Related Issue

Closes #17

## Acceptance Criteria

- [x] `uncommitted collect git` collects today's Git activity for registered projects.
- [x] Output is structured JSON suitable for later summary generation.
- [x] Output avoids raw diffs, raw code, private paths, private remotes, and emails by relying on the safe collector output.
- [x] Missing or empty project registry produces a clear actionable message.
- [x] Partial collection failures preserve successful project output and report failures.
- [x] CLI exits with code `3` for collection failures.
- [x] Tests cover success, empty registry, and partial failure behavior.

## Implementation Notes

- Added a collect command module that reads enabled projects from `~/.uncommitted/projects.json`, runs the existing safe Git activity collector, and writes project-local events to `.uncommitted/events/git/YYYY-MM-DD.json`.
- Wired `uncommitted collect git` into the CLI with compact per-project summaries.
- Added `.uncommitted/` to `.gitignore` so project-local generated event data is not accidentally committed.

## Validation

- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`

## Remaining Risk

The raw Git event path is project-local by design, matching manual note event storage and the MVP/Notion project storage model.
