### PR TITLE
feat: add AI provider abstraction

### DIFF
--- a/src/ai-provider.ts
+++ b/src/ai-provider.ts
@@ -491,6 +491,12 @@ function redactSensitiveText(value: string): string {
     .replace(/\bdiff --git\b[^\n]*/g, "[redacted-code]")
     .replace(/`[^`]+`/g, "[redacted-code]")
     .replace(
+      /\b[A-Z][A-Z0-9_]*(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD)\s*=\s*\S+/gi,
+      "[redacted-secret]"
+    )
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]+/gi, "[redacted-secret]")
+    .replace(/\bsk-[A-Za-z0-9_-]{8,}\b/g, "[redacted-secret]")
+    .replace(
       /\b(?:https?|ssh|git):\/\/\S+|git@[\w.-]+:[^\s]+/g,
       "[redacted-url]"
     )

--- a/src/ai-provider.ts
+++ b/src/ai-provider.ts
@@ -1,0 +1,502 @@
+import { readFile } from "node:fs/promises";
+import { resolveConfigPaths } from "./config-paths.js";
+
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
+export type JsonObject = { [key: string]: JsonValue };
+
+export type AiProviderName =
+  | "none"
+  | "mock"
+  | "openai"
+  | "anthropic"
+  | "google"
+  | "ollama"
+  | "mistral"
+  | "openrouter";
+
+export type AiGenerationTask = "story-plan" | "caption" | "draft";
+
+export type SafeProjectSummary = {
+  projectId: string;
+  projectName: string;
+  summary: string;
+  stats: {
+    commits: number;
+    filesChanged: number;
+    insertions: number;
+    deletions: number;
+    dirtyFiles: number;
+  };
+};
+
+export type SafeActivitySummary = {
+  schemaVersion: 1;
+  targetDate: string;
+  quiet: boolean;
+  overview: string;
+  highlights: string[];
+  projectSummaries: SafeProjectSummary[];
+  [key: string]: JsonValue;
+};
+
+export type AiGenerationRequestOptions = {
+  task: AiGenerationTask;
+  instructions: string;
+  summary: SafeActivitySummary;
+};
+
+export type AiStructuredGenerationRequest = {
+  schemaVersion: 1;
+  task: AiGenerationTask;
+  instructions: string;
+  input: SafeActivitySummary;
+};
+
+export type AiProviderRawResponse = {
+  responseJson: string;
+};
+
+export type AiStructuredGenerationResponse<
+  TData extends JsonObject = JsonObject
+> = {
+  schemaVersion: 1;
+  provider: AiProviderName;
+  data: TData;
+};
+
+export interface AiProvider {
+  readonly name: AiProviderName;
+  generateStructured(
+    request: AiStructuredGenerationRequest
+  ): Promise<AiProviderRawResponse>;
+}
+
+export type AiProviderConfig = {
+  provider: AiProviderName;
+  persona: string;
+  roastLevel: number;
+};
+
+export type LoadAiProviderConfigOptions = {
+  homeDir?: string;
+};
+
+export type MockAiProviderOptions = {
+  responseJson?: string;
+  response?: JsonObject;
+  failure?: Error;
+};
+
+export type CreateAiProviderOptions = {
+  mockResponseJson?: string;
+};
+
+export type AiGenerationErrorCode =
+  | "invalid-config"
+  | "malformed-response"
+  | "provider-failed"
+  | "provider-unavailable"
+  | "unsafe-request";
+
+export class AiGenerationError extends Error {
+  public readonly exitCode = 4;
+
+  constructor(
+    message: string,
+    public readonly code: AiGenerationErrorCode
+  ) {
+    super(message);
+    this.name = "AiGenerationError";
+  }
+}
+
+const providerNames: readonly AiProviderName[] = [
+  "none",
+  "mock",
+  "openai",
+  "anthropic",
+  "google",
+  "ollama",
+  "mistral",
+  "openrouter"
+];
+
+const unsafeInputKeys = new Set([
+  "apikey",
+  "api_key",
+  "absolutepath",
+  "absolute_path",
+  "diff",
+  "gitroot",
+  "git_root",
+  "password",
+  "patch",
+  "rawcode",
+  "raw_code",
+  "rawdiff",
+  "raw_diff",
+  "rawtranscript",
+  "raw_transcript",
+  "remoteurl",
+  "remote_url",
+  "secret",
+  "secrets",
+  "token",
+  "tokens",
+  "transcript"
+]);
+
+export function createAiGenerationRequest(
+  options: AiGenerationRequestOptions
+): AiStructuredGenerationRequest {
+  return {
+    schemaVersion: 1,
+    task: options.task,
+    instructions: redactSensitiveText(options.instructions),
+    input: sanitizeSafeSummary(options.summary)
+  };
+}
+
+export async function loadAiProviderConfig(
+  options: LoadAiProviderConfigOptions = {}
+): Promise<AiProviderConfig> {
+  const paths = resolveConfigPaths({ homeDir: options.homeDir });
+
+  try {
+    const parsed = JSON.parse(await readFile(paths.configFile, "utf8")) as unknown;
+
+    if (!isAiConfigFile(parsed)) {
+      throw new AiGenerationError("AI config is invalid.", "invalid-config");
+    }
+
+    const provider = parseProviderName(parsed.aiProvider);
+
+    if (!provider) {
+      throw new AiGenerationError("AI provider is not supported.", "invalid-config");
+    }
+
+    return {
+      provider,
+      persona: parsed.persona,
+      roastLevel: parsed.roastLevel
+    };
+  } catch (error) {
+    if (error instanceof AiGenerationError) {
+      throw error;
+    }
+
+    if (isNodeError(error) && error.code === "ENOENT") {
+      throw new AiGenerationError(
+        "AI config is missing. Run `uncommitted init` first.",
+        "invalid-config"
+      );
+    }
+
+    throw new AiGenerationError("AI config is invalid.", "invalid-config");
+  }
+}
+
+export function createAiProvider(
+  config: AiProviderConfig,
+  options: CreateAiProviderOptions = {}
+): AiProvider {
+  if (config.provider === "mock") {
+    return new MockAiProvider({
+      responseJson: options.mockResponseJson ?? "{}"
+    });
+  }
+
+  throw new AiGenerationError(
+    "AI provider is not implemented yet.",
+    "provider-unavailable"
+  );
+}
+
+export async function generateStructured<
+  TData extends JsonObject = JsonObject
+>(
+  provider: AiProvider,
+  request: AiStructuredGenerationRequest
+): Promise<AiStructuredGenerationResponse<TData>> {
+  assertSafeProviderInput(request);
+
+  let rawResponse: AiProviderRawResponse;
+
+  try {
+    rawResponse = await provider.generateStructured(request);
+  } catch (error) {
+    if (error instanceof AiGenerationError) {
+      throw error;
+    }
+
+    throw new AiGenerationError(
+      "AI provider failed. Check provider configuration.",
+      "provider-failed"
+    );
+  }
+
+  const data = parseStructuredResponse<TData>(rawResponse.responseJson);
+
+  return {
+    schemaVersion: 1,
+    provider: provider.name,
+    data
+  };
+}
+
+export class MockAiProvider implements AiProvider {
+  public readonly name = "mock";
+  public readonly requests: AiStructuredGenerationRequest[] = [];
+
+  constructor(private readonly options: MockAiProviderOptions = {}) {}
+
+  async generateStructured(
+    request: AiStructuredGenerationRequest
+  ): Promise<AiProviderRawResponse> {
+    this.requests.push(request);
+
+    if (this.options.failure) {
+      throw this.options.failure;
+    }
+
+    if (this.options.responseJson !== undefined) {
+      return { responseJson: this.options.responseJson };
+    }
+
+    return {
+      responseJson: JSON.stringify(this.options.response ?? {})
+    };
+  }
+}
+
+function sanitizeSafeSummary(summary: SafeActivitySummary): SafeActivitySummary {
+  const sanitized = sanitizeJsonValue(summary);
+
+  if (!isSafeActivitySummary(sanitized)) {
+    throw new AiGenerationError("AI provider request is invalid.", "unsafe-request");
+  }
+
+  return sanitized;
+}
+
+function sanitizeJsonValue(value: JsonValue): JsonValue {
+  if (typeof value === "string") {
+    return redactSensitiveText(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeJsonValue(item));
+  }
+
+  if (isRecord(value)) {
+    const sanitized: JsonObject = {};
+
+    for (const [key, child] of Object.entries(value)) {
+      if (isUnsafeInputKey(key)) {
+        throw new AiGenerationError(
+          "AI provider request includes unsafe raw input.",
+          "unsafe-request"
+        );
+      }
+
+      if (!isJsonValue(child)) {
+        throw new AiGenerationError(
+          "AI provider request is invalid.",
+          "unsafe-request"
+        );
+      }
+
+      sanitized[key] = sanitizeJsonValue(child);
+    }
+
+    return sanitized;
+  }
+
+  return value;
+}
+
+function assertSafeProviderInput(value: JsonValue): void {
+  assertNoUnsafeKeys(value);
+  assertNoSensitiveStrings(value);
+}
+
+function assertNoUnsafeKeys(value: JsonValue): void {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      assertNoUnsafeKeys(item);
+    }
+    return;
+  }
+
+  if (!isRecord(value)) {
+    return;
+  }
+
+  for (const [key, child] of Object.entries(value)) {
+    if (isUnsafeInputKey(key)) {
+      throw new AiGenerationError(
+        "AI provider request includes unsafe raw input.",
+        "unsafe-request"
+      );
+    }
+
+    if (!isJsonValue(child)) {
+      throw new AiGenerationError(
+        "AI provider request is invalid.",
+        "unsafe-request"
+      );
+    }
+
+    assertNoUnsafeKeys(child);
+  }
+}
+
+function assertNoSensitiveStrings(value: JsonValue): void {
+  if (typeof value === "string") {
+    if (containsSensitiveText(value)) {
+      throw new AiGenerationError(
+        "AI provider request includes unsafe raw input.",
+        "unsafe-request"
+      );
+    }
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      assertNoSensitiveStrings(item);
+    }
+    return;
+  }
+
+  if (isRecord(value)) {
+    for (const child of Object.values(value)) {
+      if (isJsonValue(child)) {
+        assertNoSensitiveStrings(child);
+      }
+    }
+  }
+}
+
+function parseStructuredResponse<TData extends JsonObject>(responseJson: string): TData {
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(responseJson);
+  } catch {
+    throw new AiGenerationError(
+      "AI provider returned invalid JSON.",
+      "malformed-response"
+    );
+  }
+
+  if (!isJsonObject(parsed)) {
+    throw new AiGenerationError(
+      "AI provider returned invalid JSON.",
+      "malformed-response"
+    );
+  }
+
+  return parsed as TData;
+}
+
+function parseProviderName(value: string): AiProviderName | undefined {
+  const normalized = value.trim().toLowerCase();
+
+  return providerNames.find((provider) => provider === normalized);
+}
+
+function isAiConfigFile(value: unknown): value is {
+  schemaVersion: 1;
+  aiProvider: string;
+  persona: string;
+  roastLevel: number;
+} {
+  return (
+    isRecord(value) &&
+    value.schemaVersion === 1 &&
+    typeof value.aiProvider === "string" &&
+    typeof value.persona === "string" &&
+    Number.isInteger(value.roastLevel)
+  );
+}
+
+function isSafeActivitySummary(value: JsonValue): value is SafeActivitySummary {
+  return (
+    isRecord(value) &&
+    value.schemaVersion === 1 &&
+    typeof value.targetDate === "string" &&
+    typeof value.quiet === "boolean" &&
+    typeof value.overview === "string" &&
+    Array.isArray(value.highlights) &&
+    value.highlights.every((item) => typeof item === "string") &&
+    Array.isArray(value.projectSummaries) &&
+    value.projectSummaries.every(isSafeProjectSummary)
+  );
+}
+
+function isSafeProjectSummary(value: unknown): value is SafeProjectSummary {
+  return (
+    isRecord(value) &&
+    typeof value.projectId === "string" &&
+    typeof value.projectName === "string" &&
+    typeof value.summary === "string" &&
+    isRecord(value.stats) &&
+    typeof value.stats.commits === "number" &&
+    typeof value.stats.filesChanged === "number" &&
+    typeof value.stats.insertions === "number" &&
+    typeof value.stats.deletions === "number" &&
+    typeof value.stats.dirtyFiles === "number"
+  );
+}
+
+function isUnsafeInputKey(key: string): boolean {
+  return unsafeInputKeys.has(key.toLowerCase().replace(/[-\s]/g, "_"));
+}
+
+function isJsonValue(value: unknown): value is JsonValue {
+  return (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    Array.isArray(value) ||
+    isJsonObject(value)
+  );
+}
+
+function isJsonObject(value: unknown): value is JsonObject {
+  if (!isRecord(value) || Array.isArray(value)) {
+    return false;
+  }
+
+  return Object.values(value).every(isJsonValue);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}
+
+function containsSensitiveText(value: string): boolean {
+  return redactSensitiveText(value) !== value;
+}
+
+function redactSensitiveText(value: string): string {
+  return value
+    .replace(/\bdiff --git\b[^\n]*/g, "[redacted-code]")
+    .replace(/`[^`]+`/g, "[redacted-code]")
+    .replace(
+      /\b(?:https?|ssh|git):\/\/\S+|git@[\w.-]+:[^\s]+/g,
+      "[redacted-url]"
+    )
+    .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, "[redacted-email]")
+    .replace(
+      /(^|[\s(["'])\/[^\s)"']+/g,
+      "$1[redacted-path]"
+    );
+}

--- a/src/doctor-command.ts
+++ b/src/doctor-command.ts
@@ -44,6 +44,7 @@ type DoctorConfig = {
 
 const aiProviderEnvKeys: Record<string, string | undefined> = {
   none: undefined,
+  mock: undefined,
   ollama: undefined,
   openai: "OPENAI_API_KEY",
   anthropic: "ANTHROPIC_API_KEY",

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,32 @@ export {
   resolveConfigPaths
 } from "./config-paths.js";
 export type { ConfigPathOptions, ConfigPaths } from "./config-paths.js";
+export {
+  AiGenerationError,
+  createAiGenerationRequest,
+  createAiProvider,
+  generateStructured,
+  loadAiProviderConfig,
+  MockAiProvider
+} from "./ai-provider.js";
+export type {
+  AiGenerationErrorCode,
+  AiGenerationRequestOptions,
+  AiGenerationTask,
+  AiProvider,
+  AiProviderConfig,
+  AiProviderName,
+  AiProviderRawResponse,
+  AiStructuredGenerationRequest,
+  AiStructuredGenerationResponse,
+  JsonObject,
+  JsonPrimitive,
+  JsonValue,
+  LoadAiProviderConfigOptions,
+  MockAiProviderOptions,
+  SafeActivitySummary,
+  SafeProjectSummary
+} from "./ai-provider.js";
 export { runInitCommand } from "./init-command.js";
 export type {
   InitAnswers,

--- a/src/init-command.ts
+++ b/src/init-command.ts
@@ -40,6 +40,7 @@ const defaultAnswers = {
 };
 const supportedAiProviders = [
   "none",
+  "mock",
   "openai",
   "anthropic",
   "google",

--- a/tests/ai-provider.test.ts
+++ b/tests/ai-provider.test.ts
@@ -105,12 +105,16 @@ describe("AI provider abstraction", () => {
   it("keeps provider requests on safe summaries and rejects unsafe raw inputs", () => {
     const request = createAiGenerationRequest({
       task: "story-plan",
-      instructions: "Build from safe summaries only.",
+      instructions:
+        "Build from safe summaries only. Authorization: Bearer secret-token-value.",
       summary: {
         ...createQuietSummary(),
         overview:
-          "See dev@example.com, /Users/dev/private, git@github.com:acme/private.git, and `const token = process.env.SECRET`.",
-        highlights: ["diff --git a/secret.ts b/secret.ts"]
+          "See dev@example.com, /Users/dev/private, git@github.com:acme/private.git, OPENAI_API_KEY=sk-live-secret123, and `const token = process.env.SECRET`.",
+        highlights: [
+          "diff --git a/secret.ts b/secret.ts",
+          "Copied provider key sk-proj-secret123 into a local note."
+        ]
       }
     });
 
@@ -121,10 +125,15 @@ describe("AI provider abstraction", () => {
     expect(serialized).not.toContain("const token");
     expect(serialized).not.toContain("process.env.SECRET");
     expect(serialized).not.toContain("diff --git");
+    expect(serialized).not.toContain("OPENAI_API_KEY");
+    expect(serialized).not.toContain("sk-live-secret123");
+    expect(serialized).not.toContain("sk-proj-secret123");
+    expect(serialized).not.toContain("Bearer secret-token-value");
     expect(serialized).toContain("[redacted-email]");
     expect(serialized).toContain("[redacted-path]");
     expect(serialized).toContain("[redacted-url]");
     expect(serialized).toContain("[redacted-code]");
+    expect(serialized).toContain("[redacted-secret]");
 
     expect(() =>
       createAiGenerationRequest({

--- a/tests/ai-provider.test.ts
+++ b/tests/ai-provider.test.ts
@@ -1,0 +1,174 @@
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  AiGenerationError,
+  createAiGenerationRequest,
+  generateStructured,
+  loadAiProviderConfig,
+  MockAiProvider
+} from "../src/ai-provider.js";
+import type { SafeActivitySummary } from "../src/ai-provider.js";
+
+describe("AI provider abstraction", () => {
+  it("loads provider configuration from the existing MVP config shape", async () => {
+    const homeDir = await createHomeWithConfig({
+      aiProvider: "mock",
+      persona: "dry reviewer",
+      roastLevel: 4
+    });
+
+    await expect(loadAiProviderConfig({ homeDir })).resolves.toEqual({
+      provider: "mock",
+      persona: "dry reviewer",
+      roastLevel: 4
+    });
+  });
+
+  it("returns deterministic structured JSON from the mock provider", async () => {
+    const request = createAiGenerationRequest({
+      task: "story-plan",
+      instructions: "Build a concise story plan.",
+      summary: {
+        schemaVersion: 1,
+        targetDate: "2026-05-08",
+        quiet: false,
+        overview: "Implemented config loading and provider boundaries.",
+        highlights: ["Added a typed provider interface."],
+        projectSummaries: [
+          {
+            projectId: "uncommitted",
+            projectName: "uncommitted",
+            summary: "Provider work without raw diffs.",
+            stats: {
+              commits: 2,
+              filesChanged: 3,
+              insertions: 120,
+              deletions: 12,
+              dirtyFiles: 0
+            }
+          }
+        ]
+      }
+    });
+    const provider = new MockAiProvider({
+      responseJson: JSON.stringify({
+        title: "Provider boundary day",
+        beats: ["Configured", "Mocked", "Validated"]
+      })
+    });
+
+    await expect(generateStructured(provider, request)).resolves.toEqual({
+      schemaVersion: 1,
+      provider: "mock",
+      data: {
+        title: "Provider boundary day",
+        beats: ["Configured", "Mocked", "Validated"]
+      }
+    });
+    expect(provider.requests).toEqual([request]);
+  });
+
+  it("fails with a short actionable error for malformed provider responses", async () => {
+    const request = createAiGenerationRequest({
+      task: "caption",
+      instructions: "Write a caption.",
+      summary: createQuietSummary()
+    });
+    const provider = new MockAiProvider({ responseJson: "not-json" });
+
+    await expect(generateStructured(provider, request)).rejects.toMatchObject({
+      code: "malformed-response",
+      exitCode: 4,
+      message: "AI provider returned invalid JSON."
+    });
+  });
+
+  it("normalizes provider failures into generation errors", async () => {
+    const request = createAiGenerationRequest({
+      task: "caption",
+      instructions: "Write a caption.",
+      summary: createQuietSummary()
+    });
+    const provider = new MockAiProvider({
+      failure: new Error("socket hang up with a very long provider trace")
+    });
+
+    await expect(generateStructured(provider, request)).rejects.toMatchObject({
+      code: "provider-failed",
+      exitCode: 4,
+      message: "AI provider failed. Check provider configuration."
+    });
+  });
+
+  it("keeps provider requests on safe summaries and rejects unsafe raw inputs", () => {
+    const request = createAiGenerationRequest({
+      task: "story-plan",
+      instructions: "Build from safe summaries only.",
+      summary: {
+        ...createQuietSummary(),
+        overview:
+          "See dev@example.com, /Users/dev/private, git@github.com:acme/private.git, and `const token = process.env.SECRET`.",
+        highlights: ["diff --git a/secret.ts b/secret.ts"]
+      }
+    });
+
+    const serialized = JSON.stringify(request);
+    expect(serialized).not.toContain("dev@example.com");
+    expect(serialized).not.toContain("/Users/dev/private");
+    expect(serialized).not.toContain("git@github.com:acme/private.git");
+    expect(serialized).not.toContain("const token");
+    expect(serialized).not.toContain("process.env.SECRET");
+    expect(serialized).not.toContain("diff --git");
+    expect(serialized).toContain("[redacted-email]");
+    expect(serialized).toContain("[redacted-path]");
+    expect(serialized).toContain("[redacted-url]");
+    expect(serialized).toContain("[redacted-code]");
+
+    expect(() =>
+      createAiGenerationRequest({
+        task: "story-plan",
+        instructions: "Build from safe summaries only.",
+        summary: {
+          ...createQuietSummary(),
+          rawDiff: "+ const apiKey = 'secret';"
+        }
+      })
+    ).toThrow(AiGenerationError);
+  });
+});
+
+async function createHomeWithConfig(
+  overrides: Partial<{ aiProvider: string; persona: string; roastLevel: number }> = {}
+): Promise<string> {
+  const homeDir = await mkdtemp(join(tmpdir(), "uncommitted-ai-provider-"));
+  const configDir = join(homeDir, ".uncommitted");
+
+  await mkdir(configDir, { recursive: true });
+  await writeFile(
+    join(configDir, "config.json"),
+    `${JSON.stringify({
+      schemaVersion: 1,
+      draftRoot: join(homeDir, "Uncommitted", "drafts"),
+      scheduleTime: "23:30",
+      aiProvider: overrides.aiProvider ?? "none",
+      persona: overrides.persona ?? "wry coworker",
+      roastLevel: overrides.roastLevel ?? 2
+    })}\n`,
+    "utf8"
+  );
+
+  return homeDir;
+}
+
+function createQuietSummary(): SafeActivitySummary {
+  return {
+    schemaVersion: 1,
+    targetDate: "2026-05-08",
+    quiet: true,
+    overview: "Quiet day with no recorded project activity.",
+    highlights: [],
+    projectSummaries: []
+  };
+}

--- a/tests/init-command.test.ts
+++ b/tests/init-command.test.ts
@@ -155,7 +155,7 @@ describe("init command", () => {
         answers: { aiProvider: "adlkfjldkajf" }
       })
     ).rejects.toThrow(
-      "AI provider must be one of: none, openai, anthropic, google, ollama, mistral, openrouter."
+      "AI provider must be one of: none, mock, openai, anthropic, google, ollama, mistral, openrouter."
     );
   });
 


### PR DESCRIPTION
# Goal

Add the AI provider abstraction and deterministic mock provider needed by Story Inventor, Diary Generator, and later real provider integration.

## Related Issue

Closes #23.

## Acceptance Criteria

- [x] A typed AI provider interface exists for structured generation
- [x] A mock provider can return deterministic JSON for tests
- [x] Provider errors map to generation failures suitable for exit code `4` when surfaced through the CLI
- [x] Invalid or malformed provider responses fail with short actionable errors
- [x] Provider request construction does not include raw diffs, raw code, raw transcripts, secrets, private paths, or private remote URLs by default
- [x] Unit tests cover mock-provider success, malformed response, and provider failure behavior

## Implementation Notes

- Adds `AiProvider`, structured generation request/response types, `MockAiProvider`, config loading, request construction, response parsing, and `AiGenerationError`.
- Adds `mock` as a supported no-key provider in init and doctor behavior.
- Keeps provider request inputs sanitized and rejects unsafe raw input keys.

## Validation

- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`

## Remaining Risk

Only the mock provider is implemented here. Real hosted provider integration is tracked separately in #35 and should land after the mock `generate today` workflow is proven.
