### PR TITLE
feat: enforce safety warning and blocked draft behavior

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -123,6 +123,10 @@ async function runGenerate(
   try {
     const result = await runGenerateCommand(args, options);
 
+    if (result.safetyReport.status === "warning") {
+      io.stderr(`Safety warning: ${result.safetyReport.message}`);
+    }
+
     io.stdout(`Generated text draft for ${result.targetDate}: ${result.outputDir}`);
     return 0;
   } catch (error) {
@@ -132,7 +136,15 @@ async function runGenerate(
         return 1;
       }
 
-      return error.code === "invalid-data" ? 3 : 2;
+      if (error.code === "invalid-data") {
+        return 3;
+      }
+
+      if (error.code === "safety-blocked") {
+        return 6;
+      }
+
+      return 2;
     }
 
     if (error instanceof AiGenerationError) {

--- a/src/generate-command.ts
+++ b/src/generate-command.ts
@@ -28,7 +28,8 @@ import type { ManualNoteEvent } from "./note-command.js";
 import type { ProjectRecord, ProjectsFile } from "./project-add.js";
 import {
   createSafetyReport,
-  type SafetyReport
+  type SafetyReport,
+  type SafetyStatus
 } from "./safety-report.js";
 import {
   generateStoryFormatPlan,
@@ -41,12 +42,14 @@ export type GenerateCommandErrorCode =
   | "invalid-arguments"
   | "invalid-config"
   | "invalid-data"
-  | "no-projects";
+  | "no-projects"
+  | "safety-blocked";
 
 export class GenerateCommandError extends Error {
   constructor(
     message: string,
-    public readonly code: GenerateCommandErrorCode
+    public readonly code: GenerateCommandErrorCode,
+    public readonly outputDir?: string
   ) {
     super(message);
     this.name = "GenerateCommandError";
@@ -69,6 +72,8 @@ export type GenerateCommandResult = {
   draft: DiaryDraft;
   caption: string;
   safetyReport: SafetyReport;
+  exportPolicy: SafetyStatus;
+  exportReady: boolean;
 };
 
 type GenerateConfig = AiProviderConfig & {
@@ -83,7 +88,7 @@ type GenerateConfigFile = {
   roastLevel: number;
 };
 
-type DraftMetadata = {
+type DraftMetadataBase = {
   schemaVersion: 1;
   version: 1;
   artifactVersion: 1;
@@ -109,6 +114,17 @@ type DraftMetadata = {
   exported: false;
   published: false;
   files: string[];
+};
+
+type DraftMetadata = DraftMetadataBase & {
+  exportPolicy: SafetyStatus;
+  exportReady: boolean;
+  publishable: boolean;
+  safety: {
+    status: SafetyStatus;
+    message: string;
+    riskCount: number;
+  };
 };
 
 const usage = "Usage: uncommitted generate today | uncommitted generate --date YYYY-MM-DD";
@@ -188,7 +204,7 @@ export async function runGenerateCommand(
     roastLevel: config.roastLevel
   });
   const caption = deriveCaptionText(draft);
-  const metadata: DraftMetadata = {
+  const baseMetadata: DraftMetadataBase = {
     schemaVersion: 1,
     version: 1,
     artifactVersion: 1,
@@ -222,8 +238,19 @@ export async function runGenerateCommand(
     ]
   };
   const safetyReport = createSafetyReport(
-    buildDraftSafetyText({ draft, caption, metadata })
+    buildDraftSafetyText({ draft, caption, metadata: baseMetadata })
   );
+  const metadata: DraftMetadata = {
+    ...baseMetadata,
+    exportPolicy: safetyReport.status,
+    exportReady: safetyReport.exportAllowed,
+    publishable: safetyReport.exportAllowed,
+    safety: {
+      status: safetyReport.status,
+      message: safetyReport.message,
+      riskCount: safetyReport.risks.length
+    }
+  };
 
   await runDraftStorageOperation(async () => {
     await writeDraftArtifactJson(draftRevision, "story.json", draft);
@@ -236,6 +263,15 @@ export async function runGenerateCommand(
     );
     await writeLatestDraftPointer(draftRevision, generatedAt);
   });
+
+  if (safetyReport.status === "blocked") {
+    throw new GenerateCommandError(
+      `Draft blocked by safety checks. ${safetyReport.message}`,
+      "safety-blocked",
+      draftRevision.outputDir
+    );
+  }
+
   await recordStoryFormatHistory({
     homeDir: options.homeDir,
     targetDate,
@@ -251,14 +287,16 @@ export async function runGenerateCommand(
     storyFormatPlan,
     draft,
     caption,
-    safetyReport
+    safetyReport,
+    exportPolicy: safetyReport.status,
+    exportReady: safetyReport.exportAllowed
   };
 }
 
 function buildDraftSafetyText(options: {
   draft: DiaryDraft;
   caption: string;
-  metadata: DraftMetadata;
+  metadata: unknown;
 }): string {
   return [
     options.caption,

--- a/tests/generate-command.test.ts
+++ b/tests/generate-command.test.ts
@@ -97,6 +97,14 @@ describe("generate command", () => {
       activityLevel: "medium",
       formatName: "Implementation Dispatch",
       status: "draft",
+      exportPolicy: "safe",
+      exportReady: true,
+      publishable: true,
+      safety: {
+        status: "safe",
+        message: "Safety check passed.",
+        riskCount: 0
+      },
       exported: false,
       published: false,
       files: [
@@ -117,6 +125,104 @@ describe("generate command", () => {
     expect(JSON.stringify({ activitySummary, story, metadata, safetyReport })).not.toContain(
       fixture.repoDir
     );
+  });
+
+  it("completes warning drafts with a visible safety warning and metadata state", async () => {
+    const { io, stdout, stderr } = createIo();
+    const fixture = await createRegisteredProjectFixture();
+    const provider = new TaskAwareProvider({ model: "fixture@example.com" });
+
+    await writeGitEvent(fixture.project, "2026-05-12");
+
+    const exitCode = await runCli(["generate", "today"], io, {
+      homeDir: fixture.homeDir,
+      now: () => "2026-05-12T23:30:00.000Z",
+      aiProvider: provider
+    });
+    const outputDir = join(fixture.draftRoot, "2026-05-12", "rev-001");
+    const metadata = await readJson(join(outputDir, "metadata.json"));
+    const safetyReport = await readJson(join(outputDir, "safety-report.json"));
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toEqual([`Generated text draft for 2026-05-12: ${outputDir}`]);
+    expect(stderr).toEqual(["Safety warning: Review redactions before export."]);
+    expect(metadata).toMatchObject({
+      exportPolicy: "warning",
+      exportReady: true,
+      publishable: true,
+      safety: {
+        status: "warning",
+        message: "Review redactions before export.",
+        riskCount: 1
+      }
+    });
+    expect(safetyReport).toMatchObject({
+      status: "warning",
+      exportAllowed: true,
+      risks: [
+        {
+          category: "email",
+          severity: "warning",
+          message: "Email address was redacted."
+        }
+      ]
+    });
+  });
+
+  it("blocks unsafe drafts at the CLI boundary while preserving inspectable artifacts", async () => {
+    const { io, stdout, stderr } = createIo();
+    const fixture = await createRegisteredProjectFixture();
+    const provider = new TaskAwareProvider({ model: "TOKEN=abc123" });
+
+    await writeGitEvent(fixture.project, "2026-05-12");
+
+    const exitCode = await runCli(["generate", "today"], io, {
+      homeDir: fixture.homeDir,
+      now: () => "2026-05-12T23:30:00.000Z",
+      aiProvider: provider
+    });
+    const outputDir = join(fixture.draftRoot, "2026-05-12", "rev-001");
+    const activitySummary = await readJson(join(outputDir, "activity-summary.json"));
+    const story = await readJson(join(outputDir, "story.json"));
+    const caption = await readFile(join(outputDir, "caption.txt"), "utf8");
+    const metadata = await readJson(join(outputDir, "metadata.json"));
+    const safetyReport = await readJson(join(outputDir, "safety-report.json"));
+    const latest = await readJson(join(fixture.draftRoot, "latest.json"));
+
+    expect(exitCode).toBe(6);
+    expect(stdout).toEqual([]);
+    expect(stderr).toEqual([
+      "Draft blocked by safety checks. Remove blocked sensitive content."
+    ]);
+    expect(activitySummary).toMatchObject({ targetDate: "2026-05-12" });
+    expect(story).toMatchObject({ title: "Generate Command Day" });
+    expect(caption).toContain("오늘은 generate command를 텍스트 draft까지 연결했다.");
+    expect(metadata).toMatchObject({
+      exportPolicy: "blocked",
+      exportReady: false,
+      publishable: false,
+      safety: {
+        status: "blocked",
+        message: "Remove blocked sensitive content.",
+        riskCount: 1
+      }
+    });
+    expect(safetyReport).toMatchObject({
+      status: "blocked",
+      exportAllowed: false,
+      risks: [
+        {
+          category: "secret",
+          severity: "blocked",
+          message: "Secret or token was redacted."
+        }
+      ]
+    });
+    expect(latest).toMatchObject({
+      targetDate: "2026-05-12",
+      revision: "rev-001",
+      path: outputDir
+    });
   });
 
   it("supports --date and generates an honest quiet-day text draft", async () => {


### PR DESCRIPTION
# Goal

Enforce safety warning and blocked draft behavior in the text draft generation flow.

## Related Issue

Closes #34.

## Acceptance Criteria

- [x] Safe drafts complete normally and are marked export-eligible for later export flows.
- [x] Warning drafts complete with a visible warning and record risks in `safety-report.json`.
- [x] Blocked drafts fail at the CLI boundary with exit code `6`.
- [x] Blocked drafts preserve inspectable artifacts but are marked non-publishable/non-export-ready.
- [x] `metadata.json` reflects safe, warning, and blocked states for later preview/export commands.
- [x] Tests cover safe, warning, blocked, and partial-output preservation behavior.

## Implementation Notes

- Adds `exportPolicy`, `exportReady`, `publishable`, and a compact `safety` summary to draft metadata.
- Maps blocked safety reports to a `safety-blocked` generate command error after artifacts are written.
- Prints warning safety messages without failing generation.

## Validation

- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`

## Remaining Risk

Provider draft validation still rejects obvious unsafe provider output before the draft safety report runs, so these tests exercise warning and blocked flows through persisted generation metadata included in the safety scan.
