### PR TITLE
feat: add safety report checker

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -100,6 +100,20 @@ export type {
   DiarySlide
 } from "./diary-generator.js";
 export {
+  checkDraftSafety,
+  createSafetyReport,
+  isSafetyReport
+} from "./safety-report.js";
+export type {
+  SafetyCheckResult,
+  SafetyRedaction,
+  SafetyReport,
+  SafetyRisk,
+  SafetyRiskCategory,
+  SafetyRiskSeverity,
+  SafetyStatus
+} from "./safety-report.js";
+export {
   GenerateCommandError,
   runGenerateCommand
 } from "./generate-command.js";

--- a/src/safety-report.ts
+++ b/src/safety-report.ts
@@ -61,7 +61,7 @@ const detectionRules: DetectionRule[] = [
     replacement: "[redacted-exploit-detail]",
     message: "Exploit detail was redacted.",
     pattern:
-      /(?:\b(?:sql injection|xss|ssrf|rce|remote code execution|exploit payload|payload)\b\s*[:-]?\s*)?(?:'\s*or\s*1\s*=\s*1\s*--|<script\b[^>]*>[\s\S]*?<\/script>|curl\s+\S+\s*\|\s*(?:sh|bash)|(?:rm\s+-rf\s+\/))/gi
+      /(?:\b(?:sql injection|xss|ssrf|rce|remote code execution|exploit payload|payload)\b\s*[:-]?\s*)?(?:'\s*or\s*1\s*=\s*1\s*--|<script\b[^>]*>[\s\S]*?<\/script\s*>|curl\s+\S+\s*\|\s*(?:sh|bash)|(?:rm\s+-rf\s+\/))/gi
   },
   {
     category: "secret",

--- a/src/safety-report.ts
+++ b/src/safety-report.ts
@@ -78,7 +78,7 @@ const detectionRules: DetectionRule[] = [
     replacement: "[redacted-secret]",
     message: "Secret or token was redacted.",
     pattern:
-      /\b[A-Z][A-Z0-9_]*(?:API[_-]?KEY|ACCESS[_-]?TOKEN|TOKEN|SECRET|PASSWORD|PRIVATE[_-]?KEY)\s*=\s*\S+|\bBearer\s+[A-Za-z0-9._~+/=-]+|\b(?:sk|ghp|github_pat|glpat|xox[baprs])[-_A-Za-z0-9]{8,}/gi
+      /\b(?:[A-Z][A-Z0-9]*[_-])*(?:API[_-]?KEY|ACCESS[_-]?TOKEN|TOKEN|SECRET|PASSWORD|PRIVATE[_-]?KEY)\s*=\s*\S+|\bBearer\s+[A-Za-z0-9._~+/=-]+|\b(?:sk|ghp|github_pat|glpat|xox[baprs])[-_A-Za-z0-9]{8,}/gi
   },
   {
     category: "private-repo-remote",
@@ -116,7 +116,7 @@ const detectionRules: DetectionRule[] = [
     replacement: "[redacted-path]",
     message: "Local absolute path was redacted.",
     pattern:
-      /(^|[\s(["'])(?:\/(?:Users|home|private|var|tmp|Volumes|opt|etc)\/[^\s)"']+|[A-Za-z]:\\[^\s)"']+)/g
+      /(^(?:file:)?|[\s(["'=,:](?:file:)?)(?:\/[A-Za-z0-9._-]+(?:\/[^\s)"']+)+|[A-Za-z]:\\[^\s)"']+)/g
   }
 ];
 

--- a/src/safety-report.ts
+++ b/src/safety-report.ts
@@ -1,0 +1,258 @@
+export type SafetyStatus = "safe" | "warning" | "blocked";
+
+export type SafetyRiskCategory =
+  | "database-credential"
+  | "email"
+  | "exploit-detail"
+  | "local-path"
+  | "phone-number"
+  | "private-repo-remote"
+  | "private-url"
+  | "secret";
+
+export type SafetyRiskSeverity = "warning" | "blocked";
+
+export type SafetyRisk = {
+  category: SafetyRiskCategory;
+  severity: SafetyRiskSeverity;
+  message: string;
+};
+
+export type SafetyRedaction = {
+  category: SafetyRiskCategory;
+  replacement: string;
+  count: number;
+};
+
+export type SafetyReport = {
+  schemaVersion: 1;
+  status: SafetyStatus;
+  risks: SafetyRisk[];
+  redactionsApplied: SafetyRedaction[];
+  exportAllowed: boolean;
+  message: string;
+};
+
+export type SafetyCheckResult = {
+  report: SafetyReport;
+  redactedText: string;
+};
+
+type DetectionRule = {
+  category: SafetyRiskCategory;
+  severity: SafetyRiskSeverity;
+  replacement: string;
+  message: string;
+  pattern: RegExp;
+};
+
+const detectionRules: DetectionRule[] = [
+  {
+    category: "database-credential",
+    severity: "blocked",
+    replacement: "[redacted-db-credential]",
+    message: "Database credential was redacted.",
+    pattern:
+      /\b(?:DATABASE_URL|DB_URL|DATABASE_PASSWORD|DB_PASSWORD|PGPASSWORD|MYSQL_PWD)\s*=\s*\S+|\b(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|redis):\/\/[^\s:@/]+:[^\s@/]+@[^\s]+/gi
+  },
+  {
+    category: "exploit-detail",
+    severity: "blocked",
+    replacement: "[redacted-exploit-detail]",
+    message: "Exploit detail was redacted.",
+    pattern:
+      /(?:\b(?:sql injection|xss|ssrf|rce|remote code execution|exploit payload|payload)\b\s*[:-]?\s*)?(?:'\s*or\s*1\s*=\s*1\s*--|<script\b[^>]*>[\s\S]*?<\/script>|curl\s+\S+\s*\|\s*(?:sh|bash)|(?:rm\s+-rf\s+\/))/gi
+  },
+  {
+    category: "secret",
+    severity: "blocked",
+    replacement: "[redacted-secret]",
+    message: "Secret or token was redacted.",
+    pattern:
+      /\b[A-Z][A-Z0-9_]*(?:API[_-]?KEY|ACCESS[_-]?TOKEN|TOKEN|SECRET|PASSWORD|PRIVATE[_-]?KEY)\s*=\s*\S+|\bBearer\s+[A-Za-z0-9._~+/=-]+|\b(?:sk|ghp|github_pat|glpat|xox[baprs])[-_A-Za-z0-9]{8,}/gi
+  },
+  {
+    category: "private-repo-remote",
+    severity: "warning",
+    replacement: "[redacted-repo-url]",
+    message: "Private repository remote was redacted.",
+    pattern:
+      /\bgit@[\w.-]+:[^\s]+|(?:https?|ssh|git):\/\/(?:[^/\s]+@)?(?:github\.com|gitlab\.com|bitbucket\.org|[\w.-]+)[:/][^\s]+\.git\b/gi
+  },
+  {
+    category: "private-url",
+    severity: "warning",
+    replacement: "[redacted-url]",
+    message: "Private URL was redacted.",
+    pattern: /\b(?:https?|ssh|git):\/\/\S+/gi
+  },
+  {
+    category: "email",
+    severity: "warning",
+    replacement: "[redacted-email]",
+    message: "Email address was redacted.",
+    pattern: /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi
+  },
+  {
+    category: "phone-number",
+    severity: "warning",
+    replacement: "[redacted-phone]",
+    message: "Phone number was redacted.",
+    pattern:
+      /(?:\+?1[\s.-]?)?(?:\([2-9]\d{2}\)|[2-9]\d{2})[\s.-]?\d{3}[\s.-]?\d{4}\b/g
+  },
+  {
+    category: "local-path",
+    severity: "warning",
+    replacement: "[redacted-path]",
+    message: "Local absolute path was redacted.",
+    pattern:
+      /(^|[\s(["'])(?:\/(?:Users|home|private|var|tmp|Volumes|opt|etc)\/[^\s)"']+|[A-Za-z]:\\[^\s)"']+)/g
+  }
+];
+
+export function createSafetyReport(text: string): SafetyReport {
+  return checkDraftSafety(text).report;
+}
+
+export function checkDraftSafety(text: string): SafetyCheckResult {
+  const risks = new Map<SafetyRiskCategory, SafetyRisk>();
+  const redactions = new Map<SafetyRiskCategory, SafetyRedaction>();
+  let redactedText = text;
+
+  for (const rule of detectionRules) {
+    const result = applyRule(redactedText, rule);
+
+    if (result.count === 0) {
+      continue;
+    }
+
+    redactedText = result.value;
+    risks.set(rule.category, {
+      category: rule.category,
+      severity: rule.severity,
+      message: rule.message
+    });
+    redactions.set(rule.category, {
+      category: rule.category,
+      replacement: rule.replacement,
+      count: result.count
+    });
+  }
+
+  const riskList = Array.from(risks.values());
+  const status = deriveStatus(riskList);
+
+  return {
+    report: {
+      schemaVersion: 1,
+      status,
+      risks: riskList,
+      redactionsApplied: Array.from(redactions.values()),
+      exportAllowed: status !== "blocked",
+      message: buildSafetyMessage(status)
+    },
+    redactedText
+  };
+}
+
+export function isSafetyReport(value: unknown): value is SafetyReport {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return (
+    value.schemaVersion === 1 &&
+    isSafetyStatus(value.status) &&
+    Array.isArray(value.risks) &&
+    value.risks.every(isSafetyRisk) &&
+    Array.isArray(value.redactionsApplied) &&
+    value.redactionsApplied.every(isSafetyRedaction) &&
+    typeof value.exportAllowed === "boolean" &&
+    typeof value.message === "string"
+  );
+}
+
+function applyRule(
+  value: string,
+  rule: DetectionRule
+): { value: string; count: number } {
+  let count = 0;
+
+  const nextValue = value.replace(rule.pattern, (...args: unknown[]) => {
+    count += 1;
+
+    if (rule.category === "local-path") {
+      return `${String(args[1])}${rule.replacement}`;
+    }
+
+    return rule.replacement;
+  });
+
+  return { value: nextValue, count };
+}
+
+function deriveStatus(risks: SafetyRisk[]): SafetyStatus {
+  if (risks.some((risk) => risk.severity === "blocked")) {
+    return "blocked";
+  }
+
+  return risks.length > 0 ? "warning" : "safe";
+}
+
+function buildSafetyMessage(status: SafetyStatus): string {
+  if (status === "blocked") {
+    return "Remove blocked sensitive content.";
+  }
+
+  if (status === "warning") {
+    return "Review redactions before export.";
+  }
+
+  return "Safety check passed.";
+}
+
+function isSafetyStatus(value: unknown): value is SafetyStatus {
+  return value === "safe" || value === "warning" || value === "blocked";
+}
+
+function isSafetyRisk(value: unknown): value is SafetyRisk {
+  return (
+    isRecord(value) &&
+    isSafetyRiskCategory(value.category) &&
+    isSafetyRiskSeverity(value.severity) &&
+    typeof value.message === "string"
+  );
+}
+
+function isSafetyRedaction(value: unknown): value is SafetyRedaction {
+  return (
+    isRecord(value) &&
+    isSafetyRiskCategory(value.category) &&
+    typeof value.replacement === "string" &&
+    typeof value.count === "number" &&
+    Number.isInteger(value.count) &&
+    value.count > 0
+  );
+}
+
+function isSafetyRiskCategory(value: unknown): value is SafetyRiskCategory {
+  return (
+    value === "database-credential" ||
+    value === "email" ||
+    value === "exploit-detail" ||
+    value === "local-path" ||
+    value === "phone-number" ||
+    value === "private-repo-remote" ||
+    value === "private-url" ||
+    value === "secret"
+  );
+}
+
+function isSafetyRiskSeverity(value: unknown): value is SafetyRiskSeverity {
+  return value === "warning" || value === "blocked";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/src/safety-report.ts
+++ b/src/safety-report.ts
@@ -46,6 +46,18 @@ type DetectionRule = {
   pattern: RegExp;
 };
 
+type DetectionResult = {
+  value: string;
+  count: number;
+};
+
+const exploitDetailRisk = {
+  category: "exploit-detail",
+  severity: "blocked",
+  replacement: "[redacted-exploit-detail]",
+  message: "Exploit detail was redacted."
+} satisfies Omit<DetectionRule, "pattern">;
+
 const detectionRules: DetectionRule[] = [
   {
     category: "database-credential",
@@ -56,12 +68,9 @@ const detectionRules: DetectionRule[] = [
       /\b(?:DATABASE_URL|DB_URL|DATABASE_PASSWORD|DB_PASSWORD|PGPASSWORD|MYSQL_PWD)\s*=\s*\S+|\b(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|redis):\/\/[^\s:@/]+:[^\s@/]+@[^\s]+/gi
   },
   {
-    category: "exploit-detail",
-    severity: "blocked",
-    replacement: "[redacted-exploit-detail]",
-    message: "Exploit detail was redacted.",
+    ...exploitDetailRisk,
     pattern:
-      /(?:\b(?:sql injection|xss|ssrf|rce|remote code execution|exploit payload|payload)\b\s*[:-]?\s*)?(?:'\s*or\s*1\s*=\s*1\s*--|<script\b[^>]*>[\s\S]*?<\/script\s*>|curl\s+\S+\s*\|\s*(?:sh|bash)|(?:rm\s+-rf\s+\/))/gi
+      /(?:\b(?:sql injection|xss|ssrf|rce|remote code execution|exploit payload|payload)\b\s*[:-]?\s*)?(?:'\s*or\s*1\s*=\s*1\s*--|curl\s+\S+\s*\|\s*(?:sh|bash)|(?:rm\s+-rf\s+\/))/gi
   },
   {
     category: "secret",
@@ -128,16 +137,14 @@ export function checkDraftSafety(text: string): SafetyCheckResult {
     }
 
     redactedText = result.value;
-    risks.set(rule.category, {
-      category: rule.category,
-      severity: rule.severity,
-      message: rule.message
-    });
-    redactions.set(rule.category, {
-      category: rule.category,
-      replacement: rule.replacement,
-      count: result.count
-    });
+    recordDetection(risks, redactions, rule, result.count);
+  }
+
+  const scriptResult = redactScriptLikeContent(redactedText);
+
+  if (scriptResult.count > 0) {
+    redactedText = scriptResult.value;
+    recordDetection(risks, redactions, exploitDetailRisk, scriptResult.count);
   }
 
   const riskList = Array.from(risks.values());
@@ -176,7 +183,7 @@ export function isSafetyReport(value: unknown): value is SafetyReport {
 function applyRule(
   value: string,
   rule: DetectionRule
-): { value: string; count: number } {
+): DetectionResult {
   let count = 0;
 
   const nextValue = value.replace(rule.pattern, (...args: unknown[]) => {
@@ -190,6 +197,90 @@ function applyRule(
   });
 
   return { value: nextValue, count };
+}
+
+function redactScriptLikeContent(value: string): DetectionResult {
+  const lowerValue = value.toLowerCase();
+  let count = 0;
+  let output = "";
+  let cursor = 0;
+
+  while (cursor < value.length) {
+    const openIndex = findScriptTagStart(lowerValue, cursor);
+
+    if (openIndex === -1) {
+      output += value.slice(cursor);
+      break;
+    }
+
+    output += value.slice(cursor, openIndex);
+
+    const closeStart = lowerValue.indexOf("</script", openIndex + "<script".length);
+
+    if (closeStart === -1) {
+      output += exploitDetailRisk.replacement;
+      count += 1;
+      break;
+    }
+
+    const closeEnd = value.indexOf(">", closeStart + "</script".length);
+
+    if (closeEnd === -1) {
+      output += exploitDetailRisk.replacement;
+      count += 1;
+      break;
+    }
+
+    output += exploitDetailRisk.replacement;
+    count += 1;
+    cursor = closeEnd + 1;
+  }
+
+  return count === 0 ? { value, count } : { value: output, count };
+}
+
+function findScriptTagStart(value: string, startIndex: number): number {
+  let cursor = startIndex;
+
+  while (cursor < value.length) {
+    const openIndex = value.indexOf("<script", cursor);
+
+    if (openIndex === -1) {
+      return -1;
+    }
+
+    if (isHtmlTagNameBoundary(value[openIndex + "<script".length])) {
+      return openIndex;
+    }
+
+    cursor = openIndex + "<script".length;
+  }
+
+  return -1;
+}
+
+function isHtmlTagNameBoundary(value: string | undefined): boolean {
+  return value === undefined || !/[a-z0-9]/i.test(value);
+}
+
+function recordDetection(
+  risks: Map<SafetyRiskCategory, SafetyRisk>,
+  redactions: Map<SafetyRiskCategory, SafetyRedaction>,
+  detection: Omit<DetectionRule, "pattern">,
+  count: number
+): void {
+  risks.set(detection.category, {
+    category: detection.category,
+    severity: detection.severity,
+    message: detection.message
+  });
+
+  const existingRedaction = redactions.get(detection.category);
+  redactions.set(detection.category, {
+    category: detection.category,
+    replacement: detection.replacement,
+    count: (existingRedaction?.count ?? 0) + count
+  });
 }
 
 function deriveStatus(risks: SafetyRisk[]): SafetyStatus {

--- a/tests/safety-report.test.ts
+++ b/tests/safety-report.test.ts
@@ -114,7 +114,8 @@ describe("safety report", () => {
     const result = checkDraftSafety(
       [
         "DATABASE_URL=postgres://user:password@localhost:5432/app",
-        "Do not publish the SQL injection payload: ' OR 1=1 --"
+        "Do not publish the SQL injection payload: ' OR 1=1 --",
+        "The draft pasted <script>alert('xss')</script >"
       ].join(" ")
     );
 
@@ -136,6 +137,7 @@ describe("safety report", () => {
     expect(result.redactedText).toContain("[redacted-exploit-detail]");
     expect(result.redactedText).not.toContain("postgres://user:password");
     expect(result.redactedText).not.toContain("' OR 1=1 --");
+    expect(result.redactedText).not.toContain("<script>");
   });
 
   it("recognizes private repository remote URLs", () => {

--- a/tests/safety-report.test.ts
+++ b/tests/safety-report.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import {
+  checkDraftSafety,
+  createSafetyReport,
+  isSafetyReport
+} from "../src/safety-report.js";
+
+describe("safety report", () => {
+  it("marks ordinary draft text as safe and exportable", () => {
+    const report = createSafetyReport(
+      "Quiet day. Refined the CLI shape and left a few TODOs for tomorrow."
+    );
+
+    expect(isSafetyReport(report)).toBe(true);
+    expect(report).toEqual({
+      schemaVersion: 1,
+      status: "safe",
+      risks: [],
+      redactionsApplied: [],
+      exportAllowed: true,
+      message: "Safety check passed."
+    });
+  });
+
+  it("warns and redacts local paths, emails, phone numbers, and private URLs", () => {
+    const result = checkDraftSafety(
+      [
+        "Debug notes lived at /Users/chase/private/todo.md.",
+        "Ask dev@example.com or 555-123-4567.",
+        "Private repo: https://github.com/acme/secret-project"
+      ].join(" ")
+    );
+
+    expect(result.report.status).toBe("warning");
+    expect(result.report.exportAllowed).toBe(true);
+    expect(result.report.message).toBe("Review redactions before export.");
+    expect(result.report.risks).toEqual([
+      {
+        category: "private-url",
+        severity: "warning",
+        message: "Private URL was redacted."
+      },
+      {
+        category: "email",
+        severity: "warning",
+        message: "Email address was redacted."
+      },
+      {
+        category: "phone-number",
+        severity: "warning",
+        message: "Phone number was redacted."
+      },
+      {
+        category: "local-path",
+        severity: "warning",
+        message: "Local absolute path was redacted."
+      }
+    ]);
+    expect(result.report.redactionsApplied).toEqual([
+      {
+        category: "private-url",
+        replacement: "[redacted-url]",
+        count: 1
+      },
+      {
+        category: "email",
+        replacement: "[redacted-email]",
+        count: 1
+      },
+      {
+        category: "phone-number",
+        replacement: "[redacted-phone]",
+        count: 1
+      },
+      {
+        category: "local-path",
+        replacement: "[redacted-path]",
+        count: 1
+      }
+    ]);
+    expect(result.redactedText).toContain("[redacted-path]");
+    expect(result.redactedText).toContain("[redacted-email]");
+    expect(result.redactedText).toContain("[redacted-phone]");
+    expect(result.redactedText).toContain("[redacted-url]");
+    expect(result.redactedText).not.toContain("/Users/chase");
+    expect(result.redactedText).not.toContain("dev@example.com");
+    expect(result.redactedText).not.toContain("555-123-4567");
+    expect(result.redactedText).not.toContain("secret-project");
+  });
+
+  it("blocks token-like strings and records secret redactions", () => {
+    const result = checkDraftSafety(
+      "The deployment failed with OPENAI_API_KEY=sk-1234567890abcdef and Bearer ghp_abcdefghijklmnopqrstuvwxyz."
+    );
+
+    expect(result.report.status).toBe("blocked");
+    expect(result.report.exportAllowed).toBe(false);
+    expect(result.report.message).toBe("Remove blocked sensitive content.");
+    expect(result.report.risks).toContainEqual({
+      category: "secret",
+      severity: "blocked",
+      message: "Secret or token was redacted."
+    });
+    expect(result.report.redactionsApplied).toContainEqual({
+      category: "secret",
+      replacement: "[redacted-secret]",
+      count: 2
+    });
+    expect(result.redactedText).not.toContain("OPENAI_API_KEY");
+    expect(result.redactedText).not.toContain("Bearer ghp_");
+  });
+
+  it("blocks database credentials and exploit details where pattern matching is feasible", () => {
+    const result = checkDraftSafety(
+      [
+        "DATABASE_URL=postgres://user:password@localhost:5432/app",
+        "Do not publish the SQL injection payload: ' OR 1=1 --"
+      ].join(" ")
+    );
+
+    expect(result.report.status).toBe("blocked");
+    expect(result.report.exportAllowed).toBe(false);
+    expect(result.report.risks).toEqual([
+      {
+        category: "database-credential",
+        severity: "blocked",
+        message: "Database credential was redacted."
+      },
+      {
+        category: "exploit-detail",
+        severity: "blocked",
+        message: "Exploit detail was redacted."
+      }
+    ]);
+    expect(result.redactedText).toContain("[redacted-db-credential]");
+    expect(result.redactedText).toContain("[redacted-exploit-detail]");
+    expect(result.redactedText).not.toContain("postgres://user:password");
+    expect(result.redactedText).not.toContain("' OR 1=1 --");
+  });
+
+  it("recognizes private repository remote URLs", () => {
+    const result = checkDraftSafety(
+      "Origin was git@github.com:acme/secret-project.git during cleanup."
+    );
+
+    expect(result.report.status).toBe("warning");
+    expect(result.report.risks).toContainEqual({
+      category: "private-repo-remote",
+      severity: "warning",
+      message: "Private repository remote was redacted."
+    });
+    expect(result.report.redactionsApplied).toContainEqual({
+      category: "private-repo-remote",
+      replacement: "[redacted-repo-url]",
+      count: 1
+    });
+    expect(result.redactedText).toContain("[redacted-repo-url]");
+    expect(result.redactedText).not.toContain("git@github.com");
+  });
+});

--- a/tests/safety-report.test.ts
+++ b/tests/safety-report.test.ts
@@ -115,7 +115,7 @@ describe("safety report", () => {
       [
         "DATABASE_URL=postgres://user:password@localhost:5432/app",
         "Do not publish the SQL injection payload: ' OR 1=1 --",
-        "The draft pasted <script>alert('xss')</script >"
+        "The draft pasted <ScRiPt>alert('xss')</script\t\n bar>"
       ].join(" ")
     );
 
@@ -137,7 +137,7 @@ describe("safety report", () => {
     expect(result.redactedText).toContain("[redacted-exploit-detail]");
     expect(result.redactedText).not.toContain("postgres://user:password");
     expect(result.redactedText).not.toContain("' OR 1=1 --");
-    expect(result.redactedText).not.toContain("<script>");
+    expect(result.redactedText).not.toContain("alert('xss')");
   });
 
   it("recognizes private repository remote URLs", () => {

--- a/tests/safety-report.test.ts
+++ b/tests/safety-report.test.ts
@@ -90,7 +90,7 @@ describe("safety report", () => {
 
   it("blocks token-like strings and records secret redactions", () => {
     const result = checkDraftSafety(
-      "The deployment failed with OPENAI_API_KEY=sk-1234567890abcdef and Bearer ghp_abcdefghijklmnopqrstuvwxyz."
+      "The deployment failed with OPENAI_API_KEY=sk-1234567890abcdef, TOKEN=abc123, SECRET=def456, PASSWORD=hunter2, and Bearer ghp_abcdefghijklmnopqrstuvwxyz."
     );
 
     expect(result.report.status).toBe("blocked");
@@ -104,10 +104,38 @@ describe("safety report", () => {
     expect(result.report.redactionsApplied).toContainEqual({
       category: "secret",
       replacement: "[redacted-secret]",
-      count: 2
+      count: 5
     });
     expect(result.redactedText).not.toContain("OPENAI_API_KEY");
+    expect(result.redactedText).not.toContain("TOKEN=abc123");
+    expect(result.redactedText).not.toContain("SECRET=def456");
+    expect(result.redactedText).not.toContain("PASSWORD=hunter2");
     expect(result.redactedText).not.toContain("Bearer ghp_");
+  });
+
+  it("warns and redacts broad Unix and Windows absolute paths", () => {
+    const result = checkDraftSafety(
+      [
+        "Current workspace was cwd=/workspace/uncommitted/src/index.ts.",
+        "Windows path appeared as file:C:\\Users\\chase\\secret\\notes.txt."
+      ].join(" ")
+    );
+
+    expect(result.report.status).toBe("warning");
+    expect(result.report.risks).toContainEqual({
+      category: "local-path",
+      severity: "warning",
+      message: "Local absolute path was redacted."
+    });
+    expect(result.report.redactionsApplied).toContainEqual({
+      category: "local-path",
+      replacement: "[redacted-path]",
+      count: 2
+    });
+    expect(result.redactedText).toContain("cwd=[redacted-path]");
+    expect(result.redactedText).toContain("file:[redacted-path]");
+    expect(result.redactedText).not.toContain("/workspace/uncommitted");
+    expect(result.redactedText).not.toContain("C:\\Users\\chase");
   });
 
   it("blocks database credentials and exploit details where pattern matching is feasible", () => {


### PR DESCRIPTION
# Goal

Add a local safety report checker so generated draft text can be classified before later draft/export flows consume it.

## Related Issue

Closes #31.

## Acceptance Criteria

- [x] A typed Safety Report schema exists for `safety-report.json`
- [x] Safe generated content produces `status: "safe"` and `exportAllowed: true`
- [x] Sensitive string/path examples produce `warning` or `blocked` reports with risk entries
- [x] Redactions, when applied, are recorded in `redactionsApplied`
- [x] Local absolute paths, emails, private URLs, and token-like strings are covered by focused tests
- [x] Safety errors/messages are short and actionable
- [x] The checker does not send draft content to any external service

## Implementation Notes

- Added a deterministic local checker for obvious MVP-sensitive content patterns.
- Added typed report, risk, redaction, and status exports.
- Kept moderation and hosted policy checks out of scope.

## Validation

- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`

## Remaining Risk

Pattern-based detection is intentionally conservative MVP coverage, not a full moderation or secret-scanning guarantee.
