### PR TITLE
feat: implement generate today text draft workflow

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -128,7 +128,11 @@ async function runGenerate(
   } catch (error) {
     if (error instanceof GenerateCommandError) {
       io.stderr(error.message);
-      return error.code === "invalid-arguments" ? 1 : 2;
+      if (error.code === "invalid-arguments") {
+        return 1;
+      }
+
+      return error.code === "invalid-data" ? 3 : 2;
     }
 
     if (error instanceof AiGenerationError) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,8 +7,13 @@ import {
   collectGitForRegisteredProjects,
   CollectGitCommandError
 } from "./collect-git-command.js";
+import { AiGenerationError, type AiProvider } from "./ai-provider.js";
 import { commands, isKnownCommand } from "./commands.js";
 import { formatDoctorReport, runDoctorCommand } from "./doctor-command.js";
+import {
+  GenerateCommandError,
+  runGenerateCommand
+} from "./generate-command.js";
 import { runInitCommand } from "./init-command.js";
 import {
   listManualNotes,
@@ -27,6 +32,7 @@ export type CliOptions = {
   cwd?: string;
   homeDir?: string;
   now?: () => string;
+  aiProvider?: AiProvider;
 };
 
 const defaultIo: CliIo = {
@@ -101,8 +107,37 @@ export async function runCli(
     return await runCollect(commandArgs, io, options);
   }
 
+  if (command === "generate") {
+    return await runGenerate(commandArgs, io, options);
+  }
+
   io.stderr(`Command not implemented yet: ${command}`);
   return 1;
+}
+
+async function runGenerate(
+  args: string[],
+  io: CliIo,
+  options: CliOptions
+): Promise<number> {
+  try {
+    const result = await runGenerateCommand(args, options);
+
+    io.stdout(`Generated text draft for ${result.targetDate}.`);
+    return 0;
+  } catch (error) {
+    if (error instanceof GenerateCommandError) {
+      io.stderr(error.message);
+      return error.code === "invalid-arguments" ? 1 : 2;
+    }
+
+    if (error instanceof AiGenerationError) {
+      io.stderr(error.message);
+      return 4;
+    }
+
+    throw error;
+  }
 }
 
 async function runCollect(

--- a/src/generate-command.ts
+++ b/src/generate-command.ts
@@ -1,0 +1,449 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  buildActivitySummary,
+  type ActivitySummary
+} from "./activity-summary.js";
+import {
+  createAiProvider,
+  type AiProvider,
+  type AiProviderConfig,
+  type AiProviderName
+} from "./ai-provider.js";
+import type { GitActivityEvent } from "./collect-git-command.js";
+import { resolveConfigPaths } from "./config-paths.js";
+import {
+  deriveCaptionText,
+  generateDiaryDraft,
+  type DiaryDraft
+} from "./diary-generator.js";
+import type { ManualNoteEvent } from "./note-command.js";
+import type { ProjectRecord, ProjectsFile } from "./project-add.js";
+import {
+  generateStoryFormatPlan,
+  loadRecentStoryFormatHistory,
+  type StoryFormatPlan
+} from "./story-format-plan.js";
+
+export type GenerateCommandErrorCode =
+  | "invalid-arguments"
+  | "invalid-config"
+  | "invalid-data"
+  | "no-projects";
+
+export class GenerateCommandError extends Error {
+  constructor(
+    message: string,
+    public readonly code: GenerateCommandErrorCode
+  ) {
+    super(message);
+    this.name = "GenerateCommandError";
+  }
+}
+
+export type GenerateCommandOptions = {
+  homeDir?: string;
+  now?: () => string;
+  aiProvider?: AiProvider;
+};
+
+export type GenerateCommandResult = {
+  targetDate: string;
+  outputDir: string;
+  activitySummary: ActivitySummary;
+  storyFormatPlan: StoryFormatPlan;
+  draft: DiaryDraft;
+  caption: string;
+};
+
+type GenerateConfig = AiProviderConfig & {
+  draftRoot: string;
+};
+
+type GenerateConfigFile = {
+  schemaVersion: 1;
+  draftRoot: string;
+  aiProvider: AiProviderName;
+  persona: string;
+  roastLevel: number;
+};
+
+type DraftMetadata = {
+  schemaVersion: 1;
+  artifactVersion: 1;
+  targetDate: string;
+  generatedAt: string;
+  provider: AiProviderName;
+  activityLevel: ActivitySummary["activityLevel"];
+  storyFormat: {
+    formatName: string;
+    voice: string;
+    tone: string;
+  };
+  projectIds: string[];
+  files: string[];
+};
+
+const usage = "Usage: uncommitted generate today | uncommitted generate --date YYYY-MM-DD";
+const providerNames: readonly AiProviderName[] = [
+  "none",
+  "mock",
+  "openai",
+  "anthropic",
+  "google",
+  "ollama",
+  "mistral",
+  "openrouter"
+];
+
+export async function runGenerateCommand(
+  args: string[],
+  options: GenerateCommandOptions = {}
+): Promise<GenerateCommandResult> {
+  const targetDate = parseGenerateDate(args, options.now);
+  const paths = resolveConfigPaths({ homeDir: options.homeDir });
+  const config = await readGenerateConfig(paths.configFile);
+  const projectsFile = await readProjectsFile(paths.projectsFile);
+  const projects = projectsFile.projects.filter((project) => project.enabled);
+
+  if (projects.length === 0) {
+    throw new GenerateCommandError(
+      "No registered projects. Run `uncommitted project add .` first.",
+      "no-projects"
+    );
+  }
+
+  const generatedAt = options.now ? options.now() : new Date().toISOString();
+  const outputDir = join(config.draftRoot, targetDate, "rev-001");
+  const gitEvents = await readGitActivityEvents(projects, targetDate);
+  const manualNotes = await readManualNoteEvents(projects, targetDate);
+  const activitySummary = buildActivitySummary({
+    targetDate,
+    generatedAt,
+    gitEvents,
+    manualNotes
+  });
+
+  await mkdir(outputDir, { recursive: true });
+  await writeJson(join(outputDir, "activity-summary.json"), activitySummary);
+
+  const provider = options.aiProvider ?? createAiProvider(config);
+  const recentFormats = await loadRecentStoryFormatHistory({
+    homeDir: options.homeDir
+  });
+  const storyFormatPlan = await generateStoryFormatPlan({
+    activitySummary,
+    provider,
+    persona: config.persona,
+    roastLevel: config.roastLevel,
+    recentFormats
+  });
+  const draft = await generateDiaryDraft({
+    activitySummary,
+    storyFormatPlan,
+    provider,
+    persona: config.persona,
+    roastLevel: config.roastLevel
+  });
+  const caption = deriveCaptionText(draft);
+  const metadata: DraftMetadata = {
+    schemaVersion: 1,
+    artifactVersion: 1,
+    targetDate,
+    generatedAt,
+    provider: provider.name,
+    activityLevel: activitySummary.activityLevel,
+    storyFormat: {
+      formatName: storyFormatPlan.formatName,
+      voice: storyFormatPlan.voice,
+      tone: storyFormatPlan.tone
+    },
+    projectIds: activitySummary.projects.map((project) => project.projectId),
+    files: ["activity-summary.json", "story.json", "caption.txt", "metadata.json"]
+  };
+
+  await writeJson(join(outputDir, "story.json"), draft);
+  await writeFile(join(outputDir, "caption.txt"), caption, "utf8");
+  await writeJson(join(outputDir, "metadata.json"), metadata);
+
+  return {
+    targetDate,
+    outputDir,
+    activitySummary,
+    storyFormatPlan,
+    draft,
+    caption
+  };
+}
+
+function parseGenerateDate(
+  args: string[],
+  now: (() => string) | undefined
+): string {
+  if (args.length === 1 && args[0] === "today") {
+    return (now ? now() : new Date().toISOString()).slice(0, 10);
+  }
+
+  if (args.length === 2 && args[0] === "--date") {
+    const targetDate = args[1];
+
+    if (!isValidDateString(targetDate)) {
+      throw new GenerateCommandError(
+        "Date must use YYYY-MM-DD format.",
+        "invalid-arguments"
+      );
+    }
+
+    return targetDate;
+  }
+
+  throw new GenerateCommandError(usage, "invalid-arguments");
+}
+
+function isValidDateString(value: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return false;
+  }
+
+  const date = new Date(`${value}T00:00:00.000Z`);
+
+  return !Number.isNaN(date.getTime()) && date.toISOString().slice(0, 10) === value;
+}
+
+async function readGenerateConfig(path: string): Promise<GenerateConfig> {
+  try {
+    const parsed = JSON.parse(await readFile(path, "utf8")) as unknown;
+
+    if (!isGenerateConfigFile(parsed)) {
+      throw new GenerateCommandError("AI config is invalid.", "invalid-config");
+    }
+
+    return {
+      draftRoot: parsed.draftRoot,
+      provider: parsed.aiProvider,
+      persona: parsed.persona,
+      roastLevel: parsed.roastLevel
+    };
+  } catch (error) {
+    if (error instanceof GenerateCommandError) {
+      throw error;
+    }
+
+    if (isNodeError(error) && error.code === "ENOENT") {
+      throw new GenerateCommandError(
+        "AI config is missing. Run `uncommitted init` first.",
+        "invalid-config"
+      );
+    }
+
+    throw new GenerateCommandError("AI config is invalid.", "invalid-config");
+  }
+}
+
+async function readProjectsFile(path: string): Promise<ProjectsFile> {
+  try {
+    const parsed = JSON.parse(await readFile(path, "utf8")) as unknown;
+
+    if (isProjectsFile(parsed)) {
+      return parsed;
+    }
+
+    throw new GenerateCommandError("Invalid projects file.", "invalid-config");
+  } catch (error) {
+    if (error instanceof GenerateCommandError) {
+      throw error;
+    }
+
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return { schemaVersion: 1, projects: [] };
+    }
+
+    throw new GenerateCommandError("Invalid projects file.", "invalid-config");
+  }
+}
+
+async function readGitActivityEvents(
+  projects: ProjectRecord[],
+  targetDate: string
+): Promise<GitActivityEvent[]> {
+  const events: GitActivityEvent[] = [];
+
+  for (const project of projects) {
+    const event = await readOptionalJson(
+      join(project.root, ".uncommitted", "events", "git", `${targetDate}.json`)
+    );
+
+    if (event === undefined) {
+      continue;
+    }
+
+    if (!isGitActivityEvent(event)) {
+      throw new GenerateCommandError(
+        "Stored Git activity is malformed. Re-run `uncommitted collect git`.",
+        "invalid-data"
+      );
+    }
+
+    events.push(event);
+  }
+
+  return events;
+}
+
+async function readManualNoteEvents(
+  projects: ProjectRecord[],
+  targetDate: string
+): Promise<ManualNoteEvent[]> {
+  const notes: ManualNoteEvent[] = [];
+
+  for (const project of projects) {
+    const content = await readOptionalText(
+      join(project.root, ".uncommitted", "events", "manual", `${targetDate}.jsonl`)
+    );
+
+    if (content === undefined) {
+      continue;
+    }
+
+    for (const line of content.split("\n")) {
+      if (!line.trim()) {
+        continue;
+      }
+
+      try {
+        const parsed = JSON.parse(line) as unknown;
+
+        if (!isManualNoteEvent(parsed)) {
+          throw new Error("Invalid manual note.");
+        }
+
+        notes.push(parsed);
+      } catch {
+        throw new GenerateCommandError(
+          "Stored manual notes are malformed. Fix or remove the invalid note data.",
+          "invalid-data"
+        );
+      }
+    }
+  }
+
+  return notes;
+}
+
+async function readOptionalJson(path: string): Promise<unknown | undefined> {
+  const content = await readOptionalText(path);
+
+  if (content === undefined) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(content) as unknown;
+  } catch {
+    throw new GenerateCommandError(
+      "Stored Git activity is malformed. Re-run `uncommitted collect git`.",
+      "invalid-data"
+    );
+  }
+}
+
+async function readOptionalText(path: string): Promise<string | undefined> {
+  try {
+    return await readFile(path, "utf8");
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return undefined;
+    }
+
+    throw new GenerateCommandError(
+      "Could not read stored activity data.",
+      "invalid-data"
+    );
+  }
+}
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function isGenerateConfigFile(value: unknown): value is GenerateConfigFile {
+  return (
+    isRecord(value) &&
+    value.schemaVersion === 1 &&
+    typeof value.draftRoot === "string" &&
+    isAiProviderName(value.aiProvider) &&
+    typeof value.persona === "string" &&
+    typeof value.roastLevel === "number" &&
+    Number.isInteger(value.roastLevel) &&
+    value.roastLevel >= 0 &&
+    value.roastLevel <= 5
+  );
+}
+
+function isProjectsFile(value: unknown): value is ProjectsFile {
+  if (!isRecord(value) || value.schemaVersion !== 1 || !Array.isArray(value.projects)) {
+    return false;
+  }
+
+  return value.projects.every(isProjectRecord);
+}
+
+function isProjectRecord(value: unknown): value is ProjectRecord {
+  return (
+    isRecord(value) &&
+    value.schemaVersion === 1 &&
+    typeof value.id === "string" &&
+    typeof value.name === "string" &&
+    typeof value.root === "string" &&
+    typeof value.gitRoot === "string" &&
+    typeof value.enabled === "boolean" &&
+    typeof value.createdAt === "string"
+  );
+}
+
+function isGitActivityEvent(value: unknown): value is GitActivityEvent {
+  return (
+    isRecord(value) &&
+    value.schemaVersion === 1 &&
+    value.source === "git" &&
+    typeof value.targetDate === "string" &&
+    typeof value.collectedAt === "string" &&
+    isRecord(value.project) &&
+    typeof value.project.id === "string" &&
+    typeof value.project.name === "string" &&
+    isRecord(value.activity) &&
+    value.activity.schemaVersion === 1 &&
+    typeof value.activity.targetDate === "string" &&
+    Array.isArray(value.activity.commits) &&
+    isRecord(value.activity.dirty) &&
+    Array.isArray(value.activity.dirty.files)
+  );
+}
+
+function isManualNoteEvent(value: unknown): value is ManualNoteEvent {
+  return (
+    isRecord(value) &&
+    value.schemaVersion === 1 &&
+    typeof value.id === "string" &&
+    typeof value.timestamp === "string" &&
+    typeof value.date === "string" &&
+    typeof value.projectId === "string" &&
+    typeof value.text === "string" &&
+    value.source === "manual"
+  );
+}
+
+function isAiProviderName(value: unknown): value is AiProviderName {
+  return (
+    typeof value === "string" &&
+    providerNames.includes(value as AiProviderName)
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}

--- a/src/generate-command.ts
+++ b/src/generate-command.ts
@@ -95,6 +95,15 @@ const providerNames: readonly AiProviderName[] = [
   "mistral",
   "openrouter"
 ];
+const dirtyStatuses = new Set([
+  "modified",
+  "added",
+  "deleted",
+  "renamed",
+  "copied",
+  "untracked",
+  "other"
+]);
 
 export async function runGenerateCommand(
   args: string[],
@@ -414,10 +423,62 @@ function isGitActivityEvent(value: unknown): value is GitActivityEvent {
     isRecord(value.activity) &&
     value.activity.schemaVersion === 1 &&
     typeof value.activity.targetDate === "string" &&
+    isRecord(value.activity.repository) &&
+    typeof value.activity.repository.rootName === "string" &&
     Array.isArray(value.activity.commits) &&
+    value.activity.commits.every(isGitActivityCommit) &&
+    isRecord(value.activity.totals) &&
+    isGitActivityStats(value.activity.totals) &&
+    isFiniteNumber(value.activity.totals.commits) &&
     isRecord(value.activity.dirty) &&
-    Array.isArray(value.activity.dirty.files)
+    Array.isArray(value.activity.dirty.files) &&
+    value.activity.dirty.files.every(isDirtyFileSummary) &&
+    isRecord(value.activity.dirty.totals) &&
+    isDirtyStatusTotals(value.activity.dirty.totals)
   );
+}
+
+function isGitActivityCommit(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    typeof value.hash === "string" &&
+    typeof value.shortHash === "string" &&
+    typeof value.authorName === "string" &&
+    typeof value.authoredAt === "string" &&
+    typeof value.subject === "string" &&
+    isRecord(value.stats) &&
+    isGitActivityStats(value.stats)
+  );
+}
+
+function isGitActivityStats(value: Record<string, unknown>): boolean {
+  return (
+    isFiniteNumber(value.filesChanged) &&
+    isFiniteNumber(value.insertions) &&
+    isFiniteNumber(value.deletions)
+  );
+}
+
+function isDirtyFileSummary(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    typeof value.path === "string" &&
+    isDirtyStatus(value.status)
+  );
+}
+
+function isDirtyStatusTotals(value: Record<string, unknown>): boolean {
+  return Array.from(dirtyStatuses).every((status) =>
+    isFiniteNumber(value[status])
+  );
+}
+
+function isDirtyStatus(value: unknown): boolean {
+  return typeof value === "string" && dirtyStatuses.has(value);
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
 }
 
 function isManualNoteEvent(value: unknown): value is ManualNoteEvent {

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,6 +94,15 @@ export type {
   DiaryGeneratorOptions,
   DiarySlide
 } from "./diary-generator.js";
+export {
+  GenerateCommandError,
+  runGenerateCommand
+} from "./generate-command.js";
+export type {
+  GenerateCommandErrorCode,
+  GenerateCommandOptions,
+  GenerateCommandResult
+} from "./generate-command.js";
 export { runInitCommand } from "./init-command.js";
 export type {
   InitAnswers,

--- a/tests/generate-command.test.ts
+++ b/tests/generate-command.test.ts
@@ -1,0 +1,448 @@
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+import type {
+  AiProvider,
+  AiProviderRawResponse,
+  AiStructuredGenerationRequest
+} from "../src/ai-provider.js";
+import { runCli } from "../src/cli.js";
+import type { GitActivityEvent } from "../src/collect-git-command.js";
+import type { DiaryDraft } from "../src/diary-generator.js";
+import { addProject, type ProjectRecord } from "../src/project-add.js";
+import type { StoryFormatPlan } from "../src/story-format-plan.js";
+
+const execFileAsync = promisify(execFile);
+
+function createIo() {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+
+  return {
+    io: {
+      stdout: (message: string) => stdout.push(message),
+      stderr: (message: string) => stderr.push(message)
+    },
+    stdout,
+    stderr
+  };
+}
+
+describe("generate command", () => {
+  it("generates today's text draft from collected Git activity and manual notes", async () => {
+    const { io, stdout, stderr } = createIo();
+    const fixture = await createRegisteredProjectFixture();
+    const provider = new TaskAwareProvider();
+
+    await writeGitEvent(fixture.project, "2026-05-12");
+    await writeManualNote(fixture.project, "2026-05-12");
+
+    const exitCode = await runCli(["generate", "today"], io, {
+      homeDir: fixture.homeDir,
+      now: () => "2026-05-12T23:30:00.000Z",
+      aiProvider: provider
+    });
+    const outputDir = join(fixture.draftRoot, "2026-05-12", "rev-001");
+    const activitySummary = await readJson(join(outputDir, "activity-summary.json"));
+    const story = await readJson(join(outputDir, "story.json"));
+    const caption = await readFile(join(outputDir, "caption.txt"), "utf8");
+    const metadata = await readJson(join(outputDir, "metadata.json"));
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toEqual([]);
+    expect(stdout).toEqual(["Generated text draft for 2026-05-12."]);
+    expect(provider.requests.map((request) => request.task)).toEqual([
+      "story-plan",
+      "draft"
+    ]);
+    expect(activitySummary).toMatchObject({
+      schemaVersion: 1,
+      targetDate: "2026-05-12",
+      activityLevel: "medium",
+      commitSignals: {
+        totalCommits: 1,
+        subjects: ["implement generate command"]
+      },
+      manualContext: {
+        noteCount: 1
+      }
+    });
+    expect(story).toMatchObject({
+      schemaVersion: 1,
+      targetDate: "2026-05-12",
+      title: "Generate Command Day"
+    });
+    expect(caption).toBe(
+      "오늘은 generate command를 텍스트 draft까지 연결했다.\n\n#Uncommitted #개발일기\n"
+    );
+    expect(metadata).toMatchObject({
+      schemaVersion: 1,
+      targetDate: "2026-05-12",
+      artifactVersion: 1,
+      provider: "mock",
+      files: ["activity-summary.json", "story.json", "caption.txt", "metadata.json"]
+    });
+    expect(JSON.stringify({ activitySummary, story, metadata })).not.toContain(
+      fixture.repoDir
+    );
+  });
+
+  it("supports --date and generates an honest quiet-day text draft", async () => {
+    const { io, stdout, stderr } = createIo();
+    const fixture = await createRegisteredProjectFixture();
+    const provider = new TaskAwareProvider({
+      draft: createProviderDraft({
+        title: "Quiet Terminal Watch",
+        caption: "오늘은 기록된 작업이 없었다. 없는 성과는 만들지 않았다.",
+        slides: [
+          {
+            index: 1,
+            title: "조용한 시작",
+            body: "기록된 Git activity나 manual note가 없었다.",
+            visualMood: "still terminal"
+          },
+          {
+            index: 2,
+            title: "대기",
+            body: "없는 작업을 invent하지 않고 조용한 하루를 적었다.",
+            visualMood: "waiting cursor"
+          },
+          {
+            index: 3,
+            title: "마무리",
+            body: "내일의 기록을 기다리는 쪽으로 닫았다.",
+            visualMood: "small note"
+          }
+        ],
+        altText: "Quiet-day Uncommitted draft with no recorded work."
+      })
+    });
+
+    const exitCode = await runCli(["generate", "--date", "2026-05-11"], io, {
+      homeDir: fixture.homeDir,
+      now: () => "2026-05-12T23:30:00.000Z",
+      aiProvider: provider
+    });
+    const outputDir = join(fixture.draftRoot, "2026-05-11", "rev-001");
+    const activitySummary = await readJson(join(outputDir, "activity-summary.json"));
+    const story = await readJson(join(outputDir, "story.json"));
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toEqual([]);
+    expect(stdout).toEqual(["Generated text draft for 2026-05-11."]);
+    expect(activitySummary).toMatchObject({
+      targetDate: "2026-05-11",
+      activityLevel: "none",
+      dominantTheme: "quiet",
+      projects: []
+    });
+    expect(story).toMatchObject({
+      targetDate: "2026-05-11",
+      title: "Quiet Terminal Watch"
+    });
+    expect(provider.requests[0]?.input.quiet).toBe(true);
+  });
+
+  it("returns a config error when no projects are registered", async () => {
+    const { io, stdout, stderr } = createIo();
+    const directory = await mkdtemp(join(tmpdir(), "uncommitted-generate-empty-"));
+    const homeDir = join(directory, "home");
+
+    await writeConfig(homeDir, join(directory, "drafts"));
+
+    const exitCode = await runCli(["generate", "today"], io, {
+      homeDir,
+      now: () => "2026-05-12T23:30:00.000Z",
+      aiProvider: new TaskAwareProvider()
+    });
+
+    expect(exitCode).toBe(2);
+    expect(stdout).toEqual([]);
+    expect(stderr).toEqual([
+      "No registered projects. Run `uncommitted project add .` first."
+    ]);
+  });
+
+  it("preserves activity-summary.json when draft generation fails", async () => {
+    const { io, stdout, stderr } = createIo();
+    const fixture = await createRegisteredProjectFixture();
+    const provider = new TaskAwareProvider({ failDraft: true });
+
+    await writeGitEvent(fixture.project, "2026-05-12");
+
+    const exitCode = await runCli(["generate", "today"], io, {
+      homeDir: fixture.homeDir,
+      now: () => "2026-05-12T23:30:00.000Z",
+      aiProvider: provider
+    });
+    const outputDir = join(fixture.draftRoot, "2026-05-12", "rev-001");
+    const activitySummary = await readJson(join(outputDir, "activity-summary.json"));
+
+    expect(exitCode).toBe(4);
+    expect(stdout).toEqual([]);
+    expect(stderr).toEqual(["AI provider failed. Check provider configuration."]);
+    expect(activitySummary).toMatchObject({
+      targetDate: "2026-05-12",
+      commitSignals: {
+        totalCommits: 1
+      }
+    });
+    await expect(readFile(join(outputDir, "story.json"), "utf8")).rejects.toMatchObject({
+      code: "ENOENT"
+    });
+  });
+});
+
+class TaskAwareProvider implements AiProvider {
+  readonly name = "mock";
+  readonly requests: AiStructuredGenerationRequest[] = [];
+
+  constructor(
+    private readonly options: {
+      plan?: StoryFormatPlan;
+      draft?: ReturnType<typeof createProviderDraft>;
+      failDraft?: boolean;
+    } = {}
+  ) {}
+
+  async generateStructured(
+    request: AiStructuredGenerationRequest
+  ): Promise<AiProviderRawResponse> {
+    this.requests.push(request);
+
+    if (request.task === "story-plan") {
+      return {
+        responseJson: JSON.stringify(this.options.plan ?? createStoryFormatPlan())
+      };
+    }
+
+    if (request.task === "draft") {
+      if (this.options.failDraft) {
+        throw new Error("provider unavailable");
+      }
+
+      return {
+        responseJson: JSON.stringify(this.options.draft ?? createProviderDraft())
+      };
+    }
+
+    throw new Error(`Unexpected task: ${request.task}`);
+  }
+}
+
+async function createRegisteredProjectFixture(): Promise<{
+  directory: string;
+  repoDir: string;
+  homeDir: string;
+  draftRoot: string;
+  project: ProjectRecord;
+}> {
+  const directory = await mkdtemp(join(tmpdir(), "uncommitted-generate-"));
+  const repoDir = join(directory, "repo");
+  const homeDir = join(directory, "home");
+  const draftRoot = join(directory, "drafts");
+
+  await execFileAsync("git", ["init", repoDir]);
+  await execFileAsync("git", ["-C", repoDir, "config", "user.name", "Fixture Dev"]);
+  await execFileAsync("git", ["-C", repoDir, "config", "user.email", "dev@example.com"]);
+  await writeConfig(homeDir, draftRoot);
+
+  const registered = await addProject(repoDir, {
+    homeDir,
+    now: () => "2026-05-12T00:00:00.000Z"
+  });
+
+  return {
+    directory,
+    repoDir,
+    homeDir,
+    draftRoot,
+    project: registered.project
+  };
+}
+
+async function writeConfig(homeDir: string, draftRoot: string): Promise<void> {
+  const configDir = join(homeDir, ".uncommitted");
+
+  await mkdir(join(configDir, "history"), { recursive: true });
+  await writeFile(
+    join(configDir, "config.json"),
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        draftRoot,
+        scheduleTime: "23:30",
+        aiProvider: "mock",
+        persona: "wry coworker",
+        roastLevel: 2
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+  await writeFile(
+    join(configDir, "history", "formats.json"),
+    `${JSON.stringify({ schemaVersion: 1, formats: [] })}\n`,
+    "utf8"
+  );
+}
+
+async function writeGitEvent(
+  project: ProjectRecord,
+  targetDate: string
+): Promise<void> {
+  const event: GitActivityEvent = {
+    schemaVersion: 1,
+    source: "git",
+    targetDate,
+    collectedAt: `${targetDate}T23:00:00.000Z`,
+    project: {
+      id: project.id,
+      name: project.name
+    },
+    activity: {
+      schemaVersion: 1,
+      targetDate,
+      repository: {
+        rootName: project.name
+      },
+      commits: [
+        {
+          hash: "abc1234",
+          shortHash: "abc1234",
+          authorName: "Fixture Dev",
+          subject: "implement generate command",
+          authoredAt: `${targetDate}T10:00:00.000Z`,
+          stats: {
+            filesChanged: 2,
+            insertions: 45,
+            deletions: 5
+          }
+        }
+      ],
+      dirty: {
+        files: [
+          {
+            path: "src/generate-command.ts",
+            status: "modified"
+          }
+        ],
+        totals: {
+          modified: 1,
+          added: 0,
+          deleted: 0,
+          renamed: 0,
+          copied: 0,
+          untracked: 0,
+          other: 0
+        }
+      },
+      totals: {
+        commits: 1,
+        filesChanged: 2,
+        insertions: 45,
+        deletions: 5
+      }
+    }
+  };
+  const eventsDir = join(project.root, ".uncommitted", "events", "git");
+
+  await mkdir(eventsDir, { recursive: true });
+  await writeFile(
+    join(eventsDir, `${targetDate}.json`),
+    `${JSON.stringify(event, null, 2)}\n`,
+    "utf8"
+  );
+}
+
+async function writeManualNote(
+  project: ProjectRecord,
+  targetDate: string
+): Promise<void> {
+  const eventsDir = join(project.root, ".uncommitted", "events", "manual");
+
+  await mkdir(eventsDir, { recursive: true });
+  await writeFile(
+    join(eventsDir, `${targetDate}.jsonl`),
+    `${JSON.stringify({
+      schemaVersion: 1,
+      id: "note-1",
+      timestamp: `${targetDate}T15:00:00.000Z`,
+      date: targetDate,
+      projectId: project.id,
+      text: "Finished the text draft workflow without exposing dev@example.com or /Users/dev/private.",
+      source: "manual"
+    })}\n`,
+    "utf8"
+  );
+}
+
+function createStoryFormatPlan(
+  overrides: Partial<StoryFormatPlan> = {}
+): StoryFormatPlan {
+  return {
+    schemaVersion: 1,
+    formatName: "Implementation Dispatch",
+    voice: "dry coworker",
+    tone: "concise and lightly amused",
+    reason: "Generation workflow had enough real signals for a compact update.",
+    structure: [
+      {
+        part: "Signal",
+        purpose: "Name the concrete activity."
+      },
+      {
+        part: "Draft",
+        purpose: "Turn it into a diary beat."
+      },
+      {
+        part: "Close",
+        purpose: "End without inventing extra work."
+      }
+    ],
+    suggestedSlideCount: 3,
+    captionStyle: "short witty caption",
+    doNotMention: ["raw diffs", "private paths"],
+    ...overrides
+  };
+}
+
+function createProviderDraft(
+  overrides: Partial<Omit<DiaryDraft, "schemaVersion" | "targetDate" | "metadata">> = {}
+) {
+  return {
+    title: "Generate Command Day",
+    caption: "오늘은 generate command를 텍스트 draft까지 연결했다.",
+    slides: [
+      {
+        index: 1,
+        title: "Signal",
+        body: "Collected activity and manual notes were summarized safely.",
+        visualMood: "compact terminal summary"
+      },
+      {
+        index: 2,
+        title: "Draft",
+        body: "Story and caption artifacts were written for the target date.",
+        visualMood: "plain text files"
+      },
+      {
+        index: 3,
+        title: "Close",
+        body: "No card rendering happened yet, exactly as scoped.",
+        visualMood: "checklist with one unchecked render item"
+      }
+    ],
+    hashtags: ["#Uncommitted", "#개발일기"],
+    altText: "Uncommitted text diary draft generated from local activity.",
+    ...overrides
+  };
+}
+
+async function readJson(path: string): Promise<unknown> {
+  return JSON.parse(await readFile(path, "utf8")) as unknown;
+}

--- a/tests/generate-command.test.ts
+++ b/tests/generate-command.test.ts
@@ -194,6 +194,25 @@ describe("generate command", () => {
       code: "ENOENT"
     });
   });
+
+  it("returns collection exit code for malformed stored Git activity", async () => {
+    const { io, stdout, stderr } = createIo();
+    const fixture = await createRegisteredProjectFixture();
+
+    await writeMalformedGitEvent(fixture.project, "2026-05-12");
+
+    const exitCode = await runCli(["generate", "today"], io, {
+      homeDir: fixture.homeDir,
+      now: () => "2026-05-12T23:30:00.000Z",
+      aiProvider: new TaskAwareProvider()
+    });
+
+    expect(exitCode).toBe(3);
+    expect(stdout).toEqual([]);
+    expect(stderr).toEqual([
+      "Stored Git activity is malformed. Re-run `uncommitted collect git`."
+    ]);
+  });
 });
 
 class TaskAwareProvider implements AiProvider {
@@ -355,6 +374,59 @@ async function writeGitEvent(
   await writeFile(
     join(eventsDir, `${targetDate}.json`),
     `${JSON.stringify(event, null, 2)}\n`,
+    "utf8"
+  );
+}
+
+async function writeMalformedGitEvent(
+  project: ProjectRecord,
+  targetDate: string
+): Promise<void> {
+  const eventsDir = join(project.root, ".uncommitted", "events", "git");
+
+  await mkdir(eventsDir, { recursive: true });
+  await writeFile(
+    join(eventsDir, `${targetDate}.json`),
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        source: "git",
+        targetDate,
+        collectedAt: `${targetDate}T23:00:00.000Z`,
+        project: {
+          id: project.id,
+          name: project.name
+        },
+        activity: {
+          schemaVersion: 1,
+          targetDate,
+          repository: {
+            rootName: project.name
+          },
+          commits: [{}],
+          dirty: {
+            files: [],
+            totals: {
+              modified: 0,
+              added: 0,
+              deleted: 0,
+              renamed: 0,
+              copied: 0,
+              untracked: 0,
+              other: 0
+            }
+          },
+          totals: {
+            commits: 1,
+            filesChanged: 0,
+            insertions: 0,
+            deletions: 0
+          }
+        }
+      },
+      null,
+      2
+    )}\n`,
     "utf8"
   );
 }


### PR DESCRIPTION
# Goal

Implement the text-only `uncommitted generate today` workflow so collected Git activity and manual notes can produce local draft artifacts without rendering PNG cards.

## Related Issue

Closes #26

## Acceptance Criteria

- [x] `uncommitted generate today` generates text draft output from available Git activity and manual notes
- [x] `uncommitted generate --date YYYY-MM-DD` works through the same command path
- [x] Quiet days generate a valid text draft without inventing work
- [x] Missing registered projects produce a clear actionable config message
- [x] AI generation failure preserves completed `activity-summary.json` output when possible
- [x] Blocking AI generation errors exit with code `4`
- [x] Output avoids raw diffs, raw code, secrets, emails, private paths, private URLs, and private remote URLs through existing summary/provider/draft safety boundaries
- [x] Integration tests cover success, quiet day, missing project/config, and provider failure behavior

## Implementation Notes

- Added `src/generate-command.ts` as the orchestration layer for target date parsing, registered project loading, stored Git/manual event reads, activity summary creation, AI story planning, diary generation, and artifact writes.
- Writes text draft artifacts to `<draftRoot>/<YYYY-MM-DD>/rev-001/` as the smallest milestone-scoped output structure.
- Wires `generate` through the CLI and maps AI generation failures to exit code `4`.

## Validation

- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`

## Remaining Risk

- This intentionally does not implement latest-pointer behavior, final revision storage semantics, safety-report generation, or PNG rendering; those remain out of scope for this milestone issue.
