### PR TITLE
feat: write text draft artifacts with metadata

### DIFF
--- a/src/ai-provider.ts
+++ b/src/ai-provider.ts
@@ -68,6 +68,7 @@ export type AiStructuredGenerationResponse<
 
 export interface AiProvider {
   readonly name: AiProviderName;
+  readonly model?: string;
   generateStructured(
     request: AiStructuredGenerationRequest
   ): Promise<AiProviderRawResponse>;
@@ -373,6 +374,7 @@ export class MockAiProvider implements AiProvider {
 
 class OpenAiCompatibleProvider implements AiProvider {
   public readonly name: OpenAiCompatibleProviderName;
+  public readonly model: string;
 
   constructor(
     private readonly options: {
@@ -383,6 +385,7 @@ class OpenAiCompatibleProvider implements AiProvider {
     }
   ) {
     this.name = options.metadata.name;
+    this.model = options.metadata.model;
   }
 
   async generateStructured(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -123,7 +123,7 @@ async function runGenerate(
   try {
     const result = await runGenerateCommand(args, options);
 
-    io.stdout(`Generated text draft for ${result.targetDate}.`);
+    io.stdout(`Generated text draft for ${result.targetDate}: ${result.outputDir}`);
     return 0;
   } catch (error) {
     if (error instanceof GenerateCommandError) {

--- a/src/draft-storage.ts
+++ b/src/draft-storage.ts
@@ -1,7 +1,11 @@
 import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
-export type DraftStorageErrorCode = "inspect-failed" | "write-failed" | "invalid-pointer";
+export type DraftStorageErrorCode =
+  | "inspect-failed"
+  | "invalid-json"
+  | "invalid-pointer"
+  | "write-failed";
 
 export class DraftStorageError extends Error {
   constructor(
@@ -104,11 +108,25 @@ export async function writeDraftArtifactJson(
   filename: string,
   value: unknown
 ): Promise<void> {
-  await writeDraftArtifactText(
-    revision,
-    filename,
-    `${JSON.stringify(value, null, 2)}\n`
-  );
+  let serialized: string;
+
+  try {
+    const nextSerialized = JSON.stringify(value, null, 2);
+
+    if (nextSerialized === undefined) {
+      throw new Error("JSON artifact is not serializable.");
+    }
+
+    JSON.parse(nextSerialized);
+    serialized = nextSerialized;
+  } catch {
+    throw new DraftStorageError(
+      "Draft artifact JSON is invalid.",
+      "invalid-json"
+    );
+  }
+
+  await writeDraftArtifactText(revision, filename, `${serialized}\n`);
 }
 
 export async function writeDraftArtifactText(

--- a/src/generate-command.ts
+++ b/src/generate-command.ts
@@ -27,6 +27,10 @@ import {
 import type { ManualNoteEvent } from "./note-command.js";
 import type { ProjectRecord, ProjectsFile } from "./project-add.js";
 import {
+  createSafetyReport,
+  type SafetyReport
+} from "./safety-report.js";
+import {
   generateStoryFormatPlan,
   loadRecentStoryFormatHistory,
   recordStoryFormatHistory,
@@ -64,6 +68,7 @@ export type GenerateCommandResult = {
   storyFormatPlan: StoryFormatPlan;
   draft: DiaryDraft;
   caption: string;
+  safetyReport: SafetyReport;
 };
 
 type GenerateConfig = AiProviderConfig & {
@@ -80,17 +85,29 @@ type GenerateConfigFile = {
 
 type DraftMetadata = {
   schemaVersion: 1;
+  version: 1;
   artifactVersion: 1;
+  date: string;
   targetDate: string;
+  createdAt: string;
   generatedAt: string;
   provider: AiProviderName;
+  model?: string;
   activityLevel: ActivitySummary["activityLevel"];
+  formatName: string;
   storyFormat: {
     formatName: string;
     voice: string;
     tone: string;
   };
+  projects: {
+    id: string;
+    name: string;
+  }[];
   projectIds: string[];
+  status: "draft";
+  exported: false;
+  published: false;
   files: string[];
 };
 
@@ -173,24 +190,50 @@ export async function runGenerateCommand(
   const caption = deriveCaptionText(draft);
   const metadata: DraftMetadata = {
     schemaVersion: 1,
+    version: 1,
     artifactVersion: 1,
+    date: targetDate,
     targetDate,
+    createdAt: generatedAt,
     generatedAt,
     provider: provider.name,
+    model: provider.model,
     activityLevel: activitySummary.activityLevel,
+    formatName: storyFormatPlan.formatName,
     storyFormat: {
       formatName: storyFormatPlan.formatName,
       voice: storyFormatPlan.voice,
       tone: storyFormatPlan.tone
     },
+    projects: activitySummary.projects.map((project) => ({
+      id: project.projectId,
+      name: project.projectName
+    })),
     projectIds: activitySummary.projects.map((project) => project.projectId),
-    files: ["activity-summary.json", "story.json", "caption.txt", "metadata.json"]
+    status: "draft",
+    exported: false,
+    published: false,
+    files: [
+      "activity-summary.json",
+      "story.json",
+      "caption.txt",
+      "metadata.json",
+      "safety-report.json"
+    ]
   };
+  const safetyReport = createSafetyReport(
+    buildDraftSafetyText({ draft, caption, metadata })
+  );
 
   await runDraftStorageOperation(async () => {
     await writeDraftArtifactJson(draftRevision, "story.json", draft);
     await writeDraftArtifactText(draftRevision, "caption.txt", caption);
     await writeDraftArtifactJson(draftRevision, "metadata.json", metadata);
+    await writeDraftArtifactJson(
+      draftRevision,
+      "safety-report.json",
+      safetyReport
+    );
     await writeLatestDraftPointer(draftRevision, generatedAt);
   });
   await recordStoryFormatHistory({
@@ -207,8 +250,21 @@ export async function runGenerateCommand(
     activitySummary,
     storyFormatPlan,
     draft,
-    caption
+    caption,
+    safetyReport
   };
+}
+
+function buildDraftSafetyText(options: {
+  draft: DiaryDraft;
+  caption: string;
+  metadata: DraftMetadata;
+}): string {
+  return [
+    options.caption,
+    JSON.stringify(options.draft),
+    JSON.stringify(options.metadata)
+  ].join("\n");
 }
 
 async function runDraftStorageOperation<T>(

--- a/tests/draft-storage.test.ts
+++ b/tests/draft-storage.test.ts
@@ -182,6 +182,21 @@ describe("draft storage", () => {
     });
   });
 
+  it("fails with an actionable error when JSON artifact content is invalid", async () => {
+    const draftRoot = await createDraftRoot();
+    const revision = await createDraftRevision({
+      draftRoot,
+      targetDate: "2026-05-20"
+    });
+
+    await expect(
+      writeDraftArtifactJson(revision, "metadata.json", undefined)
+    ).rejects.toMatchObject({
+      code: "invalid-json",
+      message: "Draft artifact JSON is invalid."
+    });
+  });
+
   it("returns a short error for unusable draft roots", async () => {
     const directory = await createDraftRoot();
     const draftRoot = join(directory, "draft-root-file");

--- a/tests/generate-command.test.ts
+++ b/tests/generate-command.test.ts
@@ -50,10 +50,11 @@ describe("generate command", () => {
     const story = await readJson(join(outputDir, "story.json"));
     const caption = await readFile(join(outputDir, "caption.txt"), "utf8");
     const metadata = await readJson(join(outputDir, "metadata.json"));
+    const safetyReport = await readJson(join(outputDir, "safety-report.json"));
 
     expect(exitCode).toBe(0);
     expect(stderr).toEqual([]);
-    expect(stdout).toEqual(["Generated text draft for 2026-05-12."]);
+    expect(stdout).toEqual([`Generated text draft for 2026-05-12: ${outputDir}`]);
     expect(provider.requests.map((request) => request.task)).toEqual([
       "story-plan",
       "draft"
@@ -80,12 +81,40 @@ describe("generate command", () => {
     );
     expect(metadata).toMatchObject({
       schemaVersion: 1,
+      version: 1,
       targetDate: "2026-05-12",
+      date: "2026-05-12",
       artifactVersion: 1,
+      createdAt: "2026-05-12T23:30:00.000Z",
       provider: "mock",
-      files: ["activity-summary.json", "story.json", "caption.txt", "metadata.json"]
+      model: "fixture-model",
+      projects: [
+        {
+          id: fixture.project.id,
+          name: fixture.project.name
+        }
+      ],
+      activityLevel: "medium",
+      formatName: "Implementation Dispatch",
+      status: "draft",
+      exported: false,
+      published: false,
+      files: [
+        "activity-summary.json",
+        "story.json",
+        "caption.txt",
+        "metadata.json",
+        "safety-report.json"
+      ]
     });
-    expect(JSON.stringify({ activitySummary, story, metadata })).not.toContain(
+    expect(safetyReport).toMatchObject({
+      schemaVersion: 1,
+      status: "safe",
+      exportAllowed: true,
+      risks: [],
+      redactionsApplied: []
+    });
+    expect(JSON.stringify({ activitySummary, story, metadata, safetyReport })).not.toContain(
       fixture.repoDir
     );
   });
@@ -132,7 +161,9 @@ describe("generate command", () => {
 
     expect(exitCode).toBe(0);
     expect(stderr).toEqual([]);
-    expect(stdout).toEqual(["Generated text draft for 2026-05-11."]);
+    expect(stdout).toEqual([
+      `Generated text draft for 2026-05-11: ${outputDir}`
+    ]);
     expect(activitySummary).toMatchObject({
       targetDate: "2026-05-11",
       activityLevel: "none",
@@ -181,8 +212,8 @@ describe("generate command", () => {
     expect(secondExitCode).toBe(0);
     expect(stderr).toEqual([]);
     expect(stdout).toEqual([
-      "Generated text draft for 2026-05-12.",
-      "Generated text draft for 2026-05-12."
+      `Generated text draft for 2026-05-12: ${join(dateDir, "rev-001")}`,
+      `Generated text draft for 2026-05-12: ${join(dateDir, "rev-002")}`
     ]);
     expect(revOneCaption).toBe("첫 번째 draft 감정 기록.\n\n#Uncommitted #개발일기\n");
     expect(revTwoCaption).toBe("두 번째 draft 감정 기록.\n\n#Uncommitted #개발일기\n");
@@ -351,6 +382,7 @@ describe("generate command", () => {
 
 class TaskAwareProvider implements AiProvider {
   readonly name = "mock";
+  readonly model?: string;
   readonly requests: AiStructuredGenerationRequest[] = [];
 
   constructor(
@@ -358,8 +390,11 @@ class TaskAwareProvider implements AiProvider {
       plan?: StoryFormatPlan;
       draft?: ReturnType<typeof createProviderDraft>;
       failDraft?: boolean;
+      model?: string;
     } = {}
-  ) {}
+  ) {
+    this.model = options.model ?? "fixture-model";
+  }
 
   async generateStructured(
     request: AiStructuredGenerationRequest


### PR DESCRIPTION
# Goal

Complete generated text draft artifact writing so each successful `uncommitted generate` run produces the inspectable MVP artifact set with metadata and safety report output.

## Related Issue

Closes #33.

## Acceptance Criteria

- [x] A generated text draft writes `caption.txt`, `story.json`, `activity-summary.json`, `metadata.json`, and `safety-report.json`.
- [x] `metadata.json` includes date, created timestamp, version, projects, activity level, format name, provider/model when known, `status: "draft"`, `exported: false`, and `published: false`.
- [x] JSON artifacts are valid JSON and fail with actionable errors when invalid.
- [x] Partial output such as `activity-summary.json` is preserved when later generation fails after it is produced.
- [x] Existing revisions are not overwritten by artifact writing.
- [x] Tests cover a successful artifact set and failure/partial-output behavior.

## Implementation Notes

- Uses the existing draft storage helpers for revision allocation, artifact writes, and latest pointers.
- Uses the existing safety report checker to write `safety-report.json`; warning and blocked draft behavior remain scoped to the follow-up issue.
- Adds optional provider model metadata so OpenAI-compatible providers can record the configured model when available.
- Updates generate success output to include the draft revision path.

## Validation

- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`
- `git diff --staged --check`

## Remaining Risk

- Safety warning and blocked draft enforcement is intentionally not implemented here; that belongs to issue #34.
