### PR TITLE
feat: define activity summary builder

### DIFF
--- a/src/activity-summary.ts
+++ b/src/activity-summary.ts
@@ -119,6 +119,11 @@ const privateItemOrder = [
 export function buildActivitySummary(
   input: ActivitySummaryInput
 ): ActivitySummary {
+  const gitEvents = input.gitEvents.filter(
+    (event) =>
+      event.targetDate === input.targetDate &&
+      event.activity.targetDate === input.targetDate
+  );
   const privateItems = new Set<string>();
   const projects = new Map<string, ProjectAccumulator>();
   const subjects: string[] = [];
@@ -137,7 +142,7 @@ export function buildActivitySummary(
   let insertions = 0;
   let deletions = 0;
 
-  for (const event of input.gitEvents) {
+  for (const event of gitEvents) {
     const project = getProject(projects, event.project.id, event.project.name);
     project.repositoryName = event.activity.repository.rootName;
 
@@ -227,7 +232,7 @@ export function buildActivitySummary(
   const allThemes = sortThemes(new Set([...commitThemes, ...manualThemes]));
   const dominantTheme = deriveDominantTheme(activityLevel, allThemes);
   const uncertaintyNotes = buildUncertaintyNotes(input, {
-    gitEventCount: input.gitEvents.length,
+    gitEventCount: gitEvents.length,
     totalCommits,
     manualNoteCount: manualNotes.length,
     themeCount: allThemes.length,
@@ -534,14 +539,9 @@ function sanitizeText(value: string): SanitizedText {
     );
   }
 
-  if (/`[^`]+`/.test(sanitized)) {
+  if (containsRawCodeSnippet(sanitized)) {
     privateItems.add("raw code snippets");
-    sanitized = sanitized.replace(/`[^`]+`/g, "[redacted-code]");
-  }
-
-  if (/\bdiff --git\b/.test(sanitized)) {
-    privateItems.add("raw code snippets");
-    sanitized = sanitized.replace(/\bdiff --git\b[^\n]*/g, "[redacted-code]");
+    sanitized = redactRawCodeSnippets(sanitized);
   }
 
   return {
@@ -554,6 +554,21 @@ function addPrivateItems(target: Set<string>, items: string[]): void {
   for (const item of items) {
     target.add(item);
   }
+}
+
+function containsRawCodeSnippet(value: string): boolean {
+  return redactRawCodeSnippets(value) !== value;
+}
+
+function redactRawCodeSnippets(value: string): string {
+  return value
+    .replace(/\bdiff --git\b[^\n]*/g, "[redacted-code]")
+    .replace(/`[^`]+`/g, "[redacted-code]")
+    .replace(
+      /\b(?:const|let|var)\s+[A-Za-z_$][\w$]*\s*=\s*(?:process\.env\.[A-Z0-9_]+|["'][^"']*["']|[A-Za-z0-9_$.[\]]+)/g,
+      "[redacted-code]"
+    )
+    .replace(/\bprocess\.env\.[A-Z0-9_]+\b/g, "[redacted-code]");
 }
 
 function sortPrivateItems(items: Set<string>): string[] {

--- a/src/activity-summary.ts
+++ b/src/activity-summary.ts
@@ -1,0 +1,597 @@
+import type { GitActivityEvent } from "./collect-git-command.js";
+import type { DirtyFileStatus, DirtyStatusTotals } from "./git-activity-collector.js";
+import type { ManualNoteEvent } from "./note-command.js";
+
+export type ActivityLevel = "none" | "low" | "medium" | "high";
+
+export type ActivityTheme =
+  | "coding"
+  | "debugging"
+  | "mixed"
+  | "planning"
+  | "quiet"
+  | "refactoring";
+
+export type ActivitySummaryInput = {
+  targetDate: string;
+  generatedAt: string;
+  gitEvents: GitActivityEvent[];
+  manualNotes: ManualNoteEvent[];
+};
+
+export type ActivityProjectSummary = {
+  projectId: string;
+  projectName: string;
+  repositoryName?: string;
+  commitCount: number;
+  filesChanged: number;
+  insertions: number;
+  deletions: number;
+  uncommittedChangeCount: number;
+  manualNoteCount: number;
+  themes: Exclude<ActivityTheme, "mixed" | "quiet">[];
+  summary: string;
+};
+
+export type CommitSignals = {
+  totalCommits: number;
+  filesChanged: number;
+  insertions: number;
+  deletions: number;
+  subjects: string[];
+  themes: Exclude<ActivityTheme, "mixed" | "quiet">[];
+};
+
+export type UncommittedChangeSummary = {
+  totalFiles: number;
+  byStatus: DirtyStatusTotals;
+  files: {
+    projectId: string;
+    projectName: string;
+    path: string;
+    status: DirtyFileStatus;
+  }[];
+};
+
+export type ManualContextSummary = {
+  noteCount: number;
+  notes: {
+    projectId: string;
+    timestamp: string;
+    text: string;
+  }[];
+};
+
+export type ActivitySummary = {
+  schemaVersion: 1;
+  targetDate: string;
+  generatedAt: string;
+  activityLevel: ActivityLevel;
+  dominantTheme: ActivityTheme;
+  projects: ActivityProjectSummary[];
+  commitSignals: CommitSignals;
+  uncommittedChanges: UncommittedChangeSummary;
+  manualContext: ManualContextSummary;
+  smallWins: string[];
+  blockersOrConfusion: string[];
+  unfinishedThreads: string[];
+  possibleJokes: string[];
+  publicSafetyNotes: string[];
+  privateItemsToAvoid: string[];
+  uncertaintyNotes: string[];
+};
+
+type SanitizedText = {
+  value: string;
+  privateItems: string[];
+};
+
+type ProjectAccumulator = {
+  projectId: string;
+  projectName: string;
+  repositoryName?: string;
+  commitCount: number;
+  filesChanged: number;
+  insertions: number;
+  deletions: number;
+  uncommittedChangeCount: number;
+  manualNoteCount: number;
+  themes: Set<Exclude<ActivityTheme, "mixed" | "quiet">>;
+};
+
+const dirtyStatuses: DirtyFileStatus[] = [
+  "modified",
+  "added",
+  "deleted",
+  "renamed",
+  "copied",
+  "untracked",
+  "other"
+];
+
+const privateItemOrder = [
+  "emails",
+  "local absolute paths",
+  "private URLs",
+  "raw code snippets"
+];
+
+export function buildActivitySummary(
+  input: ActivitySummaryInput
+): ActivitySummary {
+  const privateItems = new Set<string>();
+  const projects = new Map<string, ProjectAccumulator>();
+  const subjects: string[] = [];
+  const commitThemes = new Set<Exclude<ActivityTheme, "mixed" | "quiet">>();
+  const uncommittedFiles: UncommittedChangeSummary["files"] = [];
+  const uncommittedTotals = createEmptyDirtyTotals();
+  const manualNotes: ManualContextSummary["notes"] = [];
+  const manualThemes = new Set<Exclude<ActivityTheme, "mixed" | "quiet">>();
+  const smallWins: string[] = [];
+  const blockersOrConfusion: string[] = [];
+  const unfinishedThreads: string[] = [];
+  let hasManualPrivateItems = false;
+
+  let totalCommits = 0;
+  let filesChanged = 0;
+  let insertions = 0;
+  let deletions = 0;
+
+  for (const event of input.gitEvents) {
+    const project = getProject(projects, event.project.id, event.project.name);
+    project.repositoryName = event.activity.repository.rootName;
+
+    for (const commit of event.activity.commits) {
+      const sanitizedSubject = sanitizeText(commit.subject);
+      addPrivateItems(privateItems, sanitizedSubject.privateItems);
+
+      totalCommits += 1;
+      filesChanged += commit.stats.filesChanged;
+      insertions += commit.stats.insertions;
+      deletions += commit.stats.deletions;
+      project.commitCount += 1;
+      project.filesChanged += commit.stats.filesChanged;
+      project.insertions += commit.stats.insertions;
+      project.deletions += commit.stats.deletions;
+      subjects.push(sanitizedSubject.value);
+      smallWins.push(sanitizedSubject.value);
+
+      for (const theme of classifyThemes(sanitizedSubject.value)) {
+        commitThemes.add(theme);
+        project.themes.add(theme);
+      }
+    }
+
+    for (const file of event.activity.dirty.files) {
+      const sanitizedPath = sanitizeText(file.path);
+      addPrivateItems(privateItems, sanitizedPath.privateItems);
+      project.uncommittedChangeCount += 1;
+      uncommittedTotals[file.status] += 1;
+      uncommittedFiles.push({
+        projectId: event.project.id,
+        projectName: event.project.name,
+        path: sanitizedPath.value,
+        status: file.status
+      });
+    }
+  }
+
+  for (const note of input.manualNotes.filter((note) => note.date === input.targetDate)) {
+    const sanitizedNote = sanitizeText(note.text);
+    addPrivateItems(privateItems, sanitizedNote.privateItems);
+    hasManualPrivateItems ||= sanitizedNote.privateItems.length > 0;
+
+    const project = getProject(projects, note.projectId, note.projectId);
+    project.manualNoteCount += 1;
+    manualNotes.push({
+      projectId: note.projectId,
+      timestamp: note.timestamp,
+      text: sanitizedNote.value
+    });
+
+    const noteThemes = classifyThemes(sanitizedNote.value);
+    for (const theme of noteThemes) {
+      manualThemes.add(theme);
+      project.themes.add(theme);
+    }
+
+    if (looksLikeSmallWin(sanitizedNote.value)) {
+      smallWins.push(sanitizedNote.value);
+    }
+
+    if (looksLikeBlocker(sanitizedNote.value)) {
+      blockersOrConfusion.push(sanitizedNote.value);
+    }
+
+    if (looksUnfinished(sanitizedNote.value)) {
+      unfinishedThreads.push(sanitizedNote.value);
+    }
+  }
+
+  for (const project of projects.values()) {
+    if (project.uncommittedChangeCount === 0) {
+      continue;
+    }
+
+    unfinishedThreads.unshift(
+      `${project.uncommittedChangeCount} ${project.uncommittedChangeCount === 1 ? "uncommitted file remains" : "uncommitted files remain"} in ${project.projectName}.`
+    );
+  }
+
+  const score =
+    totalCommits * 2 +
+    filesChanged +
+    uncommittedFiles.length +
+    manualNotes.length * 2;
+  const activityLevel = classifyActivityLevel(score);
+  const allThemes = sortThemes(new Set([...commitThemes, ...manualThemes]));
+  const dominantTheme = deriveDominantTheme(activityLevel, allThemes);
+  const uncertaintyNotes = buildUncertaintyNotes(input, {
+    gitEventCount: input.gitEvents.length,
+    totalCommits,
+    manualNoteCount: manualNotes.length,
+    themeCount: allThemes.length,
+    uncommittedChangeCount: uncommittedFiles.length
+  });
+  const publicSafetyNotes = buildPublicSafetyNotes({
+    hasManualPrivateItems,
+    hasUncommittedChanges: uncommittedFiles.length > 0
+  });
+
+  return {
+    schemaVersion: 1,
+    targetDate: input.targetDate,
+    generatedAt: input.generatedAt,
+    activityLevel,
+    dominantTheme,
+    projects: Array.from(projects.values(), toProjectSummary),
+    commitSignals: {
+      totalCommits,
+      filesChanged,
+      insertions,
+      deletions,
+      subjects,
+      themes: sortThemes(commitThemes)
+    },
+    uncommittedChanges: {
+      totalFiles: uncommittedFiles.length,
+      byStatus: uncommittedTotals,
+      files: uncommittedFiles
+    },
+    manualContext: {
+      noteCount: manualNotes.length,
+      notes: manualNotes
+    },
+    smallWins,
+    blockersOrConfusion,
+    unfinishedThreads,
+    possibleJokes: buildPossibleJokes(activityLevel, {
+      hasBlockers: blockersOrConfusion.length > 0,
+      hasUncommittedChanges: uncommittedFiles.length > 0
+    }),
+    publicSafetyNotes,
+    privateItemsToAvoid: sortPrivateItems(privateItems),
+    uncertaintyNotes
+  };
+}
+
+export function isActivitySummary(value: unknown): value is ActivitySummary {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return (
+    value.schemaVersion === 1 &&
+    typeof value.targetDate === "string" &&
+    typeof value.generatedAt === "string" &&
+    isActivityLevel(value.activityLevel) &&
+    isActivityTheme(value.dominantTheme) &&
+    Array.isArray(value.projects) &&
+    isRecord(value.commitSignals) &&
+    isRecord(value.uncommittedChanges) &&
+    isRecord(value.manualContext) &&
+    Array.isArray(value.smallWins) &&
+    Array.isArray(value.blockersOrConfusion) &&
+    Array.isArray(value.unfinishedThreads) &&
+    Array.isArray(value.possibleJokes) &&
+    Array.isArray(value.publicSafetyNotes) &&
+    Array.isArray(value.privateItemsToAvoid) &&
+    Array.isArray(value.uncertaintyNotes)
+  );
+}
+
+function getProject(
+  projects: Map<string, ProjectAccumulator>,
+  projectId: string,
+  projectName: string
+): ProjectAccumulator {
+  const existingProject = projects.get(projectId);
+
+  if (existingProject) {
+    if (existingProject.projectName === projectId && projectName !== projectId) {
+      existingProject.projectName = projectName;
+    }
+
+    return existingProject;
+  }
+
+  const project: ProjectAccumulator = {
+    projectId,
+    projectName,
+    commitCount: 0,
+    filesChanged: 0,
+    insertions: 0,
+    deletions: 0,
+    uncommittedChangeCount: 0,
+    manualNoteCount: 0,
+    themes: new Set()
+  };
+
+  projects.set(projectId, project);
+  return project;
+}
+
+function toProjectSummary(project: ProjectAccumulator): ActivityProjectSummary {
+  return {
+    projectId: project.projectId,
+    projectName: project.projectName,
+    repositoryName: project.repositoryName,
+    commitCount: project.commitCount,
+    filesChanged: project.filesChanged,
+    insertions: project.insertions,
+    deletions: project.deletions,
+    uncommittedChangeCount: project.uncommittedChangeCount,
+    manualNoteCount: project.manualNoteCount,
+    themes: sortThemes(project.themes),
+    summary: summarizeProject(project)
+  };
+}
+
+function summarizeProject(project: ProjectAccumulator): string {
+  const parts: string[] = [];
+
+  if (project.commitCount > 0) {
+    parts.push(`${project.commitCount} ${project.commitCount === 1 ? "commit" : "commits"}`);
+  }
+
+  if (project.manualNoteCount > 0) {
+    parts.push(`${project.manualNoteCount} manual ${project.manualNoteCount === 1 ? "note" : "notes"}`);
+  }
+
+  if (project.uncommittedChangeCount > 0) {
+    parts.push(`${project.uncommittedChangeCount} uncommitted ${project.uncommittedChangeCount === 1 ? "file" : "files"}`);
+  }
+
+  return parts.length > 0 ? parts.join(", ") : "No activity signals.";
+}
+
+function classifyActivityLevel(score: number): ActivityLevel {
+  if (score === 0) {
+    return "none";
+  }
+
+  if (score <= 4) {
+    return "low";
+  }
+
+  if (score <= 11) {
+    return "medium";
+  }
+
+  return "high";
+}
+
+function deriveDominantTheme(
+  activityLevel: ActivityLevel,
+  themes: Exclude<ActivityTheme, "mixed" | "quiet">[]
+): ActivityTheme {
+  if (activityLevel === "none") {
+    return "quiet";
+  }
+
+  return themes.length === 1 ? themes[0] : "mixed";
+}
+
+function classifyThemes(text: string): Exclude<ActivityTheme, "mixed" | "quiet">[] {
+  const lowerText = text.toLowerCase();
+  const themes = new Set<Exclude<ActivityTheme, "mixed" | "quiet">>();
+
+  if (/\b(refactor|cleanup|rename|restructure|simplify)\b/.test(lowerText)) {
+    themes.add("refactoring");
+  }
+
+  if (/\b(plan|planned|planning|spec|design|milestone|todo|roadmap)\b/.test(lowerText)) {
+    themes.add("planning");
+  }
+
+  if (/\b(blocked|bug|debug|error|exception|fail|failed|failing|fix|fixed|flaky|unclear)\b/.test(lowerText)) {
+    themes.add("debugging");
+  }
+
+  if (/\b(add|build|command|feature|implement|implemented|test|update)\b/.test(lowerText)) {
+    themes.add("coding");
+  }
+
+  return sortThemes(themes);
+}
+
+function looksLikeSmallWin(text: string): boolean {
+  return /\b(add|built|fixed|implement|implemented|shipped|solved)\b/i.test(text);
+}
+
+function looksLikeBlocker(text: string): boolean {
+  return /\b(blocked|confused|confusion|failed|failing|stuck|unclear)\b/i.test(text);
+}
+
+function looksUnfinished(text: string): boolean {
+  return /\b(follow-up|later|todo|tomorrow|unfinished|wip)\b/i.test(text);
+}
+
+function buildUncertaintyNotes(
+  input: ActivitySummaryInput,
+  signals: {
+    gitEventCount: number;
+    totalCommits: number;
+    manualNoteCount: number;
+    themeCount: number;
+    uncommittedChangeCount: number;
+  }
+): string[] {
+  const notes: string[] = [];
+
+  if (
+    signals.gitEventCount === 0 &&
+    signals.manualNoteCount === 0 &&
+    signals.uncommittedChangeCount === 0
+  ) {
+    notes.push(`No Git activity or manual notes were found for ${input.targetDate}.`);
+  }
+
+  if (signals.gitEventCount === 0 && signals.manualNoteCount > 0) {
+    notes.push("Git activity was not provided; summary relies on manual notes.");
+  }
+
+  if (
+    signals.themeCount === 0 &&
+    (signals.totalCommits > 0 || signals.manualNoteCount > 0)
+  ) {
+    notes.push("Activity existed, but theme signals were insufficient.");
+  }
+
+  if (signals.uncommittedChangeCount > 0) {
+    notes.push("Uncommitted changes show file status only, not intent.");
+  }
+
+  return notes;
+}
+
+function buildPossibleJokes(
+  activityLevel: ActivityLevel,
+  options: {
+    hasBlockers: boolean;
+    hasUncommittedChanges: boolean;
+  }
+): string[] {
+  if (activityLevel === "none") {
+    return ["Quiet day, but the draft still has to admit nothing exploded."];
+  }
+
+  const jokes: string[] = [];
+
+  if (options.hasUncommittedChanges) {
+    jokes.push("The working tree kept a few tabs open for tomorrow.");
+  }
+
+  if (options.hasBlockers) {
+    jokes.push("The day left a breadcrumb trail of blockers instead of a victory lap.");
+  }
+
+  return jokes;
+}
+
+function buildPublicSafetyNotes(options: {
+  hasManualPrivateItems: boolean;
+  hasUncommittedChanges: boolean;
+}): string[] {
+  const notes = ["Summary excludes raw diffs and raw code."];
+
+  if (options.hasManualPrivateItems) {
+    notes.push("Manual notes were sanitized for private details.");
+  }
+
+  if (options.hasUncommittedChanges) {
+    notes.push("Review uncommitted file names before sharing.");
+  }
+
+  return notes;
+}
+
+function sanitizeText(value: string): SanitizedText {
+  const privateItems = new Set<string>();
+  let sanitized = value;
+
+  if (/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i.test(sanitized)) {
+    privateItems.add("emails");
+    sanitized = sanitized.replace(
+      /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi,
+      "[redacted-email]"
+    );
+  }
+
+  if (/(^|[\s(["'])\/[^\s)"']+/.test(sanitized)) {
+    privateItems.add("local absolute paths");
+    sanitized = sanitized.replace(
+      /(^|[\s(["'])\/[^\s)"']+/g,
+      "$1[redacted-path]"
+    );
+  }
+
+  if (/\b(?:https?|ssh|git):\/\/\S+|git@[\w.-]+:[^\s]+/.test(sanitized)) {
+    privateItems.add("private URLs");
+    sanitized = sanitized.replace(
+      /\b(?:https?|ssh|git):\/\/\S+|git@[\w.-]+:[^\s]+/g,
+      "[redacted-url]"
+    );
+  }
+
+  if (/`[^`]+`/.test(sanitized)) {
+    privateItems.add("raw code snippets");
+    sanitized = sanitized.replace(/`[^`]+`/g, "[redacted-code]");
+  }
+
+  if (/\bdiff --git\b/.test(sanitized)) {
+    privateItems.add("raw code snippets");
+    sanitized = sanitized.replace(/\bdiff --git\b[^\n]*/g, "[redacted-code]");
+  }
+
+  return {
+    value: sanitized,
+    privateItems: sortPrivateItems(privateItems)
+  };
+}
+
+function addPrivateItems(target: Set<string>, items: string[]): void {
+  for (const item of items) {
+    target.add(item);
+  }
+}
+
+function sortPrivateItems(items: Set<string>): string[] {
+  return privateItemOrder.filter((item) => items.has(item));
+}
+
+function sortThemes(
+  themes: Set<Exclude<ActivityTheme, "mixed" | "quiet">>
+): Exclude<ActivityTheme, "mixed" | "quiet">[] {
+  return Array.from(themes).sort((left, right) => left.localeCompare(right));
+}
+
+function createEmptyDirtyTotals(): DirtyStatusTotals {
+  return Object.fromEntries(
+    dirtyStatuses.map((status) => [status, 0])
+  ) as DirtyStatusTotals;
+}
+
+function isActivityLevel(value: unknown): value is ActivityLevel {
+  return (
+    value === "none" ||
+    value === "low" ||
+    value === "medium" ||
+    value === "high"
+  );
+}
+
+function isActivityTheme(value: unknown): value is ActivityTheme {
+  return (
+    value === "coding" ||
+    value === "debugging" ||
+    value === "mixed" ||
+    value === "planning" ||
+    value === "quiet" ||
+    value === "refactoring"
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,17 @@
+export {
+  buildActivitySummary,
+  isActivitySummary
+} from "./activity-summary.js";
+export type {
+  ActivityLevel,
+  ActivityProjectSummary,
+  ActivitySummary,
+  ActivitySummaryInput,
+  ActivityTheme,
+  CommitSignals,
+  ManualContextSummary,
+  UncommittedChangeSummary
+} from "./activity-summary.js";
 export { getHelpText, runCli } from "./cli.js";
 export type { CliIo, CliOptions } from "./cli.js";
 export { commands, isKnownCommand } from "./commands.js";

--- a/tests/activity-summary.test.ts
+++ b/tests/activity-summary.test.ts
@@ -1,0 +1,299 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildActivitySummary,
+  isActivitySummary,
+  type ActivitySummaryInput
+} from "../src/activity-summary.js";
+
+describe("activity summary", () => {
+  it("summarizes an active Git day with safe project, commit, and dirty signals", () => {
+    const input = createInput({
+      gitEvents: [
+        createGitEvent({
+          projectId: "cli",
+          projectName: "CLI",
+          commits: [
+            createCommit({
+              subject: "implement collect git command",
+              filesChanged: 4,
+              insertions: 80,
+              deletions: 10
+            }),
+            createCommit({
+              subject: "fix flaky collector path handling",
+              filesChanged: 2,
+              insertions: 12,
+              deletions: 5
+            })
+          ],
+          dirtyFiles: [
+            { path: "src/activity-summary.ts", status: "modified" },
+            { path: "tests/activity-summary.test.ts", status: "untracked" }
+          ]
+        })
+      ]
+    });
+
+    const summary = buildActivitySummary(input);
+
+    expect(isActivitySummary(summary)).toBe(true);
+    expect(summary).toMatchObject({
+      schemaVersion: 1,
+      targetDate: "2026-05-12",
+      generatedAt: "2026-05-12T23:30:00.000Z",
+      activityLevel: "high",
+      dominantTheme: "mixed",
+      commitSignals: {
+        totalCommits: 2,
+        filesChanged: 6,
+        insertions: 92,
+        deletions: 15,
+        subjects: [
+          "implement collect git command",
+          "fix flaky collector path handling"
+        ],
+        themes: ["coding", "debugging"]
+      },
+      uncommittedChanges: {
+        totalFiles: 2
+      }
+    });
+    expect(summary.projects).toEqual([
+      expect.objectContaining({
+        projectId: "cli",
+        projectName: "CLI",
+        repositoryName: "cli-repo",
+        commitCount: 2,
+        manualNoteCount: 0,
+        uncommittedChangeCount: 2,
+        themes: ["coding", "debugging"]
+      })
+    ]);
+    expect(summary.smallWins).toEqual([
+      "implement collect git command",
+      "fix flaky collector path handling"
+    ]);
+    expect(summary.unfinishedThreads).toContain(
+      "2 uncommitted files remain in CLI."
+    );
+    expect(summary.possibleJokes).toContain(
+      "The working tree kept a few tabs open for tomorrow."
+    );
+    expect(JSON.stringify(summary)).not.toContain("const ");
+  });
+
+  it("treats quiet days as valid summaries without inventing work", () => {
+    const summary = buildActivitySummary(createInput());
+
+    expect(isActivitySummary(summary)).toBe(true);
+    expect(summary.activityLevel).toBe("none");
+    expect(summary.dominantTheme).toBe("quiet");
+    expect(summary.projects).toEqual([]);
+    expect(summary.commitSignals.totalCommits).toBe(0);
+    expect(summary.manualContext.noteCount).toBe(0);
+    expect(summary.smallWins).toEqual([]);
+    expect(summary.blockersOrConfusion).toEqual([]);
+    expect(summary.unfinishedThreads).toEqual([]);
+    expect(summary.possibleJokes).toEqual([
+      "Quiet day, but the draft still has to admit nothing exploded."
+    ]);
+    expect(summary.uncertaintyNotes).toContain(
+      "No Git activity or manual notes were found for 2026-05-12."
+    );
+  });
+
+  it("represents manual-note-only days without requiring Git commits", () => {
+    const summary = buildActivitySummary(
+      createInput({
+        manualNotes: [
+          {
+            schemaVersion: 1,
+            id: "note-1",
+            timestamp: "2026-05-12T09:00:00.000Z",
+            date: "2026-05-12",
+            projectId: "cli",
+            text: "Planned activity summary shape with dev@example.com in /Users/me/private and https://github.com/acme/private",
+            source: "manual"
+          }
+        ]
+      })
+    );
+
+    expect(summary.activityLevel).toBe("low");
+    expect(summary.dominantTheme).toBe("planning");
+    expect(summary.projects).toEqual([
+      expect.objectContaining({
+        projectId: "cli",
+        projectName: "cli",
+        commitCount: 0,
+        manualNoteCount: 1,
+        themes: ["planning"]
+      })
+    ]);
+    expect(summary.manualContext.notes).toEqual([
+      expect.objectContaining({
+        projectId: "cli",
+        text: "Planned activity summary shape with [redacted-email] in [redacted-path] and [redacted-url]"
+      })
+    ]);
+    expect(summary.publicSafetyNotes).toContain(
+      "Manual notes were sanitized for private details."
+    );
+    expect(summary.privateItemsToAvoid).toEqual([
+      "emails",
+      "local absolute paths",
+      "private URLs"
+    ]);
+    expect(summary.uncertaintyNotes).toContain(
+      "Git activity was not provided; summary relies on manual notes."
+    );
+
+    const serialized = JSON.stringify(summary);
+    expect(serialized).not.toContain("dev@example.com");
+    expect(serialized).not.toContain("/Users/me/private");
+    expect(serialized).not.toContain("github.com/acme/private");
+  });
+
+  it("merges mixed Git and manual context without raw diffs or raw code", () => {
+    const summary = buildActivitySummary(
+      createInput({
+        gitEvents: [
+          createGitEvent({
+            projectId: "cli",
+            projectName: "CLI",
+            commits: [
+              createCommit({
+                subject: "refactor note parsing",
+                filesChanged: 3,
+                insertions: 20,
+                deletions: 18
+              })
+            ],
+            dirtyFiles: [{ path: "src/note-command.ts", status: "modified" }]
+          })
+        ],
+        manualNotes: [
+          {
+            schemaVersion: 1,
+            id: "note-2",
+            timestamp: "2026-05-12T15:00:00.000Z",
+            date: "2026-05-12",
+            projectId: "cli",
+            text: "Blocked by unclear edge case. TODO revisit `const token = process.env.SECRET` tomorrow.",
+            source: "manual"
+          }
+        ]
+      })
+    );
+
+    expect(summary.activityLevel).toBe("medium");
+    expect(summary.dominantTheme).toBe("mixed");
+    expect(summary.projects).toEqual([
+      expect.objectContaining({
+        projectId: "cli",
+        projectName: "CLI",
+        commitCount: 1,
+        manualNoteCount: 1,
+        uncommittedChangeCount: 1,
+        themes: ["debugging", "planning", "refactoring"]
+      })
+    ]);
+    expect(summary.blockersOrConfusion).toEqual([
+      "Blocked by unclear edge case. TODO revisit [redacted-code] tomorrow."
+    ]);
+    expect(summary.unfinishedThreads).toEqual([
+      "1 uncommitted file remains in CLI.",
+      "Blocked by unclear edge case. TODO revisit [redacted-code] tomorrow."
+    ]);
+    expect(summary.privateItemsToAvoid).toContain("raw code snippets");
+
+    const serialized = JSON.stringify(summary);
+    expect(serialized).not.toContain("const token");
+    expect(serialized).not.toContain("process.env.SECRET");
+    expect(serialized).not.toContain("diff --git");
+  });
+});
+
+function createInput(
+  overrides: Partial<ActivitySummaryInput> = {}
+): ActivitySummaryInput {
+  return {
+    targetDate: "2026-05-12",
+    generatedAt: "2026-05-12T23:30:00.000Z",
+    gitEvents: [],
+    manualNotes: [],
+    ...overrides
+  };
+}
+
+function createGitEvent(
+  options: {
+    projectId: string;
+    projectName: string;
+    commits?: ActivitySummaryInput["gitEvents"][number]["activity"]["commits"];
+    dirtyFiles?: ActivitySummaryInput["gitEvents"][number]["activity"]["dirty"]["files"];
+  }
+): ActivitySummaryInput["gitEvents"][number] {
+  const commits = options.commits ?? [];
+  const dirtyFiles = options.dirtyFiles ?? [];
+
+  return {
+    schemaVersion: 1,
+    source: "git",
+    targetDate: "2026-05-12",
+    collectedAt: "2026-05-12T23:00:00.000Z",
+    project: {
+      id: options.projectId,
+      name: options.projectName
+    },
+    activity: {
+      schemaVersion: 1,
+      targetDate: "2026-05-12",
+      repository: {
+        rootName: `${options.projectId}-repo`
+      },
+      commits,
+      totals: commits.reduce(
+        (totals, commit) => ({
+          commits: totals.commits + 1,
+          filesChanged: totals.filesChanged + commit.stats.filesChanged,
+          insertions: totals.insertions + commit.stats.insertions,
+          deletions: totals.deletions + commit.stats.deletions
+        }),
+        { commits: 0, filesChanged: 0, insertions: 0, deletions: 0 }
+      ),
+      dirty: {
+        files: dirtyFiles,
+        totals: {
+          modified: dirtyFiles.filter((file) => file.status === "modified").length,
+          added: dirtyFiles.filter((file) => file.status === "added").length,
+          deleted: dirtyFiles.filter((file) => file.status === "deleted").length,
+          renamed: dirtyFiles.filter((file) => file.status === "renamed").length,
+          copied: dirtyFiles.filter((file) => file.status === "copied").length,
+          untracked: dirtyFiles.filter((file) => file.status === "untracked").length,
+          other: dirtyFiles.filter((file) => file.status === "other").length
+        }
+      }
+    }
+  };
+}
+
+function createCommit(options: {
+  subject: string;
+  filesChanged: number;
+  insertions: number;
+  deletions: number;
+}): ActivitySummaryInput["gitEvents"][number]["activity"]["commits"][number] {
+  return {
+    hash: "1234567890abcdef1234567890abcdef12345678",
+    shortHash: "1234567",
+    authorName: "Fixture Dev",
+    authoredAt: "2026-05-12T12:00:00.000Z",
+    subject: options.subject,
+    stats: {
+      filesChanged: options.filesChanged,
+      insertions: options.insertions,
+      deletions: options.deletions
+    }
+  };
+}

--- a/tests/activity-summary.test.ts
+++ b/tests/activity-summary.test.ts
@@ -30,6 +30,20 @@ describe("activity summary", () => {
             { path: "src/activity-summary.ts", status: "modified" },
             { path: "tests/activity-summary.test.ts", status: "untracked" }
           ]
+        }),
+        createGitEvent({
+          targetDate: "2026-05-11",
+          projectId: "old",
+          projectName: "Old Work",
+          commits: [
+            createCommit({
+              subject: "implement unrelated prior day feature",
+              filesChanged: 10,
+              insertions: 300,
+              deletions: 40
+            })
+          ],
+          dirtyFiles: [{ path: "src/old.ts", status: "modified" }]
         })
       ]
     });
@@ -69,6 +83,11 @@ describe("activity summary", () => {
         themes: ["coding", "debugging"]
       })
     ]);
+    expect(summary.projects).not.toContainEqual(
+      expect.objectContaining({
+        projectId: "old"
+      })
+    );
     expect(summary.smallWins).toEqual([
       "implement collect git command",
       "fix flaky collector path handling"
@@ -79,7 +98,9 @@ describe("activity summary", () => {
     expect(summary.possibleJokes).toContain(
       "The working tree kept a few tabs open for tomorrow."
     );
-    expect(JSON.stringify(summary)).not.toContain("const ");
+    const serialized = JSON.stringify(summary);
+    expect(serialized).not.toContain("const ");
+    expect(serialized).not.toContain("prior day");
   });
 
   it("treats quiet days as valid summaries without inventing work", () => {
@@ -179,7 +200,7 @@ describe("activity summary", () => {
             timestamp: "2026-05-12T15:00:00.000Z",
             date: "2026-05-12",
             projectId: "cli",
-            text: "Blocked by unclear edge case. TODO revisit `const token = process.env.SECRET` tomorrow.",
+            text: "Blocked by unclear edge case. TODO revisit const token = process.env.SECRET tomorrow.",
             source: "manual"
           }
         ]
@@ -228,6 +249,7 @@ function createInput(
 
 function createGitEvent(
   options: {
+    targetDate?: string;
     projectId: string;
     projectName: string;
     commits?: ActivitySummaryInput["gitEvents"][number]["activity"]["commits"];
@@ -236,11 +258,12 @@ function createGitEvent(
 ): ActivitySummaryInput["gitEvents"][number] {
   const commits = options.commits ?? [];
   const dirtyFiles = options.dirtyFiles ?? [];
+  const targetDate = options.targetDate ?? "2026-05-12";
 
   return {
     schemaVersion: 1,
     source: "git",
-    targetDate: "2026-05-12",
+    targetDate,
     collectedAt: "2026-05-12T23:00:00.000Z",
     project: {
       id: options.projectId,
@@ -248,7 +271,7 @@ function createGitEvent(
     },
     activity: {
       schemaVersion: 1,
-      targetDate: "2026-05-12",
+      targetDate,
       repository: {
         rootName: `${options.projectId}-repo`
       },


### PR DESCRIPTION
# Goal

Define the deterministic Activity Summary layer that turns collected Git activity and manual notes into safe daily generation input.

## Related Issue

Closes #22.

## Acceptance Criteria

- [x] Summary generation produces a valid `activity-summary.json` shape for a target date
- [x] Git activity and manual notes are merged into one daily summary
- [x] Quiet days produce `activityLevel: "none"` and valid quiet-day output without failure
- [x] Manual-note-only days are represented without requiring Git commits
- [x] Summary output does not include raw diffs, raw code, emails, local absolute paths, private URLs, or private remote URLs
- [x] Ambiguous signals are marked as unknown or insufficient context rather than fabricated
- [x] Unit tests cover active day, quiet day, manual-note-only day, and mixed Git/manual behavior

## Implementation Notes

- Adds `buildActivitySummary` and typed Activity Summary exports.
- Merges `GitActivityEvent` and `ManualNoteEvent` inputs into project, commit, dirty-file, manual-context, joke, safety, private-item, and uncertainty summaries.
- Keeps quiet days valid and deterministic for later generation steps.

## Validation

- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`

## Remaining Risk

The summarizer is intentionally rule-based for MVP. Theme and activity-level heuristics may need tuning after Story Inventor and Diary Generator consume the summary in later issues.
