### PR TITLE
feat: implement diary and caption text generation

### DIFF
--- a/src/diary-generator.ts
+++ b/src/diary-generator.ts
@@ -65,7 +65,6 @@ type DiaryDraftProviderData = JsonObject & {
 
 const minSlideCount = 3;
 const maxSlideCount = 8;
-const quietMaxSlideCount = 5;
 const unsafeOutputKeys = new Set([
   "apikey",
   "api_key",
@@ -233,6 +232,7 @@ function buildDiaryInstructions(options: {
     `Create ${options.storyFormatPlan.suggestedSlideCount} slides when possible, while staying within 3-8 slides.`,
     "Caption must be copyable as an Instagram caption, Korean by default, concise, and not report-like.",
     "Each slide must include index, title, body, and visualMood.",
+    "Prefer 3-5 slides for quiet or low activity days; this is guidance, not a hard validation limit.",
     "Do not invent work, commits, bugs, features, shipped changes, or user activity.",
     quietInstruction,
     "Never include raw code, raw diffs, secrets, private paths, emails, private URLs, or private remote URLs.",
@@ -286,7 +286,7 @@ function parseDiaryDraft(options: {
     throwInvalidDiaryDraft();
   }
 
-  assertSlideCountForActivity(draft, options.activitySummary.activityLevel);
+  assertSlideCount(draft);
   assertQuietDayHonesty(draft, options.activitySummary);
 
   return draft;
@@ -374,20 +374,10 @@ function isHashtag(value: unknown): value is string {
   );
 }
 
-function assertSlideCountForActivity(
-  draft: DiaryDraft,
-  activityLevel: ActivityLevel
-): void {
+function assertSlideCount(draft: DiaryDraft): void {
   if (
     draft.slides.length < minSlideCount ||
     draft.slides.length > maxSlideCount
-  ) {
-    throwInvalidDiaryDraft();
-  }
-
-  if (
-    (activityLevel === "none" || activityLevel === "low") &&
-    draft.slides.length > quietMaxSlideCount
   ) {
     throwInvalidDiaryDraft();
   }

--- a/src/diary-generator.ts
+++ b/src/diary-generator.ts
@@ -1,0 +1,548 @@
+import type { ActivityLevel, ActivitySummary } from "./activity-summary.js";
+import {
+  AiGenerationError,
+  createAiGenerationRequest,
+  generateStructured
+} from "./ai-provider.js";
+import type {
+  AiProvider,
+  JsonObject,
+  JsonValue,
+  SafeActivitySummary
+} from "./ai-provider.js";
+import type {
+  ProjectPersonaHint,
+  StoryFormatPlan
+} from "./story-format-plan.js";
+
+export type DiarySlide = {
+  index: number;
+  title: string;
+  body: string;
+  visualMood: string;
+};
+
+export type DiaryDraftMetadata = {
+  targetDate: string;
+  generatedAt: string;
+  activityLevel: ActivityLevel;
+  formatName: string;
+  storyFormatVoice: string;
+  storyFormatTone: string;
+  projectIds: string[];
+  entryMode: "daily_global";
+  slideCount: number;
+};
+
+export type DiaryDraft = {
+  schemaVersion: 1;
+  targetDate: string;
+  title: string;
+  caption: string;
+  slides: DiarySlide[];
+  hashtags: string[];
+  altText: string;
+  metadata: DiaryDraftMetadata;
+};
+
+export type DiaryGeneratorOptions = {
+  activitySummary: ActivitySummary;
+  storyFormatPlan: StoryFormatPlan;
+  provider: AiProvider;
+  persona: string;
+  roastLevel: number;
+  projectPersonaHints?: ProjectPersonaHint[];
+  entryMode?: "daily_global";
+};
+
+type DiaryDraftProviderData = JsonObject & {
+  title?: JsonValue;
+  caption?: JsonValue;
+  slides?: JsonValue;
+  hashtags?: JsonValue;
+  altText?: JsonValue;
+};
+
+const minSlideCount = 3;
+const maxSlideCount = 8;
+const quietMaxSlideCount = 5;
+const unsafeOutputKeys = new Set([
+  "apikey",
+  "api_key",
+  "absolutepath",
+  "absolute_path",
+  "diff",
+  "gitroot",
+  "git_root",
+  "password",
+  "patch",
+  "rawcode",
+  "raw_code",
+  "rawdiff",
+  "raw_diff",
+  "rawtranscript",
+  "raw_transcript",
+  "remoteurl",
+  "remote_url",
+  "secret",
+  "secrets",
+  "token",
+  "tokens",
+  "transcript"
+]);
+
+export async function generateDiaryDraft(
+  options: DiaryGeneratorOptions
+): Promise<DiaryDraft> {
+  const request = createAiGenerationRequest({
+    task: "draft",
+    instructions: buildDiaryInstructions({
+      quiet: options.activitySummary.activityLevel === "none",
+      roastLevel: options.roastLevel,
+      storyFormatPlan: options.storyFormatPlan
+    }),
+    summary: buildSafeDiaryInput({
+      activitySummary: options.activitySummary,
+      storyFormatPlan: options.storyFormatPlan,
+      persona: options.persona,
+      roastLevel: options.roastLevel,
+      projectPersonaHints: options.projectPersonaHints ?? []
+    })
+  });
+  const response = await generateStructured<DiaryDraftProviderData>(
+    options.provider,
+    request
+  );
+
+  return parseDiaryDraft({
+    data: response.data,
+    activitySummary: options.activitySummary,
+    storyFormatPlan: options.storyFormatPlan
+  });
+}
+
+export function deriveCaptionText(draft: DiaryDraft): string {
+  const parts = [draft.caption.trim()];
+
+  if (draft.hashtags.length > 0) {
+    parts.push(draft.hashtags.join(" "));
+  }
+
+  return `${parts.join("\n\n")}\n`;
+}
+
+function buildSafeDiaryInput(options: {
+  activitySummary: ActivitySummary;
+  storyFormatPlan: StoryFormatPlan;
+  persona: string;
+  roastLevel: number;
+  projectPersonaHints: ProjectPersonaHint[];
+}): SafeActivitySummary {
+  const summary = options.activitySummary;
+  const quiet = summary.activityLevel === "none";
+
+  return {
+    schemaVersion: 1,
+    targetDate: summary.targetDate,
+    quiet,
+    overview: `${summary.activityLevel} ${summary.dominantTheme} day with ${summary.projects.length} ${summary.projects.length === 1 ? "project" : "projects"}.`,
+    highlights: buildHighlights(summary, quiet),
+    projectSummaries: summary.projects.map((project) => ({
+      projectId: project.projectId,
+      projectName: project.projectName,
+      summary: project.summary,
+      stats: {
+        commits: project.commitCount,
+        filesChanged: project.filesChanged,
+        insertions: project.insertions,
+        deletions: project.deletions,
+        dirtyFiles: project.uncommittedChangeCount
+      }
+    })),
+    entryMode: "daily_global",
+    persona: options.persona,
+    storyFormatPlan: {
+      formatName: options.storyFormatPlan.formatName,
+      voice: options.storyFormatPlan.voice,
+      tone: options.storyFormatPlan.tone,
+      reason: options.storyFormatPlan.reason,
+      structure: options.storyFormatPlan.structure.map((part) => ({
+        part: part.part,
+        purpose: part.purpose
+      })),
+      suggestedSlideCount: options.storyFormatPlan.suggestedSlideCount,
+      captionStyle: options.storyFormatPlan.captionStyle,
+      doNotMention: options.storyFormatPlan.doNotMention
+    },
+    roastPolicy: {
+      roastLevel: options.roastLevel,
+      allowDirectUserRoast: options.roastLevel >= 3,
+      boundaries: [
+        "Roast situations, tools, TODOs, bugs, recurring work patterns, or requirement churn only.",
+        "Never attack identity, ability, appearance, mental health, personal value, or real life."
+      ]
+    },
+    projectPersonaHints: options.projectPersonaHints,
+    activitySignals: {
+      activityLevel: summary.activityLevel,
+      dominantTheme: summary.dominantTheme,
+      commitSubjects: summary.commitSignals.subjects,
+      unfinishedThreads: summary.unfinishedThreads,
+      possibleJokes: summary.possibleJokes,
+      publicSafetyNotes: summary.publicSafetyNotes,
+      privateItemsToAvoid: summary.privateItemsToAvoid,
+      uncertaintyNotes: summary.uncertaintyNotes
+    }
+  };
+}
+
+function buildHighlights(summary: ActivitySummary, quiet: boolean): string[] {
+  if (quiet) {
+    return [
+      "No recorded Git activity or manual notes; keep the draft honest.",
+      ...summary.possibleJokes,
+      ...summary.uncertaintyNotes
+    ];
+  }
+
+  return [
+    ...summary.smallWins,
+    ...summary.blockersOrConfusion,
+    ...summary.unfinishedThreads,
+    ...summary.possibleJokes
+  ];
+}
+
+function buildDiaryInstructions(options: {
+  quiet: boolean;
+  roastLevel: number;
+  storyFormatPlan: StoryFormatPlan;
+}): string {
+  const directRoastPolicy =
+    options.roastLevel >= 3
+      ? "Light direct roast of work habits is allowed, but never personal attacks."
+      : "Keep jokes focused on situations, tools, TODOs, bugs, and requirements.";
+  const quietInstruction = options.quiet
+    ? "For quiet days, acknowledge no recorded work and pivot to waiting, observation, or an honest quiet-day monologue."
+    : "Use only the concrete work signals in the activity summary.";
+
+  return [
+    "Return structured JSON for story.json with title, caption, slides, hashtags, and altText.",
+    `Follow the Story Format Plan named ${options.storyFormatPlan.formatName}.`,
+    `Use ${options.storyFormatPlan.voice} as the voice and ${options.storyFormatPlan.tone} as the tone.`,
+    `Create ${options.storyFormatPlan.suggestedSlideCount} slides when possible, while staying within 3-8 slides.`,
+    "Caption must be copyable as an Instagram caption, Korean by default, concise, and not report-like.",
+    "Each slide must include index, title, body, and visualMood.",
+    "Do not invent work, commits, bugs, features, shipped changes, or user activity.",
+    quietInstruction,
+    "Never include raw code, raw diffs, secrets, private paths, emails, private URLs, or private remote URLs.",
+    "Roast policy: jokes may target situations, tools, TODOs, bugs, recurring work patterns, or requirement churn.",
+    directRoastPolicy,
+    "Never attack the user's identity, ability, appearance, mental health, personal value, or real life.",
+    "Do not imply the draft was automatically posted or exported."
+  ].join("\n");
+}
+
+function parseDiaryDraft(options: {
+  data: DiaryDraftProviderData;
+  activitySummary: ActivitySummary;
+  storyFormatPlan: StoryFormatPlan;
+}): DiaryDraft {
+  assertSafeProviderData(options.data);
+
+  if (!isDiaryDraftProviderData(options.data)) {
+    throwInvalidDiaryDraft();
+  }
+
+  const draft: DiaryDraft = {
+    schemaVersion: 1,
+    targetDate: options.activitySummary.targetDate,
+    title: options.data.title.trim(),
+    caption: options.data.caption.trim(),
+    slides: options.data.slides.map((slide) => ({
+      index: slide.index,
+      title: slide.title.trim(),
+      body: slide.body.trim(),
+      visualMood: slide.visualMood.trim()
+    })),
+    hashtags: options.data.hashtags.map((hashtag) => hashtag.trim()),
+    altText: options.data.altText.trim(),
+    metadata: {
+      targetDate: options.activitySummary.targetDate,
+      generatedAt: options.activitySummary.generatedAt,
+      activityLevel: options.activitySummary.activityLevel,
+      formatName: options.storyFormatPlan.formatName,
+      storyFormatVoice: options.storyFormatPlan.voice,
+      storyFormatTone: options.storyFormatPlan.tone,
+      projectIds: options.activitySummary.projects.map(
+        (project) => project.projectId
+      ),
+      entryMode: "daily_global",
+      slideCount: options.data.slides.length
+    }
+  };
+
+  if (!isDiaryDraft(draft)) {
+    throwInvalidDiaryDraft();
+  }
+
+  assertSlideCountForActivity(draft, options.activitySummary.activityLevel);
+  assertQuietDayHonesty(draft, options.activitySummary);
+
+  return draft;
+}
+
+function isDiaryDraftProviderData(
+  value: DiaryDraftProviderData
+): value is DiaryDraftProviderData & {
+  title: string;
+  caption: string;
+  slides: DiarySlide[];
+  hashtags: string[];
+  altText: string;
+} {
+  return (
+    typeof value.title === "string" &&
+    value.title.trim().length > 0 &&
+    typeof value.caption === "string" &&
+    value.caption.trim().length > 0 &&
+    Array.isArray(value.slides) &&
+    value.slides.every(isDiarySlide) &&
+    Array.isArray(value.hashtags) &&
+    value.hashtags.every(isHashtag) &&
+    typeof value.altText === "string" &&
+    value.altText.trim().length > 0
+  );
+}
+
+function isDiaryDraft(value: unknown): value is DiaryDraft {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return (
+    value.schemaVersion === 1 &&
+    typeof value.targetDate === "string" &&
+    typeof value.title === "string" &&
+    value.title.trim().length > 0 &&
+    typeof value.caption === "string" &&
+    value.caption.trim().length > 0 &&
+    Array.isArray(value.slides) &&
+    value.slides.every(isDiarySlide) &&
+    Array.isArray(value.hashtags) &&
+    value.hashtags.every(isHashtag) &&
+    typeof value.altText === "string" &&
+    value.altText.trim().length > 0 &&
+    isDiaryMetadata(value.metadata)
+  );
+}
+
+function isDiarySlide(value: unknown): value is DiarySlide {
+  return (
+    isRecord(value) &&
+    Number.isInteger(value.index) &&
+    typeof value.title === "string" &&
+    value.title.trim().length > 0 &&
+    typeof value.body === "string" &&
+    value.body.trim().length > 0 &&
+    typeof value.visualMood === "string" &&
+    value.visualMood.trim().length > 0
+  );
+}
+
+function isDiaryMetadata(value: unknown): value is DiaryDraftMetadata {
+  return (
+    isRecord(value) &&
+    typeof value.targetDate === "string" &&
+    typeof value.generatedAt === "string" &&
+    typeof value.activityLevel === "string" &&
+    typeof value.formatName === "string" &&
+    typeof value.storyFormatVoice === "string" &&
+    typeof value.storyFormatTone === "string" &&
+    Array.isArray(value.projectIds) &&
+    value.projectIds.every((projectId) => typeof projectId === "string") &&
+    value.entryMode === "daily_global" &&
+    Number.isInteger(value.slideCount)
+  );
+}
+
+function isHashtag(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    /^#[^\s#]+$/u.test(value.trim()) &&
+    value.trim().length > 1
+  );
+}
+
+function assertSlideCountForActivity(
+  draft: DiaryDraft,
+  activityLevel: ActivityLevel
+): void {
+  if (
+    draft.slides.length < minSlideCount ||
+    draft.slides.length > maxSlideCount
+  ) {
+    throwInvalidDiaryDraft();
+  }
+
+  if (
+    (activityLevel === "none" || activityLevel === "low") &&
+    draft.slides.length > quietMaxSlideCount
+  ) {
+    throwInvalidDiaryDraft();
+  }
+
+  const expectedIndexes = draft.slides.every(
+    (slide, index) => slide.index === index + 1
+  );
+
+  if (!expectedIndexes) {
+    throwInvalidDiaryDraft();
+  }
+}
+
+function assertQuietDayHonesty(
+  draft: DiaryDraft,
+  summary: ActivitySummary
+): void {
+  if (summary.activityLevel !== "none") {
+    return;
+  }
+
+  const text = collectDraftText(draft).join("\n");
+
+  if (
+    /\b(?:\d+\s+commits?|fixed|implemented|shipped|built|released|merged|debugged)\b/i.test(
+      text
+    )
+  ) {
+    throw new AiGenerationError(
+      "AI provider fabricated quiet-day activity.",
+      "malformed-response"
+    );
+  }
+}
+
+function assertSafeProviderData(value: JsonValue): void {
+  assertNoUnsafeKeys(value);
+  assertNoUnsafeStrings(value);
+}
+
+function assertNoUnsafeKeys(value: JsonValue): void {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      assertNoUnsafeKeys(item);
+    }
+    return;
+  }
+
+  if (!isRecord(value)) {
+    return;
+  }
+
+  for (const [key, child] of Object.entries(value)) {
+    if (isUnsafeKey(key)) {
+      throwUnsafeDiaryDraft();
+    }
+
+    if (!isJsonValue(child)) {
+      throwInvalidDiaryDraft();
+    }
+
+    assertNoUnsafeKeys(child);
+  }
+}
+
+function assertNoUnsafeStrings(value: JsonValue): void {
+  if (typeof value === "string") {
+    if (containsUnsafeText(value)) {
+      throwUnsafeDiaryDraft();
+    }
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      assertNoUnsafeStrings(item);
+    }
+    return;
+  }
+
+  if (isRecord(value)) {
+    for (const child of Object.values(value)) {
+      if (isJsonValue(child)) {
+        assertNoUnsafeStrings(child);
+      }
+    }
+  }
+}
+
+function collectDraftText(draft: DiaryDraft): string[] {
+  return [
+    draft.title,
+    draft.caption,
+    ...draft.slides.flatMap((slide) => [
+      slide.title,
+      slide.body,
+      slide.visualMood
+    ]),
+    ...draft.hashtags,
+    draft.altText
+  ];
+}
+
+function containsUnsafeText(value: string): boolean {
+  return (
+    /\bdiff --git\b/i.test(value) ||
+    /`[^`]+`/.test(value) ||
+    /\b[A-Z][A-Z0-9_]*(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD)\s*=\s*\S+/i.test(
+      value
+    ) ||
+    /\bBearer\s+[A-Za-z0-9._~+/=-]+/i.test(value) ||
+    /\bsk-[A-Za-z0-9_-]{8,}\b/.test(value) ||
+    /\b(?:https?|ssh|git):\/\/\S+|git@[\w.-]+:[^\s]+/.test(value) ||
+    /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i.test(value) ||
+    /(^|[\s(["'])\/[^\s)"']+/.test(value)
+  );
+}
+
+function isUnsafeKey(key: string): boolean {
+  return unsafeOutputKeys.has(key.toLowerCase().replace(/[-\s]/g, "_"));
+}
+
+function throwInvalidDiaryDraft(): never {
+  throw new AiGenerationError(
+    "AI provider returned invalid diary draft.",
+    "malformed-response"
+  );
+}
+
+function throwUnsafeDiaryDraft(): never {
+  throw new AiGenerationError(
+    "AI provider returned unsafe diary draft.",
+    "malformed-response"
+  );
+}
+
+function isJsonValue(value: unknown): value is JsonValue {
+  return (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    Array.isArray(value) ||
+    isJsonObject(value)
+  );
+}
+
+function isJsonObject(value: unknown): value is JsonObject {
+  if (!isRecord(value) || Array.isArray(value)) {
+    return false;
+  }
+
+  return Object.values(value).every(isJsonValue);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,16 @@ export type {
   StoryFormatPlanOptions,
   StoryFormatStructurePart
 } from "./story-format-plan.js";
+export {
+  deriveCaptionText,
+  generateDiaryDraft
+} from "./diary-generator.js";
+export type {
+  DiaryDraft,
+  DiaryDraftMetadata,
+  DiaryGeneratorOptions,
+  DiarySlide
+} from "./diary-generator.js";
 export { runInitCommand } from "./init-command.js";
 export type {
   InitAnswers,

--- a/tests/diary-generator.test.ts
+++ b/tests/diary-generator.test.ts
@@ -1,0 +1,436 @@
+import { describe, expect, it } from "vitest";
+import { AiGenerationError, MockAiProvider } from "../src/ai-provider.js";
+import type { ActivitySummary } from "../src/activity-summary.js";
+import {
+  deriveCaptionText,
+  generateDiaryDraft
+} from "../src/diary-generator.js";
+import type { StoryFormatPlan } from "../src/story-format-plan.js";
+
+describe("diary generator", () => {
+  it("returns a validated story draft and derives caption text", async () => {
+    const provider = new MockAiProvider({
+      response: createProviderDraft({
+        title: "Provider Boundary Day"
+      })
+    });
+    const summary = createActivitySummary();
+    const plan = createStoryFormatPlan({ suggestedSlideCount: 4 });
+
+    const draft = await generateDiaryDraft({
+      activitySummary: summary,
+      storyFormatPlan: plan,
+      provider,
+      persona: "wry coworker",
+      roastLevel: 2
+    });
+
+    expect(draft).toEqual({
+      schemaVersion: 1,
+      targetDate: "2026-05-12",
+      title: "Provider Boundary Day",
+      caption:
+        "오늘은 provider boundary를 세우고 검증까지 붙였다. 내일의 버그도 이제 입장권 검사가 필요하다.",
+      slides: [
+        {
+          index: 1,
+          title: "Opening statement",
+          body: "Provider validation work moved from vibes to typed boundaries.",
+          visualMood: "quiet terminal with warm contrast"
+        },
+        {
+          index: 2,
+          title: "Evidence",
+          body: "Two commits and one note kept the AI request shape honest.",
+          visualMood: "annotated checklist"
+        },
+        {
+          index: 3,
+          title: "Unfinished thread",
+          body: "One uncommitted file is still waiting for tomorrow's tiny ceremony.",
+          visualMood: "single highlighted file"
+        },
+        {
+          index: 4,
+          title: "Verdict",
+          body: "The mock provider behaved, which is suspicious but welcome.",
+          visualMood: "rubber stamp on terminal"
+        }
+      ],
+      hashtags: ["#Uncommitted", "#개발일기", "#AI동료"],
+      altText:
+        "AI coworker diary carousel about provider validation work in Uncommitted.",
+      metadata: {
+        targetDate: "2026-05-12",
+        generatedAt: "2026-05-12T23:30:00.000Z",
+        activityLevel: "medium",
+        formatName: "Bug Court Transcript",
+        storyFormatVoice: "tired QA narrator",
+        storyFormatTone: "deadpan, witty, affectionate",
+        projectIds: ["uncommitted"],
+        entryMode: "daily_global",
+        slideCount: 4
+      }
+    });
+    expect(deriveCaptionText(draft)).toBe(
+      "오늘은 provider boundary를 세우고 검증까지 붙였다. 내일의 버그도 이제 입장권 검사가 필요하다.\n\n#Uncommitted #개발일기 #AI동료\n"
+    );
+    expect(provider.requests).toHaveLength(1);
+    expect(provider.requests[0]).toMatchObject({
+      schemaVersion: 1,
+      task: "draft",
+      input: {
+        schemaVersion: 1,
+        targetDate: "2026-05-12",
+        quiet: false,
+        overview: "medium coding day with 1 project.",
+        entryMode: "daily_global",
+        persona: "wry coworker",
+        storyFormatPlan: {
+          formatName: "Bug Court Transcript",
+          suggestedSlideCount: 4
+        },
+        roastPolicy: {
+          roastLevel: 2,
+          allowDirectUserRoast: false
+        }
+      }
+    });
+    expect(provider.requests[0]?.instructions).toContain(
+      "Return structured JSON for story.json"
+    );
+    expect(provider.requests[0]?.instructions).toContain(
+      "Caption must be copyable as an Instagram caption"
+    );
+    expect(provider.requests[0]?.instructions).toContain("Do not invent work");
+  });
+
+  it("generates a quiet-day request without fabricating activity", async () => {
+    const provider = new MockAiProvider({
+      response: createProviderDraft({
+        title: "Quiet Terminal Watch",
+        caption:
+          "오늘은 Git이 조용했다. 나는 평화라고 믿어보기로 했지만, TODO는 커튼 뒤에서 숨을 참고 있었다.",
+        slides: [
+          {
+            index: 1,
+            title: "조용한 시작",
+            body: "기록된 Git activity나 manual note가 없었다.",
+            visualMood: "still terminal"
+          },
+          {
+            index: 2,
+            title: "AI의 대기",
+            body: "없는 성과를 만들지 않고 조용한 하루를 그대로 적었다.",
+            visualMood: "waiting cursor"
+          },
+          {
+            index: 3,
+            title: "내일의 관찰",
+            body: "TODO가 자라났다고 단정하지 않고, 그냥 지켜보기로 했다.",
+            visualMood: "small note on desk"
+          }
+        ],
+        altText: "Quiet-day AI coworker diary carousel with no recorded work."
+      })
+    });
+
+    const draft = await generateDiaryDraft({
+      activitySummary: createActivitySummary({
+        activityLevel: "none",
+        dominantTheme: "quiet",
+        projects: [],
+        commitSignals: {
+          totalCommits: 0,
+          filesChanged: 0,
+          insertions: 0,
+          deletions: 0,
+          subjects: [],
+          themes: []
+        },
+        uncommittedChanges: {
+          totalFiles: 0,
+          byStatus: {
+            modified: 0,
+            added: 0,
+            deleted: 0,
+            renamed: 0,
+            copied: 0,
+            untracked: 0,
+            other: 0
+          },
+          files: []
+        },
+        manualContext: {
+          noteCount: 0,
+          notes: []
+        },
+        smallWins: [],
+        blockersOrConfusion: [],
+        unfinishedThreads: [],
+        possibleJokes: [
+          "Quiet day, but the draft still has to admit nothing exploded."
+        ],
+        uncertaintyNotes: [
+          "No Git activity or manual notes were found for 2026-05-12."
+        ]
+      }),
+      storyFormatPlan: createStoryFormatPlan({
+        formatName: "Quiet Terminal Watch",
+        reason: "No recorded work was available.",
+        suggestedSlideCount: 3
+      }),
+      provider,
+      persona: "slightly tired coworker",
+      roastLevel: 4
+    });
+
+    expect(draft.slides).toHaveLength(3);
+    expect(draft.metadata.activityLevel).toBe("none");
+    expect(provider.requests[0]?.input.quiet).toBe(true);
+    expect(provider.requests[0]?.input.highlights).toContain(
+      "No recorded Git activity or manual notes; keep the draft honest."
+    );
+    expect(provider.requests[0]?.instructions).toContain(
+      "For quiet days, acknowledge no recorded work"
+    );
+  });
+
+  it("rejects malformed provider output", async () => {
+    await expect(
+      generateDiaryDraft({
+        activitySummary: createActivitySummary(),
+        storyFormatPlan: createStoryFormatPlan(),
+        provider: new MockAiProvider({
+          response: {
+            title: "Missing slides"
+          }
+        }),
+        persona: "wry coworker",
+        roastLevel: 2
+      })
+    ).rejects.toMatchObject({
+      code: "malformed-response",
+      exitCode: 4,
+      message: "AI provider returned invalid diary draft."
+    });
+
+    await expect(
+      generateDiaryDraft({
+        activitySummary: createActivitySummary(),
+        storyFormatPlan: createStoryFormatPlan(),
+        provider: new MockAiProvider({
+          response: createProviderDraft({
+            slides: createProviderDraft().slides.slice(0, 2)
+          })
+        }),
+        persona: "wry coworker",
+        roastLevel: 2
+      })
+    ).rejects.toBeInstanceOf(AiGenerationError);
+  });
+
+  it("rejects unsafe or fabricated provider output where feasible", async () => {
+    await expect(
+      generateDiaryDraft({
+        activitySummary: createActivitySummary(),
+        storyFormatPlan: createStoryFormatPlan(),
+        provider: new MockAiProvider({
+          response: createProviderDraft({
+            caption:
+              "오늘은 /Users/dev/private/.env 에서 OPENAI_API_KEY=sk-live-secret123 를 확인했다."
+          })
+        }),
+        persona: "wry coworker",
+        roastLevel: 2
+      })
+    ).rejects.toMatchObject({
+      code: "malformed-response",
+      message: "AI provider returned unsafe diary draft."
+    });
+
+    await expect(
+      generateDiaryDraft({
+        activitySummary: createActivitySummary({
+          activityLevel: "none",
+          dominantTheme: "quiet",
+          projects: [],
+          commitSignals: {
+            totalCommits: 0,
+            filesChanged: 0,
+            insertions: 0,
+            deletions: 0,
+            subjects: [],
+            themes: []
+          },
+          smallWins: [],
+          unfinishedThreads: []
+        }),
+        storyFormatPlan: createStoryFormatPlan({
+          formatName: "Quiet Terminal Watch",
+          suggestedSlideCount: 3
+        }),
+        provider: new MockAiProvider({
+          response: createProviderDraft({
+            caption: "오늘은 인증 기능을 shipped 하고 버그도 fixed 했다.",
+            slides: createProviderDraft().slides.slice(0, 3)
+          })
+        }),
+        persona: "wry coworker",
+        roastLevel: 2
+      })
+    ).rejects.toMatchObject({
+      code: "malformed-response",
+      message: "AI provider fabricated quiet-day activity."
+    });
+  });
+});
+
+function createProviderDraft(
+  overrides: Partial<ReturnType<typeof baseProviderDraft>> = {}
+): ReturnType<typeof baseProviderDraft> {
+  return {
+    ...baseProviderDraft(),
+    ...overrides
+  };
+}
+
+function baseProviderDraft() {
+  return {
+    title: "Bug Court Transcript",
+    caption:
+      "오늘은 provider boundary를 세우고 검증까지 붙였다. 내일의 버그도 이제 입장권 검사가 필요하다.",
+    slides: [
+      {
+        index: 1,
+        title: "Opening statement",
+        body: "Provider validation work moved from vibes to typed boundaries.",
+        visualMood: "quiet terminal with warm contrast"
+      },
+      {
+        index: 2,
+        title: "Evidence",
+        body: "Two commits and one note kept the AI request shape honest.",
+        visualMood: "annotated checklist"
+      },
+      {
+        index: 3,
+        title: "Unfinished thread",
+        body: "One uncommitted file is still waiting for tomorrow's tiny ceremony.",
+        visualMood: "single highlighted file"
+      },
+      {
+        index: 4,
+        title: "Verdict",
+        body: "The mock provider behaved, which is suspicious but welcome.",
+        visualMood: "rubber stamp on terminal"
+      }
+    ],
+    hashtags: ["#Uncommitted", "#개발일기", "#AI동료"],
+    altText:
+      "AI coworker diary carousel about provider validation work in Uncommitted."
+  };
+}
+
+function createStoryFormatPlan(
+  overrides: Partial<StoryFormatPlan> = {}
+): StoryFormatPlan {
+  return {
+    schemaVersion: 1,
+    formatName: "Bug Court Transcript",
+    voice: "tired QA narrator",
+    tone: "deadpan, witty, affectionate",
+    reason: "The day had enough debugging evidence for a courtroom bit.",
+    structure: [
+      {
+        part: "Opening statement",
+        purpose: "Introduce the actual debugging work."
+      },
+      {
+        part: "Evidence",
+        purpose: "Mention real commits and blockers only."
+      },
+      {
+        part: "Verdict",
+        purpose: "Close with a light situation joke."
+      }
+    ],
+    suggestedSlideCount: 4,
+    captionStyle: "short witty caption",
+    doNotMention: ["raw diffs", "private paths"],
+    ...overrides
+  };
+}
+
+function createActivitySummary(
+  overrides: Partial<ActivitySummary> = {}
+): ActivitySummary {
+  return {
+    schemaVersion: 1,
+    targetDate: "2026-05-12",
+    generatedAt: "2026-05-12T23:30:00.000Z",
+    activityLevel: "medium",
+    dominantTheme: "coding",
+    projects: [
+      {
+        projectId: "uncommitted",
+        projectName: "uncommitted",
+        repositoryName: "uncommitted",
+        commitCount: 2,
+        filesChanged: 4,
+        insertions: 120,
+        deletions: 18,
+        uncommittedChangeCount: 1,
+        manualNoteCount: 1,
+        themes: ["coding"],
+        summary: "2 commits, 1 manual note, 1 uncommitted file"
+      }
+    ],
+    commitSignals: {
+      totalCommits: 2,
+      filesChanged: 4,
+      insertions: 120,
+      deletions: 18,
+      subjects: ["implement provider validation"],
+      themes: ["coding"]
+    },
+    uncommittedChanges: {
+      totalFiles: 1,
+      byStatus: {
+        modified: 1,
+        added: 0,
+        deleted: 0,
+        renamed: 0,
+        copied: 0,
+        untracked: 0,
+        other: 0
+      },
+      files: [
+        {
+          projectId: "uncommitted",
+          projectName: "uncommitted",
+          path: "src/ai-provider.ts",
+          status: "modified"
+        }
+      ]
+    },
+    manualContext: {
+      noteCount: 1,
+      notes: [
+        {
+          projectId: "uncommitted",
+          timestamp: "2026-05-12T15:00:00.000Z",
+          text: "Need to keep story plans structured."
+        }
+      ]
+    },
+    smallWins: ["Implemented provider validation."],
+    blockersOrConfusion: [],
+    unfinishedThreads: ["1 uncommitted file remains in uncommitted."],
+    possibleJokes: ["The working tree kept a few tabs open for tomorrow."],
+    publicSafetyNotes: ["Summary excludes raw diffs and raw code."],
+    privateItemsToAvoid: ["raw code snippets"],
+    uncertaintyNotes: [],
+    ...overrides
+  };
+}

--- a/tests/diary-generator.test.ts
+++ b/tests/diary-generator.test.ts
@@ -196,6 +196,41 @@ describe("diary generator", () => {
     );
   });
 
+  it("accepts low-activity drafts within the MVP slide range", async () => {
+    const provider = new MockAiProvider({
+      response: createProviderDraft({
+        slides: createSlides(6)
+      })
+    });
+
+    const draft = await generateDiaryDraft({
+      activitySummary: createActivitySummary({
+        activityLevel: "low",
+        commitSignals: {
+          totalCommits: 1,
+          filesChanged: 1,
+          insertions: 12,
+          deletions: 2,
+          subjects: ["adjust caption prompt"],
+          themes: ["coding"]
+        }
+      }),
+      storyFormatPlan: createStoryFormatPlan({ suggestedSlideCount: 6 }),
+      provider,
+      persona: "wry coworker",
+      roastLevel: 2
+    });
+
+    expect(draft.slides).toHaveLength(6);
+    expect(draft.metadata.slideCount).toBe(6);
+    expect(provider.requests[0]?.instructions).toContain(
+      "Prefer 3-5 slides for quiet or low activity days"
+    );
+    expect(provider.requests[0]?.instructions).toContain(
+      "guidance, not a hard validation limit"
+    );
+  });
+
   it("rejects malformed provider output", async () => {
     await expect(
       generateDiaryDraft({
@@ -330,6 +365,15 @@ function baseProviderDraft() {
     altText:
       "AI coworker diary carousel about provider validation work in Uncommitted."
   };
+}
+
+function createSlides(count: number): ReturnType<typeof baseProviderDraft>["slides"] {
+  return Array.from({ length: count }, (_, index) => ({
+    index: index + 1,
+    title: `Slide ${index + 1}`,
+    body: `Low activity draft beat ${index + 1}.`,
+    visualMood: "quiet checklist"
+  }));
 }
 
 function createStoryFormatPlan(


### PR DESCRIPTION
# Goal

Implement the Diary Generator step for issue #25. It turns an Activity Summary plus Story Format Plan into validated text draft artifacts for story.json and caption.txt.

## Related Issue

Closes #25.

## Acceptance Criteria

- [x] Diary Generator produces a validated story.json object from an Activity Summary and Story Format Plan
- [x] caption.txt content can be derived from the generated draft
- [x] Generated slides stay within the MVP expected range for text drafts
- [x] Quiet-day input does not fabricate commits, bugs, features, or user activity
- [x] Generated output avoids raw code, raw diffs, secrets, private paths, emails, private URLs, and private remote URLs
- [x] Roast/tone constraints are included and prevent attacks on identity, ability, appearance, mental health, personal value, or real life
- [x] Unit tests cover successful generation, quiet-day generation, invalid provider output, and unsafe/fabricated response rejection where feasible

## Implementation Notes

- Added src/diary-generator.ts with DiaryDraft types, generateDiaryDraft, and deriveCaptionText.
- The generator uses the existing AI provider abstraction with the draft task and builds safe provider input from ActivitySummary and StoryFormatPlan.
- Provider output is validated for required story fields, slide count limits, sequential slide indexes, hashtag shape, sensitive output patterns, and quiet-day fabrication signals.
- Exported the new generator API from src/index.ts.

## Validation

- pnpm test
- pnpm lint
- pnpm typecheck
- pnpm build
- git diff --check

## Remaining Risk

Live provider behavior is not exercised in this issue; the implementation is validated with the mock provider and schema/safety guards.
