### PR TITLE
feat: implement Story Inventor format planning

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,17 @@ export type {
   SafeActivitySummary,
   SafeProjectSummary
 } from "./ai-provider.js";
+export {
+  generateStoryFormatPlan,
+  loadRecentStoryFormatHistory
+} from "./story-format-plan.js";
+export type {
+  ProjectPersonaHint,
+  RecentStoryFormat,
+  StoryFormatPlan,
+  StoryFormatPlanOptions,
+  StoryFormatStructurePart
+} from "./story-format-plan.js";
 export { runInitCommand } from "./init-command.js";
 export type {
   InitAnswers,

--- a/src/story-format-plan.ts
+++ b/src/story-format-plan.ts
@@ -1,0 +1,352 @@
+import { readFile } from "node:fs/promises";
+import { resolveConfigPaths } from "./config-paths.js";
+import type { ActivitySummary } from "./activity-summary.js";
+import {
+  AiGenerationError,
+  createAiGenerationRequest,
+  generateStructured
+} from "./ai-provider.js";
+import type {
+  AiProvider,
+  JsonObject,
+  JsonValue,
+  SafeActivitySummary
+} from "./ai-provider.js";
+
+export type StoryFormatStructurePart = {
+  part: string;
+  purpose: string;
+};
+
+export type StoryFormatPlan = {
+  schemaVersion: 1;
+  formatName: string;
+  voice: string;
+  tone: string;
+  reason: string;
+  structure: StoryFormatStructurePart[];
+  suggestedSlideCount: number;
+  captionStyle: string;
+  doNotMention: string[];
+};
+
+export type RecentStoryFormat = {
+  date: string;
+  formatName: string;
+  voice?: string;
+  tone?: string;
+};
+
+export type ProjectPersonaHint = {
+  projectId: string;
+  projectName: string;
+  personaHint: string;
+};
+
+export type StoryFormatPlanOptions = {
+  activitySummary: ActivitySummary;
+  provider: AiProvider;
+  persona: string;
+  roastLevel: number;
+  projectPersonaHints?: ProjectPersonaHint[];
+  entryMode?: "daily_global";
+  recentFormats?: RecentStoryFormat[];
+};
+
+export type LoadRecentStoryFormatHistoryOptions = {
+  homeDir?: string;
+  limit?: number;
+};
+
+type StoryFormatHistoryFile = {
+  schemaVersion?: 1;
+  formats?: unknown[];
+  recent?: unknown[];
+};
+
+type StoryFormatPlanProviderData = JsonObject & {
+  formatName?: JsonValue;
+  voice?: JsonValue;
+  tone?: JsonValue;
+  reason?: JsonValue;
+  structure?: JsonValue;
+  suggestedSlideCount?: JsonValue;
+  captionStyle?: JsonValue;
+  doNotMention?: JsonValue;
+};
+
+const defaultHistoryLimit = 7;
+const minSlideCount = 3;
+const maxSlideCount = 8;
+
+export async function generateStoryFormatPlan(
+  options: StoryFormatPlanOptions
+): Promise<StoryFormatPlan> {
+  const recentFormats = options.recentFormats ?? [];
+  const request = createAiGenerationRequest({
+    task: "story-plan",
+    instructions: buildStoryFormatInstructions({
+      roastLevel: options.roastLevel,
+      entryMode: "daily_global",
+      hasRecentFormats: recentFormats.length > 0,
+      quiet: options.activitySummary.activityLevel === "none"
+    }),
+    summary: buildSafeStoryFormatInput({
+      activitySummary: options.activitySummary,
+      persona: options.persona,
+      roastLevel: options.roastLevel,
+      projectPersonaHints: options.projectPersonaHints ?? [],
+      recentFormats
+    })
+  });
+  const response = await generateStructured<StoryFormatPlanProviderData>(
+    options.provider,
+    request
+  );
+
+  return parseStoryFormatPlan(response.data);
+}
+
+export async function loadRecentStoryFormatHistory(
+  options: LoadRecentStoryFormatHistoryOptions = {}
+): Promise<RecentStoryFormat[]> {
+  const paths = resolveConfigPaths({ homeDir: options.homeDir });
+  const limit = options.limit ?? defaultHistoryLimit;
+
+  try {
+    const parsed = JSON.parse(
+      await readFile(paths.formatHistoryFile, "utf8")
+    ) as unknown;
+
+    if (!isRecord(parsed)) {
+      return [];
+    }
+
+    const historyFile = parsed as StoryFormatHistoryFile;
+    const entries = Array.isArray(historyFile.recent)
+      ? historyFile.recent
+      : Array.isArray(historyFile.formats)
+        ? historyFile.formats
+        : [];
+
+    return entries
+      .filter(isRecentStoryFormat)
+      .sort((a, b) => b.date.localeCompare(a.date))
+      .slice(0, limit);
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return [];
+    }
+
+    throw new AiGenerationError(
+      "Format history is invalid. Re-run `uncommitted init`.",
+      "invalid-config"
+    );
+  }
+}
+
+function buildSafeStoryFormatInput(options: {
+  activitySummary: ActivitySummary;
+  persona: string;
+  roastLevel: number;
+  projectPersonaHints: ProjectPersonaHint[];
+  recentFormats: RecentStoryFormat[];
+}): SafeActivitySummary {
+  const summary = options.activitySummary;
+  const quiet = summary.activityLevel === "none";
+  const highlights = buildHighlights(summary, quiet);
+
+  return {
+    schemaVersion: 1,
+    targetDate: summary.targetDate,
+    quiet,
+    overview: `${summary.activityLevel} ${summary.dominantTheme} day with ${summary.projects.length} ${summary.projects.length === 1 ? "project" : "projects"}.`,
+    highlights,
+    projectSummaries: summary.projects.map((project) => ({
+      projectId: project.projectId,
+      projectName: project.projectName,
+      summary: project.summary,
+      stats: {
+        commits: project.commitCount,
+        filesChanged: project.filesChanged,
+        insertions: project.insertions,
+        deletions: project.deletions,
+        dirtyFiles: project.uncommittedChangeCount
+      }
+    })),
+    entryMode: "daily_global",
+    persona: options.persona,
+    roastPolicy: {
+      roastLevel: options.roastLevel,
+      allowDirectUserRoast: options.roastLevel >= 3,
+      boundaries: [
+        "Roast situations, tools, TODOs, bugs, and recurring work patterns only.",
+        "Never attack identity, ability, appearance, mental health, personal value, or real life."
+      ]
+    },
+    projectPersonaHints: options.projectPersonaHints,
+    recentFormats: options.recentFormats,
+    activitySignals: {
+      activityLevel: summary.activityLevel,
+      dominantTheme: summary.dominantTheme,
+      commitSubjects: summary.commitSignals.subjects,
+      unfinishedThreads: summary.unfinishedThreads,
+      possibleJokes: summary.possibleJokes,
+      publicSafetyNotes: summary.publicSafetyNotes,
+      privateItemsToAvoid: summary.privateItemsToAvoid,
+      uncertaintyNotes: summary.uncertaintyNotes
+    }
+  };
+}
+
+function buildHighlights(summary: ActivitySummary, quiet: boolean): string[] {
+  if (quiet) {
+    return [
+      "No recorded Git activity or manual notes; keep the draft honest.",
+      ...summary.possibleJokes,
+      ...summary.uncertaintyNotes
+    ];
+  }
+
+  return [
+    ...summary.smallWins,
+    ...summary.blockersOrConfusion,
+    ...summary.unfinishedThreads,
+    ...summary.possibleJokes
+  ];
+}
+
+function buildStoryFormatInstructions(options: {
+  roastLevel: number;
+  entryMode: "daily_global";
+  hasRecentFormats: boolean;
+  quiet: boolean;
+}): string {
+  const directRoastPolicy =
+    options.roastLevel >= 3
+      ? "Light direct roast of work habits is allowed, but never personal attacks."
+      : "Keep jokes focused on situations, tools, TODOs, bugs, and requirements.";
+
+  return [
+    "Design a Story Format Plan for an Uncommitted diary draft.",
+    `Entry mode is ${options.entryMode}; create one global diary plan across all projects.`,
+    "Return structured JSON with formatName, voice, tone, reason, structure, suggestedSlideCount, captionStyle, and doNotMention.",
+    "Do not invent work, commits, bugs, features, or user activity.",
+    "For quiet days, acknowledge low or no recorded work and make the format about waiting, observation, or honest quiet.",
+    "Avoid near-duplicates of recentFormats when they are provided.",
+    "Keep the structure readable as an Instagram carousel.",
+    "Roast policy: light jokes may target situations, tools, TODOs, bugs, recurring work patterns, or requirement churn.",
+    directRoastPolicy,
+    "Never attack the user's identity, ability, appearance, mental health, personal value, or real life.",
+    `Suggested slide count must be ${minSlideCount}-${maxSlideCount}; prefer 3-5 for quiet/low days and 5-8 for high days.`
+  ].join("\n");
+}
+
+function parseStoryFormatPlan(data: StoryFormatPlanProviderData): StoryFormatPlan {
+  if (!isStoryFormatPlanProviderData(data)) {
+    throwInvalidStoryFormatPlan();
+  }
+
+  const plan: StoryFormatPlan = {
+    schemaVersion: 1,
+    formatName: data.formatName,
+    voice: data.voice,
+    tone: data.tone,
+    reason: data.reason,
+    structure: data.structure,
+    suggestedSlideCount: data.suggestedSlideCount,
+    captionStyle: data.captionStyle,
+    doNotMention: data.doNotMention
+  };
+
+  if (!isStoryFormatPlan(plan)) {
+    throwInvalidStoryFormatPlan();
+  }
+
+  return plan;
+}
+
+function isStoryFormatPlan(value: unknown): value is StoryFormatPlan {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const suggestedSlideCount = value.suggestedSlideCount;
+
+  return (
+    value.schemaVersion === 1 &&
+    typeof value.formatName === "string" &&
+    value.formatName.trim().length > 0 &&
+    typeof value.voice === "string" &&
+    value.voice.trim().length > 0 &&
+    typeof value.tone === "string" &&
+    value.tone.trim().length > 0 &&
+    typeof value.reason === "string" &&
+    value.reason.trim().length > 0 &&
+    Array.isArray(value.structure) &&
+    value.structure.length > 0 &&
+    value.structure.every(isStoryFormatStructurePart) &&
+    Number.isInteger(suggestedSlideCount) &&
+    typeof suggestedSlideCount === "number" &&
+    suggestedSlideCount >= minSlideCount &&
+    suggestedSlideCount <= maxSlideCount &&
+    typeof value.captionStyle === "string" &&
+    value.captionStyle.trim().length > 0 &&
+    Array.isArray(value.doNotMention) &&
+    value.doNotMention.every((item) => typeof item === "string")
+  );
+}
+
+function isStoryFormatPlanProviderData(
+  value: StoryFormatPlanProviderData
+): value is StoryFormatPlanProviderData & Omit<StoryFormatPlan, "schemaVersion"> {
+  return (
+    typeof value.formatName === "string" &&
+    typeof value.voice === "string" &&
+    typeof value.tone === "string" &&
+    typeof value.reason === "string" &&
+    Array.isArray(value.structure) &&
+    value.structure.every(isStoryFormatStructurePart) &&
+    Number.isInteger(value.suggestedSlideCount) &&
+    typeof value.captionStyle === "string" &&
+    Array.isArray(value.doNotMention) &&
+    value.doNotMention.every((item) => typeof item === "string")
+  );
+}
+
+function isStoryFormatStructurePart(
+  value: unknown
+): value is StoryFormatStructurePart {
+  return (
+    isRecord(value) &&
+    typeof value.part === "string" &&
+    value.part.trim().length > 0 &&
+    typeof value.purpose === "string" &&
+    value.purpose.trim().length > 0
+  );
+}
+
+function isRecentStoryFormat(value: unknown): value is RecentStoryFormat {
+  return (
+    isRecord(value) &&
+    typeof value.date === "string" &&
+    typeof value.formatName === "string" &&
+    (value.voice === undefined || typeof value.voice === "string") &&
+    (value.tone === undefined || typeof value.tone === "string")
+  );
+}
+
+function throwInvalidStoryFormatPlan(): never {
+  throw new AiGenerationError(
+    "AI provider returned invalid story format plan.",
+    "malformed-response"
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}

--- a/tests/story-format-plan.test.ts
+++ b/tests/story-format-plan.test.ts
@@ -1,0 +1,335 @@
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { AiGenerationError, MockAiProvider } from "../src/ai-provider.js";
+import type { ActivitySummary } from "../src/activity-summary.js";
+import {
+  generateStoryFormatPlan,
+  loadRecentStoryFormatHistory
+} from "../src/story-format-plan.js";
+
+describe("story format plan", () => {
+  it("returns a validated format plan for a normal activity summary", async () => {
+    const provider = new MockAiProvider({
+      response: createProviderPlan({
+        formatName: "Bug Court Transcript",
+        suggestedSlideCount: 5
+      })
+    });
+    const summary = createActivitySummary({
+      activityLevel: "medium",
+      dominantTheme: "debugging",
+      smallWins: ["Fixed flaky provider validation."],
+      blockersOrConfusion: ["Blocked by unclear retry handling."]
+    });
+
+    await expect(
+      generateStoryFormatPlan({
+        activitySummary: summary,
+        provider,
+        persona: "wry coworker",
+        roastLevel: 2
+      })
+    ).resolves.toEqual({
+      schemaVersion: 1,
+      formatName: "Bug Court Transcript",
+      voice: "tired QA narrator",
+      tone: "deadpan, witty, affectionate",
+      reason: "The day had enough debugging evidence for a courtroom bit.",
+      structure: [
+        {
+          part: "Opening statement",
+          purpose: "Introduce the actual debugging work."
+        },
+        {
+          part: "Evidence",
+          purpose: "Mention real commits and blockers only."
+        },
+        {
+          part: "Verdict",
+          purpose: "Close with a light situation joke."
+        }
+      ],
+      suggestedSlideCount: 5,
+      captionStyle: "short witty caption",
+      doNotMention: ["raw diffs", "private paths"]
+    });
+
+    expect(provider.requests).toHaveLength(1);
+    expect(provider.requests[0]).toMatchObject({
+      schemaVersion: 1,
+      task: "story-plan",
+      input: {
+        schemaVersion: 1,
+        targetDate: "2026-05-12",
+        quiet: false,
+        overview: "medium debugging day with 1 project.",
+        highlights: expect.arrayContaining([
+          "Fixed flaky provider validation.",
+          "Blocked by unclear retry handling."
+        ]),
+        entryMode: "daily_global",
+        persona: "wry coworker",
+        roastPolicy: {
+          roastLevel: 2,
+          allowDirectUserRoast: false
+        }
+      }
+    });
+    expect(provider.requests[0]?.instructions).toContain("daily_global");
+    expect(provider.requests[0]?.instructions).toContain("Roast policy");
+    expect(provider.requests[0]?.instructions).toContain("Do not invent work");
+  });
+
+  it("builds a quiet-day request without fabricating activity", async () => {
+    const provider = new MockAiProvider({
+      response: createProviderPlan({
+        formatName: "Quiet Terminal Watch",
+        reason: "No recorded work was available, so the plan admits a quiet day.",
+        suggestedSlideCount: 3
+      })
+    });
+
+    const plan = await generateStoryFormatPlan({
+      activitySummary: createActivitySummary({
+        activityLevel: "none",
+        dominantTheme: "quiet",
+        projects: [],
+        commitSignals: {
+          totalCommits: 0,
+          filesChanged: 0,
+          insertions: 0,
+          deletions: 0,
+          subjects: [],
+          themes: []
+        },
+        possibleJokes: [
+          "Quiet day, but the draft still has to admit nothing exploded."
+        ],
+        uncertaintyNotes: [
+          "No Git activity or manual notes were found for 2026-05-12."
+        ]
+      }),
+      provider,
+      persona: "slightly tired coworker",
+      roastLevel: 4
+    });
+
+    expect(plan.formatName).toBe("Quiet Terminal Watch");
+    expect(plan.suggestedSlideCount).toBe(3);
+    expect(provider.requests[0]?.input.quiet).toBe(true);
+    expect(provider.requests[0]?.input.highlights).toContain(
+      "No recorded Git activity or manual notes; keep the draft honest."
+    );
+    expect(provider.requests[0]?.instructions).toContain(
+      "For quiet days, acknowledge low or no recorded work"
+    );
+  });
+
+  it("includes recent format history for repeated-format avoidance", async () => {
+    const homeDir = await createHomeWithFormatHistory({
+      formats: [
+        {
+          date: "2026-05-11",
+          formatName: "TODO Night Council",
+          voice: "TODO list",
+          tone: "deadpan"
+        },
+        {
+          date: "2026-05-10",
+          formatName: "Commit Weather",
+          voice: "weather report",
+          tone: "witty"
+        }
+      ]
+    });
+    const recentFormats = await loadRecentStoryFormatHistory({ homeDir });
+    const provider = new MockAiProvider({
+      response: createProviderPlan({
+        formatName: "Refactor Field Notes"
+      })
+    });
+
+    await generateStoryFormatPlan({
+      activitySummary: createActivitySummary(),
+      provider,
+      persona: "wry coworker",
+      roastLevel: 1,
+      recentFormats
+    });
+
+    expect(recentFormats).toEqual([
+      {
+        date: "2026-05-11",
+        formatName: "TODO Night Council",
+        voice: "TODO list",
+        tone: "deadpan"
+      },
+      {
+        date: "2026-05-10",
+        formatName: "Commit Weather",
+        voice: "weather report",
+        tone: "witty"
+      }
+    ]);
+    expect(provider.requests[0]?.input.recentFormats).toEqual(recentFormats);
+    expect(provider.requests[0]?.instructions).toContain(
+      "Avoid near-duplicates of recentFormats"
+    );
+  });
+
+  it("fails with a short actionable generation error for malformed provider output", async () => {
+    const provider = new MockAiProvider({
+      response: {
+        formatName: "Missing required plan fields"
+      }
+    });
+
+    await expect(
+      generateStoryFormatPlan({
+        activitySummary: createActivitySummary(),
+        provider,
+        persona: "wry coworker",
+        roastLevel: 2
+      })
+    ).rejects.toMatchObject({
+      code: "malformed-response",
+      exitCode: 4,
+      message: "AI provider returned invalid story format plan."
+    });
+
+    await expect(
+      generateStoryFormatPlan({
+        activitySummary: createActivitySummary(),
+        provider: new MockAiProvider({
+          response: createProviderPlan({ suggestedSlideCount: 10 })
+        }),
+        persona: "wry coworker",
+        roastLevel: 2
+      })
+    ).rejects.toBeInstanceOf(AiGenerationError);
+  });
+});
+
+function createProviderPlan(
+  overrides: Partial<ReturnType<typeof baseProviderPlan>> = {}
+): ReturnType<typeof baseProviderPlan> {
+  return {
+    ...baseProviderPlan(),
+    ...overrides
+  };
+}
+
+function baseProviderPlan() {
+  return {
+    formatName: "Bug Court Transcript",
+    voice: "tired QA narrator",
+    tone: "deadpan, witty, affectionate",
+    reason: "The day had enough debugging evidence for a courtroom bit.",
+    structure: [
+      {
+        part: "Opening statement",
+        purpose: "Introduce the actual debugging work."
+      },
+      {
+        part: "Evidence",
+        purpose: "Mention real commits and blockers only."
+      },
+      {
+        part: "Verdict",
+        purpose: "Close with a light situation joke."
+      }
+    ],
+    suggestedSlideCount: 4,
+    captionStyle: "short witty caption",
+    doNotMention: ["raw diffs", "private paths"]
+  };
+}
+
+function createActivitySummary(
+  overrides: Partial<ActivitySummary> = {}
+): ActivitySummary {
+  return {
+    schemaVersion: 1,
+    targetDate: "2026-05-12",
+    generatedAt: "2026-05-12T23:30:00.000Z",
+    activityLevel: "medium",
+    dominantTheme: "coding",
+    projects: [
+      {
+        projectId: "uncommitted",
+        projectName: "uncommitted",
+        repositoryName: "uncommitted",
+        commitCount: 2,
+        filesChanged: 4,
+        insertions: 120,
+        deletions: 18,
+        uncommittedChangeCount: 1,
+        manualNoteCount: 1,
+        themes: ["coding"],
+        summary: "2 commits, 1 manual note, 1 uncommitted file"
+      }
+    ],
+    commitSignals: {
+      totalCommits: 2,
+      filesChanged: 4,
+      insertions: 120,
+      deletions: 18,
+      subjects: ["implement provider validation"],
+      themes: ["coding"]
+    },
+    uncommittedChanges: {
+      totalFiles: 1,
+      byStatus: {
+        modified: 1,
+        added: 0,
+        deleted: 0,
+        renamed: 0,
+        copied: 0,
+        untracked: 0,
+        other: 0
+      },
+      files: [
+        {
+          projectId: "uncommitted",
+          projectName: "uncommitted",
+          path: "src/ai-provider.ts",
+          status: "modified"
+        }
+      ]
+    },
+    manualContext: {
+      noteCount: 1,
+      notes: [
+        {
+          projectId: "uncommitted",
+          timestamp: "2026-05-12T15:00:00.000Z",
+          text: "Need to keep story plans structured."
+        }
+      ]
+    },
+    smallWins: ["Implemented provider validation."],
+    blockersOrConfusion: [],
+    unfinishedThreads: ["1 uncommitted file remains in uncommitted."],
+    possibleJokes: ["The working tree kept a few tabs open for tomorrow."],
+    publicSafetyNotes: ["Summary excludes raw diffs and raw code."],
+    privateItemsToAvoid: ["raw code snippets"],
+    uncertaintyNotes: [],
+    ...overrides
+  };
+}
+
+async function createHomeWithFormatHistory(content: unknown): Promise<string> {
+  const homeDir = await mkdtemp(join(tmpdir(), "uncommitted-story-format-"));
+  const historyDir = join(homeDir, ".uncommitted", "history");
+
+  await mkdir(historyDir, { recursive: true });
+  await writeFile(
+    join(historyDir, "formats.json"),
+    `${JSON.stringify(content)}\n`,
+    "utf8"
+  );
+
+  return homeDir;
+}


### PR DESCRIPTION
# Goal

Implement the Story Inventor format-planning step so a safe Activity Summary can be turned into a validated Story Format Plan before diary generation.

## Related Issue

Closes #24.

## Acceptance Criteria

- [x] Story Inventor returns a validated Story Format Plan for a valid Activity Summary
- [x] Quiet-day input produces a format plan that acknowledges low or no recorded work without fabricating activity
- [x] Recent format history is included so the generated format can avoid near-duplicates
- [x] Roast policy and tone boundaries are included in the generation request
- [x] MVP `daily_global` entry mode is enforced
- [x] Invalid provider output fails with a short actionable generation error
- [x] Unit tests cover normal activity, quiet day, repeated-format avoidance input, and malformed provider output

## Implementation Notes

- Adds a `story-format-plan` module with Story Format Plan types, safe provider request construction, provider response validation, and recent format history loading.
- Reuses the existing AI provider abstraction and mock provider test style.
- Keeps live provider integration, diary slide/caption writing, rendering, and draft storage out of scope.

## Validation

- `pnpm exec vitest run tests/story-format-plan.test.ts`
- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `git diff --cached --check`

## Remaining Risk

- The prompt/request shape is implemented as module-level API only; it is not wired into a user-facing `generate` command yet.
