### PR TITLE
feat: define carousel visual HTML foundation

### DIFF
--- a/src/carousel-renderer.ts
+++ b/src/carousel-renderer.ts
@@ -1,0 +1,252 @@
+import type { DiarySlide } from "./diary-generator.js";
+
+export type CarouselRenderInputErrorCode = "invalid-story";
+
+export class CarouselRenderInputError extends Error {
+  constructor(
+    message: string,
+    public readonly code: CarouselRenderInputErrorCode
+  ) {
+    super(message);
+    this.name = "CarouselRenderInputError";
+  }
+}
+
+export type CarouselRenderInput = {
+  targetDate: string;
+  projectMarker: string;
+  slides: DiarySlide[];
+};
+
+export type CarouselHtmlCard = {
+  fileName: string;
+  slideIndex: number;
+  pageNumber: number;
+  pageCount: number;
+  html: string;
+};
+
+const invalidStoryMessage =
+  "story.json must include ordered slides with title and body.";
+
+export function parseCarouselRenderInput(value: unknown): CarouselRenderInput {
+  if (!isRecord(value)) {
+    throwInvalidStory();
+  }
+
+  if (
+    value.schemaVersion !== 1 ||
+    !isNonEmptyString(value.targetDate) ||
+    !Array.isArray(value.slides) ||
+    value.slides.length === 0
+  ) {
+    throwInvalidStory();
+  }
+
+  const slides = value.slides.map((slide, index) =>
+    parseDiarySlide(slide, index)
+  );
+
+  return {
+    targetDate: value.targetDate,
+    projectMarker: deriveProjectMarker(value),
+    slides
+  };
+}
+
+export function createCarouselHtmlCards(value: unknown): CarouselHtmlCard[] {
+  const input = parseCarouselRenderInput(value);
+  const pageCount = input.slides.length;
+
+  return input.slides.map((slide, index) => {
+    const pageNumber = index + 1;
+
+    return {
+      fileName: `${String(pageNumber).padStart(2, "0")}.html`,
+      slideIndex: slide.index,
+      pageNumber,
+      pageCount,
+      html: renderCardHtml({
+        targetDate: input.targetDate,
+        projectMarker: input.projectMarker,
+        slide,
+        pageNumber,
+        pageCount
+      })
+    };
+  });
+}
+
+function parseDiarySlide(value: unknown, index: number): DiarySlide {
+  if (
+    !isRecord(value) ||
+    value.index !== index + 1 ||
+    !isNonEmptyString(value.title) ||
+    !isNonEmptyString(value.body) ||
+    !isNonEmptyString(value.visualMood)
+  ) {
+    throwInvalidStory();
+  }
+
+  return {
+    index: value.index,
+    title: value.title,
+    body: value.body,
+    visualMood: value.visualMood
+  };
+}
+
+function renderCardHtml(options: {
+  targetDate: string;
+  projectMarker: string;
+  slide: DiarySlide;
+  pageNumber: number;
+  pageCount: number;
+}): string {
+  const title = escapeHtml(options.slide.title.trim());
+  const body = escapeHtml(options.slide.body.trim());
+  const targetDate = escapeHtml(options.targetDate.trim());
+  const projectMarker = escapeHtml(options.projectMarker.trim());
+  const pageIndicator = `${options.pageNumber} / ${options.pageCount}`;
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=1080, initial-scale=1">
+  <title>${title}</title>
+  <style>
+    :root {
+      color-scheme: light;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: #f7f7f5;
+      color: #161616;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      background: #f7f7f5;
+    }
+
+    .card {
+      width: 1080px;
+      height: 1350px;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      padding: 88px 84px 72px;
+      background: #f7f7f5;
+      color: #161616;
+      overflow: hidden;
+    }
+
+    .topline,
+    .footer {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 32px;
+      font-size: 30px;
+      font-weight: 700;
+      letter-spacing: 0;
+      line-height: 1.2;
+      color: #4b5563;
+    }
+
+    .project-marker {
+      max-width: 640px;
+      overflow-wrap: anywhere;
+    }
+
+    .content {
+      display: flex;
+      flex-direction: column;
+      gap: 52px;
+      margin: 96px 0;
+    }
+
+    h1 {
+      margin: 0;
+      max-width: 900px;
+      font-size: 90px;
+      line-height: 0.98;
+      letter-spacing: 0;
+      color: #111827;
+    }
+
+    .body {
+      margin: 0;
+      max-width: 860px;
+      font-size: 48px;
+      line-height: 1.22;
+      letter-spacing: 0;
+      color: #1f2937;
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+    }
+
+    .mark {
+      font-size: 34px;
+      font-weight: 800;
+      color: #0f766e;
+    }
+  </style>
+</head>
+<body>
+  <article class="card" aria-label="Uncommitted carousel card ${escapeHtml(
+    pageIndicator
+  )}">
+    <header class="topline">
+      <div class="project-marker">${projectMarker}</div>
+      <time datetime="${targetDate}">${targetDate}</time>
+    </header>
+    <main class="content">
+      <h1>${title}</h1>
+      <p class="body">${body}</p>
+    </main>
+    <footer class="footer">
+      <div class="mark">Uncommitted</div>
+      <div>${escapeHtml(pageIndicator)}</div>
+    </footer>
+  </article>
+</body>
+</html>
+`;
+}
+
+function deriveProjectMarker(value: Record<string, unknown>): string {
+  const metadata = value.metadata;
+
+  if (!isRecord(metadata) || !Array.isArray(metadata.projectIds)) {
+    return "Uncommitted";
+  }
+
+  const firstProjectId = metadata.projectIds.find(isNonEmptyString);
+
+  return firstProjectId?.trim() ?? "Uncommitted";
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function throwInvalidStory(): never {
+  throw new CarouselRenderInputError(invalidStoryMessage, "invalid-story");
+}

--- a/src/carousel-renderer.ts
+++ b/src/carousel-renderer.ts
@@ -18,11 +18,21 @@ export type CarouselRenderInput = {
   slides: DiarySlide[];
 };
 
+export type CarouselVisualTreatmentKind = "illustration";
+
+export type CarouselVisualTreatment = {
+  kind: CarouselVisualTreatmentKind;
+  assetSlotId: string;
+  prompt: string;
+  altText: string;
+};
+
 export type CarouselHtmlCard = {
   fileName: string;
   slideIndex: number;
   pageNumber: number;
   pageCount: number;
+  visualTreatment: CarouselVisualTreatment;
   html: string;
 };
 
@@ -60,16 +70,19 @@ export function createCarouselHtmlCards(value: unknown): CarouselHtmlCard[] {
 
   return input.slides.map((slide, index) => {
     const pageNumber = index + 1;
+    const visualTreatment = createVisualTreatment(slide, pageNumber);
 
     return {
       fileName: `${String(pageNumber).padStart(2, "0")}.html`,
       slideIndex: slide.index,
       pageNumber,
       pageCount,
+      visualTreatment,
       html: renderCardHtml({
         targetDate: input.targetDate,
         projectMarker: input.projectMarker,
         slide,
+        visualTreatment,
         pageNumber,
         pageCount
       })
@@ -100,6 +113,7 @@ function renderCardHtml(options: {
   targetDate: string;
   projectMarker: string;
   slide: DiarySlide;
+  visualTreatment: CarouselVisualTreatment;
   pageNumber: number;
   pageCount: number;
 }): string {
@@ -107,6 +121,10 @@ function renderCardHtml(options: {
   const body = escapeHtml(options.slide.body.trim());
   const targetDate = escapeHtml(options.targetDate.trim());
   const projectMarker = escapeHtml(options.projectMarker.trim());
+  const visualAssetSlotId = escapeHtml(options.visualTreatment.assetSlotId);
+  const visualKind = escapeHtml(options.visualTreatment.kind);
+  const visualPrompt = escapeHtml(options.visualTreatment.prompt);
+  const visualAltText = escapeHtml(options.visualTreatment.altText);
   const pageIndicator = `${options.pageNumber} / ${options.pageCount}`;
 
   return `<!doctype html>
