### PR TITLE
feat: implement manual note list command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -149,6 +149,11 @@ async function runNote(
   options: CliOptions
 ): Promise<number> {
   if (args[0] === "list") {
+    if (args.length !== 1) {
+      io.stderr("Usage: uncommitted note list");
+      return 1;
+    }
+
     return await runNoteList(io, options);
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,7 +10,12 @@ import {
 import { commands, isKnownCommand } from "./commands.js";
 import { formatDoctorReport, runDoctorCommand } from "./doctor-command.js";
 import { runInitCommand } from "./init-command.js";
-import { NoteCommandError, recordManualNote } from "./note-command.js";
+import {
+  listManualNotes,
+  type ManualNoteEvent,
+  NoteCommandError,
+  recordManualNote
+} from "./note-command.js";
 import { addProject, ProjectAddError } from "./project-add.js";
 
 export type CliIo = {
@@ -144,8 +149,7 @@ async function runNote(
   options: CliOptions
 ): Promise<number> {
   if (args[0] === "list") {
-    io.stderr("Command not implemented yet: note list");
-    return 1;
+    return await runNoteList(io, options);
   }
 
   try {
@@ -161,6 +165,41 @@ async function runNote(
 
     throw error;
   }
+}
+
+async function runNoteList(
+  io: CliIo,
+  options: CliOptions
+): Promise<number> {
+  try {
+    const result = await listManualNotes(options);
+
+    if (result.notes.length === 0) {
+      io.stdout("No manual notes found.");
+      return 0;
+    }
+
+    io.stdout("Manual notes (newest first):");
+
+    for (const note of result.notes) {
+      io.stdout(formatManualNote(note));
+    }
+
+    return 0;
+  } catch (error) {
+    if (error instanceof NoteCommandError) {
+      io.stderr(error.message);
+      return error.code === "malformed-note-data" ? 1 : 2;
+    }
+
+    throw error;
+  }
+}
+
+function formatManualNote(note: ManualNoteEvent): string {
+  const displayTimestamp = note.timestamp.replace("T", " ").slice(0, 16);
+
+  return `${displayTimestamp} ${note.text}`;
 }
 
 function formatProjectCount(count: number): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,3 +48,16 @@ export type {
   ProjectRecord,
   ProjectsFile
 } from "./project-add.js";
+export {
+  listManualNotes,
+  NoteCommandError,
+  recordManualNote
+} from "./note-command.js";
+export type {
+  ListManualNotesOptions,
+  ListManualNotesResult,
+  ManualNoteEvent,
+  NoteCommandErrorCode,
+  RecordManualNoteOptions,
+  RecordManualNoteResult
+} from "./note-command.js";

--- a/src/note-command.ts
+++ b/src/note-command.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { mkdir, readFile, realpath, appendFile } from "node:fs/promises";
+import { appendFile, mkdir, readFile, realpath, readdir } from "node:fs/promises";
 import { join } from "node:path";
 import process from "node:process";
 import { promisify } from "node:util";
@@ -12,7 +12,8 @@ const execFileAsync = promisify(execFile);
 export type NoteCommandErrorCode =
   | "empty-note"
   | "project-not-registered"
-  | "invalid-projects-file";
+  | "invalid-projects-file"
+  | "malformed-note-data";
 
 export class NoteCommandError extends Error {
   constructor(
@@ -41,10 +42,23 @@ export type RecordManualNoteOptions = {
   createId?: () => string;
 };
 
+export type ListManualNotesOptions = {
+  cwd?: string;
+  homeDir?: string;
+  limit?: number;
+};
+
 export type RecordManualNoteResult = {
   event: ManualNoteEvent;
   eventFile: string;
 };
+
+export type ListManualNotesResult = {
+  notes: ManualNoteEvent[];
+  limit: number;
+};
+
+const DEFAULT_NOTE_LIST_LIMIT = 10;
 
 export async function recordManualNote(
   args: string[],
@@ -80,8 +94,29 @@ export async function recordManualNote(
   return { event, eventFile };
 }
 
+export async function listManualNotes(
+  options: ListManualNotesOptions = {}
+): Promise<ListManualNotesResult> {
+  const project = await resolveCurrentProject(options);
+  const limit = options.limit ?? DEFAULT_NOTE_LIST_LIMIT;
+  const eventsDir = join(project.root, ".uncommitted", "events", "manual");
+  const eventFiles = await readManualNoteEventFiles(eventsDir);
+  const notes: ManualNoteEvent[] = [];
+
+  for (const eventFile of eventFiles) {
+    notes.push(...(await readManualNoteEvents(join(eventsDir, eventFile))));
+  }
+
+  notes.sort(compareManualNoteEventsNewestFirst);
+
+  return {
+    notes: notes.slice(0, limit),
+    limit
+  };
+}
+
 async function resolveCurrentProject(
-  options: RecordManualNoteOptions
+  options: Pick<RecordManualNoteOptions, "cwd" | "homeDir">
 ): Promise<ProjectRecord> {
   const cwd = options.cwd ?? process.cwd();
   const gitRoot = await findGitRoot(cwd);
@@ -99,6 +134,76 @@ async function resolveCurrentProject(
   }
 
   return project;
+}
+
+async function readManualNoteEventFiles(eventsDir: string): Promise<string[]> {
+  try {
+    const entries = await readdir(eventsDir);
+
+    return entries
+      .filter((entry) => entry.endsWith(".jsonl"))
+      .sort((left, right) => right.localeCompare(left));
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return [];
+    }
+
+    throw new NoteCommandError(
+      "Could not read manual notes.",
+      "malformed-note-data"
+    );
+  }
+}
+
+async function readManualNoteEvents(eventFile: string): Promise<ManualNoteEvent[]> {
+  let content: string;
+
+  try {
+    content = await readFile(eventFile, "utf8");
+  } catch {
+    throw new NoteCommandError(
+      "Could not read manual notes.",
+      "malformed-note-data"
+    );
+  }
+
+  const notes: ManualNoteEvent[] = [];
+
+  for (const line of content.split("\n")) {
+    if (!line.trim()) {
+      continue;
+    }
+
+    try {
+      const parsed = JSON.parse(line) as unknown;
+
+      if (!isManualNoteEvent(parsed)) {
+        throw new Error("Invalid manual note event.");
+      }
+
+      notes.push(parsed);
+    } catch {
+      throw new NoteCommandError(
+        "Stored manual notes are malformed. Fix or remove the invalid note data.",
+        "malformed-note-data"
+      );
+    }
+  }
+
+  return notes;
+}
+
+function compareManualNoteEventsNewestFirst(
+  left: ManualNoteEvent,
+  right: ManualNoteEvent
+): number {
+  const timestampOrder = right.timestamp.localeCompare(left.timestamp);
+
+  if (timestampOrder !== 0) {
+    return timestampOrder;
+  }
+
+  return left.id.localeCompare(right.id);
 }
 
 async function findGitRoot(path: string): Promise<string> {
@@ -146,6 +251,19 @@ function isProjectsFile(value: unknown): value is ProjectsFile {
   }
 
   return value.projects.every(isProjectRecord);
+}
+
+function isManualNoteEvent(value: unknown): value is ManualNoteEvent {
+  return (
+    isRecord(value) &&
+    value.schemaVersion === 1 &&
+    typeof value.id === "string" &&
+    typeof value.timestamp === "string" &&
+    typeof value.date === "string" &&
+    typeof value.projectId === "string" &&
+    typeof value.text === "string" &&
+    value.source === "manual"
+  );
 }
 
 function isProjectRecord(value: unknown): value is ProjectRecord {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -279,6 +279,16 @@ describe("cli", () => {
     ]);
   });
 
+  it("rejects note list with extra arguments", async () => {
+    const { io, stdout, stderr } = createIo();
+
+    const exitCode = await runCli(["note", "list", "fix", "tests"], io);
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toEqual([]);
+    expect(stderr).toEqual(["Usage: uncommitted note list"]);
+  });
+
   it("routes project add to the project registration handler", async () => {
     const { io, stdout, stderr } = createIo();
     const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-project-add-"));

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -234,9 +234,49 @@ describe("cli", () => {
     await expect(
       access(join(repoDir, ".uncommitted", "events", "manual", "2026-05-06.jsonl"))
     ).rejects.toMatchObject({ code: "ENOENT" });
-    expect(exitCode).toBe(1);
-    expect(stdout).toEqual([]);
-    expect(stderr.join("\n")).toContain("Command not implemented yet: note list");
+    expect(exitCode).toBe(0);
+    expect(stdout).toEqual(["No manual notes found."]);
+    expect(stderr).toEqual([]);
+  });
+
+  it("prints manual notes newest first", async () => {
+    const { io, stdout, stderr } = createIo();
+    const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-note-list-output-"));
+    const repoDir = join(directory, "repo");
+    const homeDir = join(directory, "home");
+
+    await execFileAsync("git", ["init", repoDir]);
+    await addProject(repoDir, {
+      homeDir,
+      now: () => "2026-05-06T00:00:00.000Z"
+    });
+
+    await runCli(["note", "older note"], io, {
+      cwd: repoDir,
+      homeDir,
+      now: () => "2026-05-06T10:15:30.000Z"
+    });
+    await runCli(["note", "newer note"], io, {
+      cwd: repoDir,
+      homeDir,
+      now: () => "2026-05-06T11:00:00.000Z"
+    });
+
+    stdout.length = 0;
+    stderr.length = 0;
+
+    const exitCode = await runCli(["note", "list"], io, {
+      cwd: repoDir,
+      homeDir
+    });
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toEqual([]);
+    expect(stdout).toEqual([
+      "Manual notes (newest first):",
+      "2026-05-06 11:00 newer note",
+      "2026-05-06 10:15 older note"
+    ]);
   });
 
   it("routes project add to the project registration handler", async () => {

--- a/tests/note-command.test.ts
+++ b/tests/note-command.test.ts
@@ -1,12 +1,16 @@
 import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { mkdir, readFile, realpath } from "node:fs/promises";
+import { mkdir, readFile, realpath, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
 import { addProject } from "../src/project-add.js";
-import { NoteCommandError, recordManualNote } from "../src/note-command.js";
+import {
+  listManualNotes,
+  NoteCommandError,
+  recordManualNote
+} from "../src/note-command.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -66,6 +70,96 @@ describe("note command", () => {
       code: "project-not-registered",
       message: "Run inside a registered project."
     });
+  });
+
+  it("lists recent manual notes newest first with a small default limit", async () => {
+    const { homeDir, repoDir } = await createRegisteredProject("note-list-success");
+    const nestedDir = join(repoDir, "packages", "cli");
+    await mkdir(nestedDir, { recursive: true });
+
+    for (let index = 0; index < 11; index += 1) {
+      const minute = String(index).padStart(2, "0");
+
+      await recordManualNote([`note ${index}`], {
+        cwd: repoDir,
+        homeDir,
+        now: () => `2026-05-06T10:${minute}:00.000Z`,
+        createId: () => `note-${index}`
+      });
+    }
+
+    const result = await listManualNotes({
+      cwd: nestedDir,
+      homeDir
+    });
+
+    expect(result.limit).toBe(10);
+    expect(result.notes).toHaveLength(10);
+    expect(result.notes.map((note) => note.text)).toEqual([
+      "note 10",
+      "note 9",
+      "note 8",
+      "note 7",
+      "note 6",
+      "note 5",
+      "note 4",
+      "note 3",
+      "note 2",
+      "note 1"
+    ]);
+  });
+
+  it("treats missing manual note files as an empty list", async () => {
+    const { homeDir, repoDir } = await createRegisteredProject("note-list-empty");
+
+    await expect(
+      listManualNotes({
+        cwd: repoDir,
+        homeDir
+      })
+    ).resolves.toEqual({
+      notes: [],
+      limit: 10
+    });
+  });
+
+  it("fails clearly outside a registered project when listing notes", async () => {
+    const root = await createTempRoot("note-list-unregistered");
+    const repoDir = await initGitRepo(join(root, "repo"));
+
+    await expect(
+      listManualNotes({
+        cwd: repoDir,
+        homeDir: join(root, "home")
+      })
+    ).rejects.toMatchObject({
+      code: "project-not-registered",
+      message: "Run inside a registered project."
+    });
+  });
+
+  it("reports malformed stored manual note data without private paths", async () => {
+    const { homeDir, repoDir } = await createRegisteredProject("note-list-malformed");
+    const eventsDir = join(repoDir, ".uncommitted", "events", "manual");
+    await mkdir(eventsDir, { recursive: true });
+    await writeFile(join(eventsDir, "2026-05-06.jsonl"), "{nope}\n", "utf8");
+
+    await expect(
+      listManualNotes({
+        cwd: repoDir,
+        homeDir
+      })
+    ).rejects.toMatchObject({
+      code: "malformed-note-data",
+      message: "Stored manual notes are malformed. Fix or remove the invalid note data."
+    });
+
+    await expect(
+      listManualNotes({
+        cwd: repoDir,
+        homeDir
+      })
+    ).rejects.not.toThrow(repoDir);
   });
 
   it("uses a typed note command error", async () => {


### PR DESCRIPTION
# Goal

Implement `uncommitted note list` so users can review recently recorded manual notes from local project storage.

## Related Issue

Closes #15

## Acceptance Criteria

- [x] `uncommitted note list` prints recent manual notes for the current project
- [x] No notes prints a clear empty-state message and exits successfully
- [x] Notes are ordered newest first
- [x] Malformed note data is handled with a short actionable error
- [x] Running outside a registered project fails clearly
- [x] Unit tests cover note listing, empty state, and malformed note data

## Implementation Notes

- Added `listManualNotes` using the existing manual note event schema and current-project resolution.
- Reads project-local manual note JSONL files, applies a default limit of 10, and formats compact CLI output.
- Keeps malformed stored note errors short and avoids exposing absolute file paths.

## Validation

- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`

## Remaining Risk

No known skipped checks. Future issues can add explicit pagination or custom list limits if needed.
