### PR TITLE
feat: add draft revision storage

### DIFF
--- a/src/draft-storage.ts
+++ b/src/draft-storage.ts
@@ -1,0 +1,229 @@
+import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+export type DraftStorageErrorCode = "inspect-failed" | "write-failed" | "invalid-pointer";
+
+export class DraftStorageError extends Error {
+  constructor(
+    message: string,
+    public readonly code: DraftStorageErrorCode
+  ) {
+    super(message);
+    this.name = "DraftStorageError";
+  }
+}
+
+export type DraftRevision = {
+  targetDate: string;
+  revision: string;
+  dateDir: string;
+  outputDir: string;
+  latestPointerPath: string;
+  dateLatestPointerPath: string;
+};
+
+export type LatestDraftPointer = {
+  schemaVersion: 1;
+  targetDate: string;
+  revision: string;
+  path: string;
+  updatedAt: string;
+};
+
+export type TextDraftRevisionInput = {
+  draftRoot: string;
+  targetDate: string;
+  generatedAt: string;
+  activitySummary: unknown;
+  story: unknown;
+  caption: string;
+  metadata: unknown;
+};
+
+export type TextDraftWriteResult = DraftRevision & {
+  files: string[];
+};
+
+const textDraftFiles = [
+  "activity-summary.json",
+  "story.json",
+  "caption.txt",
+  "metadata.json"
+];
+
+export async function writeTextDraftRevision(
+  input: TextDraftRevisionInput
+): Promise<TextDraftWriteResult> {
+  const revision = await createDraftRevision({
+    draftRoot: input.draftRoot,
+    targetDate: input.targetDate
+  });
+
+  await writeDraftArtifactJson(
+    revision,
+    "activity-summary.json",
+    input.activitySummary
+  );
+  await writeDraftArtifactJson(revision, "story.json", input.story);
+  await writeDraftArtifactText(revision, "caption.txt", input.caption);
+  await writeDraftArtifactJson(revision, "metadata.json", input.metadata);
+  await writeLatestDraftPointer(revision, input.generatedAt);
+
+  return {
+    ...revision,
+    files: [...textDraftFiles]
+  };
+}
+
+export async function createDraftRevision(options: {
+  draftRoot: string;
+  targetDate: string;
+}): Promise<DraftRevision> {
+  const dateDir = join(options.draftRoot, options.targetDate);
+  const revision = await allocateNextRevision(dateDir);
+  const outputDir = join(dateDir, revision);
+
+  try {
+    await mkdir(outputDir, { recursive: true });
+  } catch {
+    throw new DraftStorageError("Could not write draft files.", "write-failed");
+  }
+
+  return {
+    targetDate: options.targetDate,
+    revision,
+    dateDir,
+    outputDir,
+    latestPointerPath: join(options.draftRoot, "latest.json"),
+    dateLatestPointerPath: join(dateDir, "latest.json")
+  };
+}
+
+export async function writeDraftArtifactJson(
+  revision: DraftRevision,
+  filename: string,
+  value: unknown
+): Promise<void> {
+  await writeDraftArtifactText(
+    revision,
+    filename,
+    `${JSON.stringify(value, null, 2)}\n`
+  );
+}
+
+export async function writeDraftArtifactText(
+  revision: DraftRevision,
+  filename: string,
+  value: string
+): Promise<void> {
+  try {
+    await writeFile(join(revision.outputDir, filename), value, "utf8");
+  } catch {
+    throw new DraftStorageError("Could not write draft files.", "write-failed");
+  }
+}
+
+export async function writeLatestDraftPointer(
+  revision: DraftRevision,
+  updatedAt: string
+): Promise<LatestDraftPointer> {
+  const pointer: LatestDraftPointer = {
+    schemaVersion: 1,
+    targetDate: revision.targetDate,
+    revision: revision.revision,
+    path: revision.outputDir,
+    updatedAt
+  };
+
+  await writeDraftPointer(revision.latestPointerPath, pointer);
+  await writeDraftPointer(revision.dateLatestPointerPath, pointer);
+
+  return pointer;
+}
+
+export async function readLatestDraftPointer(
+  draftRoot: string
+): Promise<LatestDraftPointer> {
+  try {
+    const parsed = JSON.parse(
+      await readFile(join(draftRoot, "latest.json"), "utf8")
+    ) as unknown;
+
+    if (isLatestDraftPointer(parsed)) {
+      return parsed;
+    }
+  } catch (error) {
+    if (isNodeError(error) && error.code !== "ENOENT") {
+      throw new DraftStorageError(
+        "Latest draft pointer is invalid.",
+        "invalid-pointer"
+      );
+    }
+  }
+
+  throw new DraftStorageError("Latest draft pointer is missing.", "invalid-pointer");
+}
+
+async function allocateNextRevision(dateDir: string): Promise<string> {
+  let entries: string[];
+
+  try {
+    entries = await readdir(dateDir);
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return formatRevision(1);
+    }
+
+    throw new DraftStorageError(
+      "Could not inspect draft revisions.",
+      "inspect-failed"
+    );
+  }
+
+  const highestRevision = entries.reduce((highest, entry) => {
+    const match = /^rev-(\d{3})$/.exec(entry);
+
+    if (!match) {
+      return highest;
+    }
+
+    return Math.max(highest, Number(match[1]));
+  }, 0);
+
+  return formatRevision(highestRevision + 1);
+}
+
+async function writeDraftPointer(
+  path: string,
+  pointer: LatestDraftPointer
+): Promise<void> {
+  try {
+    await writeFile(path, `${JSON.stringify(pointer, null, 2)}\n`, "utf8");
+  } catch {
+    throw new DraftStorageError("Could not write draft files.", "write-failed");
+  }
+}
+
+function formatRevision(value: number): string {
+  return `rev-${String(value).padStart(3, "0")}`;
+}
+
+function isLatestDraftPointer(value: unknown): value is LatestDraftPointer {
+  return (
+    isRecord(value) &&
+    value.schemaVersion === 1 &&
+    typeof value.targetDate === "string" &&
+    typeof value.revision === "string" &&
+    /^rev-\d{3}$/.test(value.revision) &&
+    typeof value.path === "string" &&
+    typeof value.updatedAt === "string"
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}

--- a/src/generate-command.ts
+++ b/src/generate-command.ts
@@ -133,12 +133,6 @@ export async function runGenerateCommand(
   }
 
   const generatedAt = options.now ? options.now() : new Date().toISOString();
-  const draftRevision = await runDraftStorageOperation(() =>
-    createDraftRevision({
-      draftRoot: config.draftRoot,
-      targetDate
-    })
-  );
   const gitEvents = await readGitActivityEvents(projects, targetDate);
   const manualNotes = await readManualNoteEvents(projects, targetDate);
   const activitySummary = buildActivitySummary({
@@ -147,6 +141,12 @@ export async function runGenerateCommand(
     gitEvents,
     manualNotes
   });
+  const draftRevision = await runDraftStorageOperation(() =>
+    createDraftRevision({
+      draftRoot: config.draftRoot,
+      targetDate
+    })
+  );
 
   await runDraftStorageOperation(() =>
     writeDraftArtifactJson(draftRevision, "activity-summary.json", activitySummary)

--- a/src/generate-command.ts
+++ b/src/generate-command.ts
@@ -1,4 +1,4 @@
-import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import {
   buildActivitySummary,
@@ -17,6 +17,13 @@ import {
   generateDiaryDraft,
   type DiaryDraft
 } from "./diary-generator.js";
+import {
+  createDraftRevision,
+  DraftStorageError,
+  writeDraftArtifactJson,
+  writeDraftArtifactText,
+  writeLatestDraftPointer
+} from "./draft-storage.js";
 import type { ManualNoteEvent } from "./note-command.js";
 import type { ProjectRecord, ProjectsFile } from "./project-add.js";
 import {
@@ -51,6 +58,8 @@ export type GenerateCommandOptions = {
 export type GenerateCommandResult = {
   targetDate: string;
   outputDir: string;
+  revision: string;
+  latestPointerPath: string;
   activitySummary: ActivitySummary;
   storyFormatPlan: StoryFormatPlan;
   draft: DiaryDraft;
@@ -85,14 +94,6 @@ type DraftMetadata = {
   files: string[];
 };
 
-type LatestDraftPointer = {
-  schemaVersion: 1;
-  targetDate: string;
-  revision: string;
-  path: string;
-  updatedAt: string;
-};
-
 const usage = "Usage: uncommitted generate today | uncommitted generate --date YYYY-MM-DD";
 const providerNames: readonly AiProviderName[] = [
   "none",
@@ -120,7 +121,7 @@ export async function runGenerateCommand(
 ): Promise<GenerateCommandResult> {
   const targetDate = parseGenerateDate(args, options.now);
   const paths = resolveConfigPaths({ homeDir: options.homeDir });
-  const config = await readGenerateConfig(paths.configFile);
+  const config = await readGenerateConfig(paths.configFile, options.homeDir);
   const projectsFile = await readProjectsFile(paths.projectsFile);
   const projects = projectsFile.projects.filter((project) => project.enabled);
 
@@ -132,9 +133,12 @@ export async function runGenerateCommand(
   }
 
   const generatedAt = options.now ? options.now() : new Date().toISOString();
-  const dateDir = join(config.draftRoot, targetDate);
-  const revision = await allocateNextRevision(dateDir);
-  const outputDir = join(dateDir, revision);
+  const draftRevision = await runDraftStorageOperation(() =>
+    createDraftRevision({
+      draftRoot: config.draftRoot,
+      targetDate
+    })
+  );
   const gitEvents = await readGitActivityEvents(projects, targetDate);
   const manualNotes = await readManualNoteEvents(projects, targetDate);
   const activitySummary = buildActivitySummary({
@@ -144,8 +148,9 @@ export async function runGenerateCommand(
     manualNotes
   });
 
-  await mkdir(outputDir, { recursive: true });
-  await writeJson(join(outputDir, "activity-summary.json"), activitySummary);
+  await runDraftStorageOperation(() =>
+    writeDraftArtifactJson(draftRevision, "activity-summary.json", activitySummary)
+  );
 
   const provider = options.aiProvider ?? createAiProvider(config);
   const recentFormats = await loadRecentStoryFormatHistory({
@@ -182,16 +187,12 @@ export async function runGenerateCommand(
     files: ["activity-summary.json", "story.json", "caption.txt", "metadata.json"]
   };
 
-  await writeJson(join(outputDir, "story.json"), draft);
-  await writeFile(join(outputDir, "caption.txt"), caption, "utf8");
-  await writeJson(join(outputDir, "metadata.json"), metadata);
-  await writeJson(join(dateDir, "latest.json"), {
-    schemaVersion: 1,
-    targetDate,
-    revision,
-    path: outputDir,
-    updatedAt: generatedAt
-  } satisfies LatestDraftPointer);
+  await runDraftStorageOperation(async () => {
+    await writeDraftArtifactJson(draftRevision, "story.json", draft);
+    await writeDraftArtifactText(draftRevision, "caption.txt", caption);
+    await writeDraftArtifactJson(draftRevision, "metadata.json", metadata);
+    await writeLatestDraftPointer(draftRevision, generatedAt);
+  });
   await recordStoryFormatHistory({
     homeDir: options.homeDir,
     targetDate,
@@ -200,7 +201,9 @@ export async function runGenerateCommand(
 
   return {
     targetDate,
-    outputDir,
+    outputDir: draftRevision.outputDir,
+    revision: draftRevision.revision,
+    latestPointerPath: draftRevision.latestPointerPath,
     activitySummary,
     storyFormatPlan,
     draft,
@@ -208,37 +211,18 @@ export async function runGenerateCommand(
   };
 }
 
-async function allocateNextRevision(dateDir: string): Promise<string> {
-  let entries: string[];
-
+async function runDraftStorageOperation<T>(
+  operation: () => Promise<T>
+): Promise<T> {
   try {
-    entries = await readdir(dateDir);
+    return await operation();
   } catch (error) {
-    if (isNodeError(error) && error.code === "ENOENT") {
-      return formatRevision(1);
+    if (error instanceof DraftStorageError) {
+      throw new GenerateCommandError(error.message, "invalid-config");
     }
 
-    throw new GenerateCommandError(
-      "Could not inspect draft revisions.",
-      "invalid-config"
-    );
+    throw error;
   }
-
-  const highestRevision = entries.reduce((highest, entry) => {
-    const match = /^rev-(\d{3})$/.exec(entry);
-
-    if (!match) {
-      return highest;
-    }
-
-    return Math.max(highest, Number(match[1]));
-  }, 0);
-
-  return formatRevision(highestRevision + 1);
-}
-
-function formatRevision(value: number): string {
-  return `rev-${String(value).padStart(3, "0")}`;
 }
 
 function parseGenerateDate(
@@ -275,7 +259,10 @@ function isValidDateString(value: string): boolean {
   return !Number.isNaN(date.getTime()) && date.toISOString().slice(0, 10) === value;
 }
 
-async function readGenerateConfig(path: string): Promise<GenerateConfig> {
+async function readGenerateConfig(
+  path: string,
+  homeDir: string | undefined
+): Promise<GenerateConfig> {
   try {
     const parsed = JSON.parse(await readFile(path, "utf8")) as unknown;
 
@@ -284,7 +271,10 @@ async function readGenerateConfig(path: string): Promise<GenerateConfig> {
     }
 
     return {
-      draftRoot: parsed.draftRoot,
+      draftRoot: resolveConfigPaths({
+        homeDir,
+        draftRoot: parsed.draftRoot
+      }).defaultDraftRoot,
       provider: parsed.aiProvider,
       persona: parsed.persona,
       roastLevel: parsed.roastLevel
@@ -425,10 +415,6 @@ async function readOptionalText(path: string): Promise<string | undefined> {
       "invalid-data"
     );
   }
-}
-
-async function writeJson(path: string, value: unknown): Promise<void> {
-  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`, "utf8");
 }
 
 function isGenerateConfigFile(value: unknown): value is GenerateConfigFile {

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,6 +108,22 @@ export type {
   GenerateCommandOptions,
   GenerateCommandResult
 } from "./generate-command.js";
+export {
+  createDraftRevision,
+  DraftStorageError,
+  readLatestDraftPointer,
+  writeDraftArtifactJson,
+  writeDraftArtifactText,
+  writeLatestDraftPointer,
+  writeTextDraftRevision
+} from "./draft-storage.js";
+export type {
+  DraftRevision,
+  DraftStorageErrorCode,
+  LatestDraftPointer,
+  TextDraftRevisionInput,
+  TextDraftWriteResult
+} from "./draft-storage.js";
 export { runInitCommand } from "./init-command.js";
 export type {
   InitAnswers,

--- a/tests/draft-storage.test.ts
+++ b/tests/draft-storage.test.ts
@@ -1,0 +1,218 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveConfigPaths } from "../src/config-paths.js";
+import {
+  createDraftRevision,
+  readLatestDraftPointer,
+  writeDraftArtifactJson,
+  writeDraftArtifactText,
+  writeLatestDraftPointer,
+  writeTextDraftRevision
+} from "../src/draft-storage.js";
+
+describe("draft storage", () => {
+  it("writes the first text draft revision under the configured draft root", async () => {
+    const draftRoot = await createDraftRoot();
+    const result = await writeTextDraftRevision({
+      draftRoot,
+      targetDate: "2026-05-18",
+      generatedAt: "2026-05-18T23:30:00.000Z",
+      activitySummary: { schemaVersion: 1, targetDate: "2026-05-18" },
+      story: { schemaVersion: 1, title: "First draft" },
+      caption: "First caption\n",
+      metadata: { schemaVersion: 1, files: ["activity-summary.json"] }
+    });
+
+    expect(result).toEqual({
+      targetDate: "2026-05-18",
+      revision: "rev-001",
+      dateDir: join(draftRoot, "2026-05-18"),
+      outputDir: join(draftRoot, "2026-05-18", "rev-001"),
+      latestPointerPath: join(draftRoot, "latest.json"),
+      dateLatestPointerPath: join(draftRoot, "2026-05-18", "latest.json"),
+      files: [
+        "activity-summary.json",
+        "story.json",
+        "caption.txt",
+        "metadata.json"
+      ]
+    });
+    await expectJson(join(result.outputDir, "activity-summary.json"), {
+      schemaVersion: 1,
+      targetDate: "2026-05-18"
+    });
+    await expectJson(join(result.outputDir, "story.json"), {
+      schemaVersion: 1,
+      title: "First draft"
+    });
+    await expect(readFile(join(result.outputDir, "caption.txt"), "utf8")).resolves.toBe(
+      "First caption\n"
+    );
+    await expectJson(join(result.outputDir, "metadata.json"), {
+      schemaVersion: 1,
+      files: ["activity-summary.json"]
+    });
+  });
+
+  it("creates the next revision without overwriting existing draft artifacts", async () => {
+    const draftRoot = await createDraftRoot();
+
+    const first = await writeTextDraftRevision({
+      draftRoot,
+      targetDate: "2026-05-18",
+      generatedAt: "2026-05-18T23:30:00.000Z",
+      activitySummary: { schemaVersion: 1 },
+      story: { schemaVersion: 1, title: "First" },
+      caption: "First caption\n",
+      metadata: { schemaVersion: 1 }
+    });
+    const second = await writeTextDraftRevision({
+      draftRoot,
+      targetDate: "2026-05-18",
+      generatedAt: "2026-05-18T23:45:00.000Z",
+      activitySummary: { schemaVersion: 1 },
+      story: { schemaVersion: 1, title: "Second" },
+      caption: "Second caption\n",
+      metadata: { schemaVersion: 1 }
+    });
+
+    expect(first.revision).toBe("rev-001");
+    expect(second.revision).toBe("rev-002");
+    await expect(readFile(join(first.outputDir, "caption.txt"), "utf8")).resolves.toBe(
+      "First caption\n"
+    );
+    await expect(readFile(join(second.outputDir, "caption.txt"), "utf8")).resolves.toBe(
+      "Second caption\n"
+    );
+  });
+
+  it("updates latest pointers to the newest revision", async () => {
+    const draftRoot = await createDraftRoot();
+
+    await writeTextDraftRevision({
+      draftRoot,
+      targetDate: "2026-05-18",
+      generatedAt: "2026-05-18T23:30:00.000Z",
+      activitySummary: { schemaVersion: 1 },
+      story: { schemaVersion: 1 },
+      caption: "First\n",
+      metadata: { schemaVersion: 1 }
+    });
+    const latestRevision = await writeTextDraftRevision({
+      draftRoot,
+      targetDate: "2026-05-18",
+      generatedAt: "2026-05-18T23:45:00.000Z",
+      activitySummary: { schemaVersion: 1 },
+      story: { schemaVersion: 1 },
+      caption: "Second\n",
+      metadata: { schemaVersion: 1 }
+    });
+
+    await expectJson(latestRevision.latestPointerPath, {
+      schemaVersion: 1,
+      targetDate: "2026-05-18",
+      revision: "rev-002",
+      path: latestRevision.outputDir,
+      updatedAt: "2026-05-18T23:45:00.000Z"
+    });
+    await expectJson(latestRevision.dateLatestPointerPath, {
+      schemaVersion: 1,
+      targetDate: "2026-05-18",
+      revision: "rev-002",
+      path: latestRevision.outputDir,
+      updatedAt: "2026-05-18T23:45:00.000Z"
+    });
+    await expect(readLatestDraftPointer(draftRoot)).resolves.toEqual({
+      schemaVersion: 1,
+      targetDate: "2026-05-18",
+      revision: "rev-002",
+      path: latestRevision.outputDir,
+      updatedAt: "2026-05-18T23:45:00.000Z"
+    });
+  });
+
+  it("uses draft roots resolved through config path helpers", async () => {
+    const homeDir = await createDraftRoot();
+    const draftRoot = resolveConfigPaths({
+      homeDir,
+      draftRoot: "configured-drafts"
+    }).defaultDraftRoot;
+    const result = await writeTextDraftRevision({
+      draftRoot,
+      targetDate: "2026-05-19",
+      generatedAt: "2026-05-19T23:30:00.000Z",
+      activitySummary: { schemaVersion: 1 },
+      story: { schemaVersion: 1 },
+      caption: "Configured root\n",
+      metadata: { schemaVersion: 1 }
+    });
+
+    expect(result.outputDir).toBe(
+      join(homeDir, "configured-drafts", "2026-05-19", "rev-001")
+    );
+  });
+
+  it("supports partial artifact writes before finalizing latest pointers", async () => {
+    const draftRoot = await createDraftRoot();
+    const revision = await createDraftRevision({
+      draftRoot,
+      targetDate: "2026-05-20"
+    });
+
+    await writeDraftArtifactJson(revision, "activity-summary.json", {
+      schemaVersion: 1,
+      targetDate: "2026-05-20"
+    });
+    await writeDraftArtifactText(revision, "caption.txt", "Partial caption\n");
+    await writeLatestDraftPointer(revision, "2026-05-20T23:30:00.000Z");
+
+    await expectJson(join(revision.outputDir, "activity-summary.json"), {
+      schemaVersion: 1,
+      targetDate: "2026-05-20"
+    });
+    await expect(readFile(join(revision.outputDir, "caption.txt"), "utf8")).resolves.toBe(
+      "Partial caption\n"
+    );
+    await expectJson(revision.latestPointerPath, {
+      revision: "rev-001",
+      path: revision.outputDir
+    });
+  });
+
+  it("returns a short error for unusable draft roots", async () => {
+    const directory = await createDraftRoot();
+    const draftRoot = join(directory, "draft-root-file");
+
+    await writeFile(draftRoot, "not a directory", "utf8");
+
+    await expect(
+      writeTextDraftRevision({
+        draftRoot,
+        targetDate: "2026-05-21",
+        generatedAt: "2026-05-21T23:30:00.000Z",
+        activitySummary: { schemaVersion: 1 },
+        story: { schemaVersion: 1 },
+        caption: "Blocked by storage\n",
+        metadata: { schemaVersion: 1 }
+      })
+    ).rejects.toMatchObject({
+      code: "inspect-failed",
+      message: "Could not inspect draft revisions."
+    });
+  });
+});
+
+async function createDraftRoot(): Promise<string> {
+  const root = join(tmpdir(), `uncommitted-draft-storage-${randomUUID()}`);
+
+  await mkdir(root, { recursive: true });
+
+  return root;
+}
+
+async function expectJson(path: string, value: Record<string, unknown>): Promise<void> {
+  expect(JSON.parse(await readFile(path, "utf8"))).toMatchObject(value);
+}

--- a/tests/generate-command.test.ts
+++ b/tests/generate-command.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -324,6 +324,28 @@ describe("generate command", () => {
     expect(stderr).toEqual([
       "Stored Git activity is malformed. Re-run `uncommitted collect git`."
     ]);
+  });
+
+  it("does not allocate a draft revision when stored activity is malformed", async () => {
+    const { io, stdout, stderr } = createIo();
+    const fixture = await createRegisteredProjectFixture();
+
+    await writeMalformedGitEvent(fixture.project, "2026-05-12");
+
+    const exitCode = await runCli(["generate", "today"], io, {
+      homeDir: fixture.homeDir,
+      now: () => "2026-05-12T23:30:00.000Z",
+      aiProvider: new TaskAwareProvider()
+    });
+
+    expect(exitCode).toBe(3);
+    expect(stdout).toEqual([]);
+    expect(stderr).toEqual([
+      "Stored Git activity is malformed. Re-run `uncommitted collect git`."
+    ]);
+    await expect(readdir(join(fixture.draftRoot, "2026-05-12"))).rejects.toMatchObject({
+      code: "ENOENT"
+    });
   });
 });
 


### PR DESCRIPTION
# Goal

Add reusable draft revision storage so generated text drafts are written to predictable date/revision folders without overwriting prior output.

## Related Issue

Closes #32.

## Acceptance Criteria

- [x] A draft writer creates `drafts/YYYY-MM-DD/rev-001/` under the configured draft root
- [x] Re-running for the same date creates `rev-002` or the next available revision without overwriting `rev-001`
- [x] A latest pointer records the latest draft date and path
- [x] Draft paths are resolved through existing config/path helpers and do not touch real user storage in tests
- [x] Unit tests cover first revision, repeated generation, latest pointer resolution, and custom draft root
- [x] Errors for unwritable draft locations are short and actionable

## Implementation Notes

- Extracted reusable draft storage helpers from the generate command path.
- Added latest pointer read/write support at draft-root and date-directory levels.
- Kept rendering, export, safety checks, and draft cleanup out of scope.

## Validation

- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`

## Remaining Risk

This only covers text-first draft artifacts. Carousel rendering and export policy enforcement remain later milestone work.