@@ -162,11 +180,61 @@ function renderCardHtml(options: {
       overflow-wrap: anywhere;
     }
 
+    .visual-stage {
+      position: relative;
+      min-height: 670px;
+      margin: 54px 0 44px;
+      border: 2px solid #d4d4d8;
+      background:
+        linear-gradient(135deg, rgba(15, 118, 110, 0.16), rgba(15, 23, 42, 0) 42%),
+        linear-gradient(315deg, rgba(251, 191, 36, 0.2), rgba(15, 23, 42, 0) 44%),
+        #eef2f7;
+      overflow: hidden;
+    }
+
+    .visual-stage::before,
+    .visual-stage::after {
+      position: absolute;
+      content: "";
+      border: 2px solid rgba(15, 23, 42, 0.18);
+    }
+
+    .visual-stage::before {
+      width: 430px;
+      height: 430px;
+      right: -92px;
+      top: 70px;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.42);
+    }
+
+    .visual-stage::after {
+      width: 360px;
+      height: 240px;
+      left: 92px;
+      bottom: 92px;
+      background: rgba(255, 255, 255, 0.58);
+      transform: rotate(-7deg);
+    }
+
+    .visual-placeholder {
+      position: absolute;
+      left: 72px;
+      right: 72px;
+      bottom: 58px;
+      z-index: 1;
+      font-size: 30px;
+      font-weight: 700;
+      line-height: 1.25;
+      color: #334155;
+      overflow-wrap: anywhere;
+    }
+
     .content {
       display: flex;
       flex-direction: column;
       gap: 52px;
-      margin: 96px 0;
+      margin: 0 0 44px;
     }
 
     h1 {
@@ -204,6 +272,15 @@ function renderCardHtml(options: {
       <div class="project-marker">${projectMarker}</div>
       <time datetime="${targetDate}">${targetDate}</time>
     </header>
+    <section
+      class="visual-stage"
+      data-visual-kind="${visualKind}"
+      data-asset-slot-id="${visualAssetSlotId}"
+      data-visual-prompt="${visualPrompt}"
+      aria-label="${visualAltText}"
+    >
+      <div class="visual-placeholder">${visualPrompt}</div>
+    </section>
     <main class="content">
       <h1>${title}</h1>
       <p class="body">${body}</p>
@@ -216,6 +293,20 @@ function renderCardHtml(options: {
 </body>
 </html>
 `;
+}
+
+function createVisualTreatment(
+  slide: DiarySlide,
+  pageNumber: number
+): CarouselVisualTreatment {
+  const prompt = slide.visualMood.trim();
+
+  return {
+    kind: "illustration",
+    assetSlotId: `slide-${String(pageNumber).padStart(2, "0")}-visual`,
+    prompt,
+    altText: `Illustration concept: ${prompt}`
+  };
 }
 
 function deriveProjectMarker(value: Record<string, unknown>): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,9 @@ export {
 export type {
   CarouselHtmlCard,
   CarouselRenderInput,
-  CarouselRenderInputErrorCode
+  CarouselRenderInputErrorCode,
+  CarouselVisualTreatment,
+  CarouselVisualTreatmentKind
 } from "./carousel-renderer.js";
 export {
   collectGitForRegisteredProjects,

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,16 @@ export type { CliIo, CliOptions } from "./cli.js";
 export { commands, isKnownCommand } from "./commands.js";
 export type { Command } from "./commands.js";
 export {
+  CarouselRenderInputError,
+  createCarouselHtmlCards,
+  parseCarouselRenderInput
+} from "./carousel-renderer.js";
+export type {
+  CarouselHtmlCard,
+  CarouselRenderInput,
+  CarouselRenderInputErrorCode
+} from "./carousel-renderer.js";
+export {
   collectGitForRegisteredProjects,
   CollectGitCommandError
 } from "./collect-git-command.js";

--- a/tests/carousel-renderer.test.ts
+++ b/tests/carousel-renderer.test.ts
@@ -24,9 +24,18 @@ describe("carousel renderer", () => {
     expect(cards[0]?.html).toContain("uncommitted");
     expect(cards[0]?.html).toContain("1 / 3");
     expect(cards[0]?.html).toContain("Uncommitted");
+    expect(cards[0]?.visualTreatment).toEqual({
+      kind: "illustration",
+      assetSlotId: "slide-01-visual",
+      prompt: "clean card",
+      altText: "Illustration concept: clean card"
+    });
+    expect(cards[0]?.html).toContain("class=\"visual-stage\"");
+    expect(cards[0]?.html).toContain("data-visual-kind=\"illustration\"");
+    expect(cards[0]?.html).toContain("data-asset-slot-id=\"slide-01-visual\"");
   });
 
-  it("escapes slide content before writing HTML", () => {
+  it("escapes slide and visual treatment content before writing HTML", () => {
     const cards = createCarouselHtmlCards(
       createStoryDraft({
         slides: [
@@ -34,7 +43,7 @@ describe("carousel renderer", () => {
             index: 1,
             title: "Fix <script>",
             body: "Rendered & safe.",
-            visualMood: "plain"
+            visualMood: "terminal <alert> & sparks"
           },
           {
             index: 2,
@@ -54,7 +63,9 @@ describe("carousel renderer", () => {
 
     expect(cards[0]?.html).toContain("Fix &lt;script&gt;");
     expect(cards[0]?.html).toContain("Rendered &amp; safe.");
+    expect(cards[0]?.html).toContain("terminal &lt;alert&gt; &amp; sparks");
     expect(cards[0]?.html).not.toContain("Fix <script>");
+    expect(cards[0]?.html).not.toContain("terminal <alert>");
   });
 
   it("parses the existing story.json slide contract for rendering", () => {

--- a/tests/carousel-renderer.test.ts
+++ b/tests/carousel-renderer.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import {
+  CarouselRenderInputError,
+  createCarouselHtmlCards,
+  parseCarouselRenderInput
+} from "../src/carousel-renderer.js";
+import type { DiaryDraft } from "../src/diary-generator.js";
+
+describe("carousel renderer", () => {
+  it("creates one deterministic HTML card per slide in story order", () => {
+    const cards = createCarouselHtmlCards(createStoryDraft());
+
+    expect(cards).toHaveLength(3);
+    expect(cards.map((card) => card.fileName)).toEqual([
+      "01.html",
+      "02.html",
+      "03.html"
+    ]);
+    expect(cards.map((card) => card.slideIndex)).toEqual([1, 2, 3]);
+    expect(cards[0]?.html).toContain("width: 1080px;");
+    expect(cards[0]?.html).toContain("height: 1350px;");
+    expect(cards[0]?.html).toContain("Opening Statement");
+    expect(cards[0]?.html).toContain("2026-05-18");
+    expect(cards[0]?.html).toContain("uncommitted");
+    expect(cards[0]?.html).toContain("1 / 3");
+    expect(cards[0]?.html).toContain("Uncommitted");
+  });
+
+  it("escapes slide content before writing HTML", () => {
+    const cards = createCarouselHtmlCards(
+      createStoryDraft({
+        slides: [
+          {
+            index: 1,
+            title: "Fix <script>",
+            body: "Rendered & safe.",
+            visualMood: "plain"
+          },
+          {
+            index: 2,
+            title: "Quote",
+            body: "\"Ship\" without surprise.",
+            visualMood: "plain"
+          },
+          {
+            index: 3,
+            title: "Done",
+            body: "Card renderer stays local.",
+            visualMood: "plain"
+          }
+        ]
+      })
+    );
+
+    expect(cards[0]?.html).toContain("Fix &lt;script&gt;");
+    expect(cards[0]?.html).toContain("Rendered &amp; safe.");
+    expect(cards[0]?.html).not.toContain("Fix <script>");
+  });
+
+  it("parses the existing story.json slide contract for rendering", () => {
+    const input = parseCarouselRenderInput(createStoryDraft());
+
+    expect(input).toEqual({
+      targetDate: "2026-05-18",
+      projectMarker: "uncommitted",
+      slides: [
+        {
+          index: 1,
+          title: "Opening Statement",
+          body: "The renderer now has a contract before it gets a camera.",
+          visualMood: "clean card"
+        },
+        {
+          index: 2,
+          title: "Evidence",
+          body: "Slide order survived the trip from story.json.",
+          visualMood: "ordered stack"
+        },
+        {
+          index: 3,
+          title: "Verdict",
+          body: "PNG work can arrive later without guessing HTML shape.",
+          visualMood: "quiet stamp"
+        }
+      ]
+    });
+  });
+
+  it("fails invalid slide data with a short render-input error", () => {
+    const invalidDraft = {
+      ...createStoryDraft(),
+      slides: [
+        {
+          index: 2,
+          title: "",
+          body: "Missing useful title.",
+          visualMood: "broken"
+        }
+      ]
+    };
+
+    expect(() => createCarouselHtmlCards(invalidDraft)).toThrow(
+      new CarouselRenderInputError(
+        "story.json must include ordered slides with title and body.",
+        "invalid-story"
+      )
+    );
+  });
+});
+
+function createStoryDraft(overrides: Partial<DiaryDraft> = {}): DiaryDraft {
+  return {
+    schemaVersion: 1,
+    targetDate: "2026-05-18",
+    title: "Renderer Foundation Day",
+    caption: "HTML cards first, camera later.",
+    slides: [
+      {
+        index: 1,
+        title: "Opening Statement",
+        body: "The renderer now has a contract before it gets a camera.",
+        visualMood: "clean card"
+      },
+      {
+        index: 2,
+        title: "Evidence",
+        body: "Slide order survived the trip from story.json.",
+        visualMood: "ordered stack"
+      },
+      {
+        index: 3,
+        title: "Verdict",
+        body: "PNG work can arrive later without guessing HTML shape.",
+        visualMood: "quiet stamp"
+      }
+    ],
+    hashtags: ["#Uncommitted"],
+    altText: "Uncommitted carousel draft.",
+    metadata: {
+      targetDate: "2026-05-18",
+      generatedAt: "2026-05-18T23:30:00.000Z",
+      activityLevel: "medium",
+      formatName: "Bug Court Transcript",
+      storyFormatVoice: "tired QA narrator",
+      storyFormatTone: "deadpan",
+      projectIds: ["uncommitted"],
+      entryMode: "daily_global",
+      slideCount: 3
+    },
+    ...overrides
+  };
+}


### PR DESCRIPTION
# Goal

Define the Carousel Rendering foundation that converts existing `story.json` slide data into deterministic 4:5 HTML documents with an explicit illustration/visual asset slot.

## Related Issue

Closes #47.

## Acceptance Criteria

- [x] A renderer input type or parser can load the existing `story.json` slide contract
- [x] Valid draft data produces one HTML card document per slide in original slide order
- [x] The default card dimensions are fixed at 1080 x 1350 or equivalent 4:5 CSS sizing
- [x] Generated card HTML includes title, body, date, page indicator, and Uncommitted mark
- [x] Invalid draft input fails with a short actionable render-input error
- [x] Tests cover successful HTML generation and at least one invalid input case

## Implementation Notes

- Added `parseCarouselRenderInput` and `createCarouselHtmlCards` for the HTML rendering foundation.
- Reused the existing `DiaryDraft` / `story.json` slide shape instead of introducing a separate draft schema.
- Added `CarouselVisualTreatment` metadata so each slide has a stable illustration asset slot such as `slide-01-visual` derived from `visualMood`.
- The HTML template is no longer purely text-card shaped: it reserves a primary visual stage where a future AI-generated or selected illustration asset can be composed before Playwright screenshots the final PNG.
- Actual AI image generation and Playwright PNG output remain scoped to follow-up renderer work.

## Validation

- `pnpm exec vitest run tests/carousel-renderer.test.ts`
- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`

## Remaining Risk

- The current visual stage uses deterministic placeholder CSS/content only. A later issue still needs to define how AI-generated illustration assets are produced, stored, and inserted into this slot.