### PR TITLE
feat: generate carousel visual assets from slide intent

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,7 @@ import {
   recordManualNote
 } from "./note-command.js";
 import { addProject, ProjectAddError } from "./project-add.js";
+import type { ImageAssetProvider } from "./visual-assets.js";
 
 export type CliIo = {
   stdout: (message: string) => void;
@@ -33,6 +34,7 @@ export type CliOptions = {
   homeDir?: string;
   now?: () => string;
   aiProvider?: AiProvider;
+  imageAssetProvider?: ImageAssetProvider;
 };
 
 const defaultIo: CliIo = {
@@ -142,6 +144,10 @@ async function runGenerate(
 
       if (error.code === "safety-blocked") {
         return 6;
+      }
+
+      if (error.code === "visual-generation-failed") {
+        return 5;
       }
 
       return 2;

--- a/src/draft-storage.ts
+++ b/src/draft-storage.ts
@@ -1,5 +1,5 @@
 import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 export type DraftStorageErrorCode =
   | "inspect-failed"
@@ -136,6 +136,21 @@ export async function writeDraftArtifactText(
 ): Promise<void> {
   try {
     await writeFile(join(revision.outputDir, filename), value, "utf8");
+  } catch {
+    throw new DraftStorageError("Could not write draft files.", "write-failed");
+  }
+}
+
+export async function writeDraftArtifactBinary(
+  revision: DraftRevision,
+  filename: string,
+  value: Uint8Array
+): Promise<void> {
+  const path = join(revision.outputDir, filename);
+
+  try {
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, value);
   } catch {
     throw new DraftStorageError("Could not write draft files.", "write-failed");
   }

--- a/src/generate-command.ts
+++ b/src/generate-command.ts
@@ -10,6 +10,7 @@ import {
   type AiProviderConfig,
   type AiProviderName
 } from "./ai-provider.js";
+import { createCarouselHtmlCards } from "./carousel-renderer.js";
 import type { GitActivityEvent } from "./collect-git-command.js";
 import { resolveConfigPaths } from "./config-paths.js";
 import {
@@ -37,13 +38,22 @@ import {
   recordStoryFormatHistory,
   type StoryFormatPlan
 } from "./story-format-plan.js";
+import {
+  createImageAssetProvider,
+  generateCarouselVisualAssets,
+  type ImageAssetProvider,
+  VisualAssetGenerationError,
+  type VisualAssetGenerationResult,
+  type VisualAssetMetadata
+} from "./visual-assets.js";
 
 export type GenerateCommandErrorCode =
   | "invalid-arguments"
   | "invalid-config"
   | "invalid-data"
   | "no-projects"
-  | "safety-blocked";
+  | "safety-blocked"
+  | "visual-generation-failed";
 
 export class GenerateCommandError extends Error {
   constructor(
@@ -60,6 +70,7 @@ export type GenerateCommandOptions = {
   homeDir?: string;
   now?: () => string;
   aiProvider?: AiProvider;
+  imageAssetProvider?: ImageAssetProvider;
 };
 
 export type GenerateCommandResult = {
@@ -72,6 +83,7 @@ export type GenerateCommandResult = {
   draft: DiaryDraft;
   caption: string;
   safetyReport: SafetyReport;
+  visualAssets: VisualAssetGenerationResult;
   exportPolicy: SafetyStatus;
   exportReady: boolean;
 };
@@ -120,6 +132,7 @@ type DraftMetadata = DraftMetadataBase & {
   exportPolicy: SafetyStatus;
   exportReady: boolean;
   publishable: boolean;
+  visualAssets: VisualAssetMetadata[];
   safety: {
     status: SafetyStatus;
     message: string;
@@ -147,6 +160,13 @@ const dirtyStatuses = new Set([
   "untracked",
   "other"
 ]);
+const baseDraftFiles = [
+  "activity-summary.json",
+  "story.json",
+  "caption.txt",
+  "metadata.json",
+  "safety-report.json"
+];
 
 export async function runGenerateCommand(
   args: string[],
@@ -186,6 +206,10 @@ export async function runGenerateCommand(
   );
 
   const provider = options.aiProvider ?? createAiProvider(config);
+  const imageAssetProvider = await runVisualAssetGeneration(
+    async () => options.imageAssetProvider ?? createImageAssetProvider(config),
+    draftRevision.outputDir
+  );
   const recentFormats = await loadRecentStoryFormatHistory({
     homeDir: options.homeDir
   });
@@ -229,48 +253,64 @@ export async function runGenerateCommand(
     status: "draft",
     exported: false,
     published: false,
-    files: [
-      "activity-summary.json",
-      "story.json",
-      "caption.txt",
-      "metadata.json",
-      "safety-report.json"
-    ]
+    files: [...baseDraftFiles]
   };
   const safetyReport = createSafetyReport(
     buildDraftSafetyText({ draft, caption, metadata: baseMetadata })
   );
-  const metadata: DraftMetadata = {
-    ...baseMetadata,
-    exportPolicy: safetyReport.status,
-    exportReady: safetyReport.exportAllowed,
-    publishable: safetyReport.exportAllowed,
-    safety: {
-      status: safetyReport.status,
-      message: safetyReport.message,
-      riskCount: safetyReport.risks.length
+  const safetyMetadata = buildDraftMetadata({
+    baseMetadata,
+    safetyReport,
+    visualAssets: {
+      schemaVersion: 1,
+      files: [],
+      assets: []
     }
-  };
+  });
 
   await runDraftStorageOperation(async () => {
     await writeDraftArtifactJson(draftRevision, "story.json", draft);
     await writeDraftArtifactText(draftRevision, "caption.txt", caption);
-    await writeDraftArtifactJson(draftRevision, "metadata.json", metadata);
     await writeDraftArtifactJson(
       draftRevision,
       "safety-report.json",
       safetyReport
     );
-    await writeLatestDraftPointer(draftRevision, generatedAt);
   });
 
   if (safetyReport.status === "blocked") {
+    await runDraftStorageOperation(async () => {
+      await writeDraftArtifactJson(draftRevision, "metadata.json", safetyMetadata);
+      await writeLatestDraftPointer(draftRevision, generatedAt);
+    });
+
     throw new GenerateCommandError(
       `Draft blocked by safety checks. ${safetyReport.message}`,
       "safety-blocked",
       draftRevision.outputDir
     );
   }
+
+  const visualAssets = await runVisualAssetGeneration(
+    () =>
+      generateCarouselVisualAssets({
+        revision: draftRevision,
+        cards: createCarouselHtmlCards(draft),
+        provider: imageAssetProvider,
+        fallbackProviderName: config.provider
+      }),
+    draftRevision.outputDir
+  );
+  const metadata = buildDraftMetadata({
+    baseMetadata,
+    safetyReport,
+    visualAssets
+  });
+
+  await runDraftStorageOperation(async () => {
+    await writeDraftArtifactJson(draftRevision, "metadata.json", metadata);
+    await writeLatestDraftPointer(draftRevision, generatedAt);
+  });
 
   await recordStoryFormatHistory({
     homeDir: options.homeDir,
@@ -288,8 +328,29 @@ export async function runGenerateCommand(
     draft,
     caption,
     safetyReport,
+    visualAssets,
     exportPolicy: safetyReport.status,
     exportReady: safetyReport.exportAllowed
+  };
+}
+
+function buildDraftMetadata(options: {
+  baseMetadata: DraftMetadataBase;
+  safetyReport: SafetyReport;
+  visualAssets: VisualAssetGenerationResult;
+}): DraftMetadata {
+  return {
+    ...options.baseMetadata,
+    files: [...baseDraftFiles, ...options.visualAssets.files],
+    exportPolicy: options.safetyReport.status,
+    exportReady: options.safetyReport.exportAllowed,
+    publishable: options.safetyReport.exportAllowed,
+    visualAssets: options.visualAssets.assets,
+    safety: {
+      status: options.safetyReport.status,
+      message: options.safetyReport.message,
+      riskCount: options.safetyReport.risks.length
+    }
   };
 }
 
@@ -313,6 +374,25 @@ async function runDraftStorageOperation<T>(
   } catch (error) {
     if (error instanceof DraftStorageError) {
       throw new GenerateCommandError(error.message, "invalid-config");
+    }
+
+    throw error;
+  }
+}
+
+async function runVisualAssetGeneration<T>(
+  operation: () => Promise<T>,
+  outputDir: string
+): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    if (error instanceof VisualAssetGenerationError) {
+      throw new GenerateCommandError(
+        error.message,
+        "visual-generation-failed",
+        outputDir
+      );
     }
 
     throw error;

--- a/src/index.ts
+++ b/src/index.ts
@@ -138,6 +138,7 @@ export {
   createDraftRevision,
   DraftStorageError,
   readLatestDraftPointer,
+  writeDraftArtifactBinary,
   writeDraftArtifactJson,
   writeDraftArtifactText,
   writeLatestDraftPointer,
@@ -150,6 +151,22 @@ export type {
   TextDraftRevisionInput,
   TextDraftWriteResult
 } from "./draft-storage.js";
+export {
+  createImageAssetProvider,
+  generateCarouselVisualAssets,
+  VisualAssetGenerationError
+} from "./visual-assets.js";
+export type {
+  CreateImageAssetProviderOptions,
+  GenerateCarouselVisualAssetsOptions,
+  ImageAssetProvider,
+  ImageAssetProviderResult,
+  ImageAssetRequest,
+  VisualAssetFallbackState,
+  VisualAssetGenerationErrorCode,
+  VisualAssetGenerationResult,
+  VisualAssetMetadata
+} from "./visual-assets.js";
 export { runInitCommand } from "./init-command.js";
 export type {
   InitAnswers,

--- a/src/visual-assets.ts
+++ b/src/visual-assets.ts
@@ -1,0 +1,414 @@
+import { join } from "node:path";
+import process from "node:process";
+import type {
+  AiProviderConfig,
+  AiProviderHttpRequest,
+  AiProviderHttpResponse,
+  AiProviderHttpTransport,
+  AiProviderName
+} from "./ai-provider.js";
+import type { CarouselHtmlCard } from "./carousel-renderer.js";
+import {
+  type DraftRevision,
+  DraftStorageError,
+  writeDraftArtifactBinary
+} from "./draft-storage.js";
+import { checkDraftSafety } from "./safety-report.js";
+
+export type VisualAssetFallbackState =
+  | "none"
+  | "no-provider"
+  | "provider-unsupported";
+
+export type VisualAssetGenerationErrorCode =
+  | "provider-failed"
+  | "provider-unavailable"
+  | "write-failed";
+
+export class VisualAssetGenerationError extends Error {
+  constructor(
+    message: string,
+    public readonly code: VisualAssetGenerationErrorCode
+  ) {
+    super(message);
+    this.name = "VisualAssetGenerationError";
+  }
+}
+
+export type ImageAssetRequest = {
+  schemaVersion: 1;
+  slideIndex: number;
+  assetSlotId: string;
+  prompt: string;
+  promptSummary: string;
+};
+
+export type ImageAssetProviderResult = {
+  mimeType: "image/png";
+  data: Uint8Array;
+};
+
+export interface ImageAssetProvider {
+  readonly name: string;
+  generateImageAsset(
+    request: ImageAssetRequest
+  ): Promise<ImageAssetProviderResult>;
+}
+
+export type VisualAssetMetadata = {
+  schemaVersion: 1;
+  slideIndex: number;
+  assetSlotId: string;
+  promptSummary: string;
+  provider: string;
+  filePath: string;
+  fallbackState: VisualAssetFallbackState;
+};
+
+export type VisualAssetGenerationResult = {
+  schemaVersion: 1;
+  files: string[];
+  assets: VisualAssetMetadata[];
+};
+
+export type GenerateCarouselVisualAssetsOptions = {
+  revision: DraftRevision;
+  cards: CarouselHtmlCard[];
+  provider?: ImageAssetProvider;
+  fallbackProviderName: AiProviderName | string;
+};
+
+export type CreateImageAssetProviderOptions = {
+  env?: Record<string, string | undefined>;
+  transport?: AiProviderHttpTransport;
+  timeoutMs?: number;
+};
+
+const openAiImageEndpoint = "https://api.openai.com/v1/images/generations";
+const openAiImageEnvKey = "OPENAI_API_KEY";
+const openAiImageModel = "gpt-image-1.5";
+const defaultImageProviderTimeoutMs = 300_000;
+const providerTimeoutEnvKey = "UNCOMMITTED_AI_TIMEOUT_MS";
+const placeholderPng = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+  "base64"
+);
+
+export function createImageAssetProvider(
+  config: AiProviderConfig,
+  options: CreateImageAssetProviderOptions = {}
+): ImageAssetProvider | undefined {
+  if (config.provider !== "openai") {
+    return undefined;
+  }
+
+  const apiKey = resolveEnvValue(options, openAiImageEnvKey);
+
+  if (!apiKey) {
+    throw new VisualAssetGenerationError(
+      `${openAiImageEnvKey} is not set.`,
+      "provider-unavailable"
+    );
+  }
+
+  return new OpenAiImageAssetProvider({
+    apiKey,
+    timeoutMs: resolveProviderTimeoutMs(options),
+    transport: options.transport ?? defaultFetchTransport
+  });
+}
+
+export async function generateCarouselVisualAssets(
+  options: GenerateCarouselVisualAssetsOptions
+): Promise<VisualAssetGenerationResult> {
+  const assets: VisualAssetMetadata[] = [];
+  const files: string[] = [];
+
+  for (const [index, card] of options.cards.entries()) {
+    const fileName = `visuals/${String(index + 1).padStart(2, "0")}.png`;
+    const request = createImageAssetRequest(card);
+    const provider = options.provider;
+    const image = provider
+      ? await generateProviderImage(provider, request)
+      : {
+          mimeType: "image/png" as const,
+          data: placeholderPng
+        };
+
+    try {
+      await writeDraftArtifactBinary(options.revision, fileName, image.data);
+    } catch (error) {
+      if (error instanceof DraftStorageError) {
+        throw new VisualAssetGenerationError(
+          error.message,
+          "write-failed"
+        );
+      }
+
+      throw error;
+    }
+
+    files.push(fileName);
+    assets.push({
+      schemaVersion: 1,
+      slideIndex: card.slideIndex,
+      assetSlotId: card.visualTreatment.assetSlotId,
+      promptSummary: request.promptSummary,
+      provider: provider?.name ?? options.fallbackProviderName,
+      filePath: join(options.revision.outputDir, fileName),
+      fallbackState: provider
+        ? "none"
+        : deriveFallbackState(options.fallbackProviderName)
+    });
+  }
+
+  return {
+    schemaVersion: 1,
+    files,
+    assets
+  };
+}
+
+function createImageAssetRequest(card: CarouselHtmlCard): ImageAssetRequest {
+  const promptSummary = sanitizeVisualPrompt(card.visualTreatment.prompt);
+
+  return {
+    schemaVersion: 1,
+    slideIndex: card.slideIndex,
+    assetSlotId: card.visualTreatment.assetSlotId,
+    promptSummary,
+    prompt: [
+      "Create a 4:5 editorial illustration for an Uncommitted developer diary carousel.",
+      "Use abstract UI objects, terminals, notes, browser frames, charts, or desk objects.",
+      "Do not include readable secrets, raw code, private URLs, emails, tokens, or local file paths.",
+      `Visual intent: ${promptSummary}`
+    ].join("\n")
+  };
+}
+
+function sanitizeVisualPrompt(value: string): string {
+  const safetyChecked = checkDraftSafety(value).redactedText;
+  const codeRedacted = safetyChecked
+    .replace(/`[^`]*`/g, "[redacted-code]")
+    .replace(/\bdiff --git\b[\s\S]*/gi, "[redacted-code]")
+    .replace(
+      /\b(?:const|let|var|function|class|import|export)\s+[^.;\n]+[;]?/g,
+      "[redacted-code]"
+    )
+    .replace(/\bprocess\.env\.[A-Z0-9_]+\b/gi, "[redacted-secret]")
+    .replace(/`/g, "");
+  const normalized = codeRedacted.replace(/\s+/g, " ").trim();
+
+  return normalized.length > 0 ? normalized.slice(0, 280) : "abstract workday";
+}
+
+class OpenAiImageAssetProvider implements ImageAssetProvider {
+  readonly name = "openai";
+
+  constructor(
+    private readonly options: {
+      apiKey: string;
+      timeoutMs: number;
+      transport: AiProviderHttpTransport;
+    }
+  ) {}
+
+  async generateImageAsset(
+    request: ImageAssetRequest
+  ): Promise<ImageAssetProviderResult> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.options.timeoutMs);
+
+    try {
+      const response = await this.options.transport(openAiImageEndpoint, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this.options.apiKey}`,
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({
+          model: openAiImageModel,
+          prompt: request.prompt,
+          n: 1,
+          size: "1024x1536",
+          quality: "low",
+          output_format: "png"
+        }),
+        signal: controller.signal
+      });
+
+      if (!response.ok) {
+        throwOpenAiImageHttpError(response.status);
+      }
+
+      return {
+        mimeType: "image/png",
+        data: decodeOpenAiImageResponse(await readResponseJson(response))
+      };
+    } catch (error) {
+      if (error instanceof VisualAssetGenerationError) {
+        throw error;
+      }
+
+      if (isAbortError(error)) {
+        throw new VisualAssetGenerationError(
+          "Visual generation timed out. Try again later.",
+          "provider-failed"
+        );
+      }
+
+      throw new VisualAssetGenerationError(
+        "Visual generation failed. Check image provider configuration.",
+        "provider-failed"
+      );
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+async function generateProviderImage(
+  provider: ImageAssetProvider,
+  request: ImageAssetRequest
+): Promise<ImageAssetProviderResult> {
+  try {
+    const result = await provider.generateImageAsset(request);
+
+    if (result.mimeType !== "image/png") {
+      throw new VisualAssetGenerationError(
+        "Visual generation failed. Check image provider configuration.",
+        "provider-failed"
+      );
+    }
+
+    return result;
+  } catch (error) {
+    if (error instanceof VisualAssetGenerationError) {
+      throw error;
+    }
+
+    throw new VisualAssetGenerationError(
+      "Visual generation failed. Check image provider configuration.",
+      "provider-failed"
+    );
+  }
+}
+
+async function defaultFetchTransport(
+  url: string,
+  request: AiProviderHttpRequest
+): Promise<AiProviderHttpResponse> {
+  return await fetch(url, request);
+}
+
+async function readResponseJson(
+  response: AiProviderHttpResponse
+): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    throw new VisualAssetGenerationError(
+      "Image provider returned invalid response.",
+      "provider-failed"
+    );
+  }
+}
+
+function decodeOpenAiImageResponse(value: unknown): Uint8Array {
+  if (!isOpenAiImageResponse(value)) {
+    throw new VisualAssetGenerationError(
+      "Image provider returned invalid response.",
+      "provider-failed"
+    );
+  }
+
+  return Buffer.from(value.data[0].b64_json, "base64");
+}
+
+function throwOpenAiImageHttpError(status: number): never {
+  if (status === 401 || status === 403) {
+    throw new VisualAssetGenerationError(
+      "Image provider authentication failed. Check API key.",
+      "provider-failed"
+    );
+  }
+
+  if (status === 408 || status === 504) {
+    throw new VisualAssetGenerationError(
+      "Visual generation timed out. Try again later.",
+      "provider-failed"
+    );
+  }
+
+  if (status === 429) {
+    throw new VisualAssetGenerationError(
+      "Image provider rate limit exceeded. Try again later.",
+      "provider-failed"
+    );
+  }
+
+  throw new VisualAssetGenerationError(
+    "Visual generation failed. Check image provider configuration.",
+    "provider-failed"
+  );
+}
+
+function resolveProviderTimeoutMs(
+  options: CreateImageAssetProviderOptions
+): number {
+  if (options.timeoutMs !== undefined) {
+    return assertPositiveIntegerTimeout(options.timeoutMs);
+  }
+
+  const timeoutValue = resolveEnvValue(options, providerTimeoutEnvKey);
+
+  if (timeoutValue === undefined || timeoutValue.trim() === "") {
+    return defaultImageProviderTimeoutMs;
+  }
+
+  return assertPositiveIntegerTimeout(Number(timeoutValue));
+}
+
+function assertPositiveIntegerTimeout(value: number): number {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new VisualAssetGenerationError(
+      `${providerTimeoutEnvKey} must be a positive integer.`,
+      "provider-failed"
+    );
+  }
+
+  return value;
+}
+
+function resolveEnvValue(
+  options: CreateImageAssetProviderOptions,
+  key: string
+): string | undefined {
+  return options.env === undefined ? process.env[key] : options.env[key];
+}
+
+function deriveFallbackState(
+  providerName: AiProviderName | string
+): VisualAssetFallbackState {
+  return providerName === "none" ? "no-provider" : "provider-unsupported";
+}
+
+function isOpenAiImageResponse(value: unknown): value is {
+  data: [{ b64_json: string }];
+} {
+  return (
+    isRecord(value) &&
+    Array.isArray(value.data) &&
+    isRecord(value.data[0]) &&
+    typeof value.data[0].b64_json === "string" &&
+    value.data[0].b64_json.trim().length > 0
+  );
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/src/visual-assets.ts
+++ b/src/visual-assets.ts
@@ -1,4 +1,3 @@
-import { join } from "node:path";
 import process from "node:process";
 import type {
   AiProviderConfig,
@@ -155,7 +154,7 @@ export async function generateCarouselVisualAssets(
       assetSlotId: card.visualTreatment.assetSlotId,
       promptSummary: request.promptSummary,
       provider: provider?.name ?? options.fallbackProviderName,
-      filePath: join(options.revision.outputDir, fileName),
+      filePath: fileName,
       fallbackState: provider
         ? "none"
         : deriveFallbackState(options.fallbackProviderName)

--- a/tests/generate-command.test.ts
+++ b/tests/generate-command.test.ts
@@ -14,6 +14,7 @@ import type { GitActivityEvent } from "../src/collect-git-command.js";
 import type { DiaryDraft } from "../src/diary-generator.js";
 import { addProject, type ProjectRecord } from "../src/project-add.js";
 import type { StoryFormatPlan } from "../src/story-format-plan.js";
+import type { ImageAssetProvider } from "../src/visual-assets.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -51,6 +52,7 @@ describe("generate command", () => {
     const caption = await readFile(join(outputDir, "caption.txt"), "utf8");
     const metadata = await readJson(join(outputDir, "metadata.json"));
     const safetyReport = await readJson(join(outputDir, "safety-report.json"));
+    const visualAsset = await readFile(join(outputDir, "visuals", "01.png"));
 
     expect(exitCode).toBe(0);
     expect(stderr).toEqual([]);
@@ -112,9 +114,43 @@ describe("generate command", () => {
         "story.json",
         "caption.txt",
         "metadata.json",
-        "safety-report.json"
+        "safety-report.json",
+        "visuals/01.png",
+        "visuals/02.png",
+        "visuals/03.png"
+      ],
+      visualAssets: [
+        {
+          schemaVersion: 1,
+          slideIndex: 1,
+          assetSlotId: "slide-01-visual",
+          provider: "mock",
+          filePath: join(outputDir, "visuals", "01.png"),
+          fallbackState: "provider-unsupported",
+          promptSummary: "compact terminal summary"
+        },
+        {
+          slideIndex: 2,
+          assetSlotId: "slide-02-visual",
+          fallbackState: "provider-unsupported"
+        },
+        {
+          slideIndex: 3,
+          assetSlotId: "slide-03-visual",
+          fallbackState: "provider-unsupported"
+        }
       ]
     });
+    expect([...visualAsset.subarray(0, 8)]).toEqual([
+      0x89,
+      0x50,
+      0x4e,
+      0x47,
+      0x0d,
+      0x0a,
+      0x1a,
+      0x0a
+    ]);
     expect(safetyReport).toMatchObject({
       schemaVersion: 1,
       status: "safe",
@@ -444,6 +480,42 @@ describe("generate command", () => {
     });
   });
 
+  it("returns a visual-generation error while preserving text draft artifacts", async () => {
+    const { io, stdout, stderr } = createIo();
+    const fixture = await createRegisteredProjectFixture();
+
+    await writeGitEvent(fixture.project, "2026-05-12");
+
+    const exitCode = await runCli(["generate", "today"], io, {
+      homeDir: fixture.homeDir,
+      now: () => "2026-05-12T23:30:00.000Z",
+      aiProvider: new TaskAwareProvider(),
+      imageAssetProvider: new FailingImageAssetProvider()
+    });
+    const outputDir = join(fixture.draftRoot, "2026-05-12", "rev-001");
+
+    expect(exitCode).toBe(5);
+    expect(stdout).toEqual([]);
+    expect(stderr).toEqual([
+      "Visual generation failed. Check image provider configuration."
+    ]);
+    await expect(readJson(join(outputDir, "activity-summary.json"))).resolves.toMatchObject({
+      targetDate: "2026-05-12"
+    });
+    await expect(readJson(join(outputDir, "story.json"))).resolves.toMatchObject({
+      title: "Generate Command Day"
+    });
+    await expect(readFile(join(outputDir, "caption.txt"), "utf8")).resolves.toContain(
+      "오늘은 generate command를 텍스트 draft까지 연결했다."
+    );
+    await expect(readJson(join(outputDir, "safety-report.json"))).resolves.toMatchObject({
+      status: "safe"
+    });
+    await expect(readFile(join(outputDir, "metadata.json"), "utf8")).rejects.toMatchObject({
+      code: "ENOENT"
+    });
+  });
+
   it("returns collection exit code for malformed stored Git activity", async () => {
     const { io, stdout, stderr } = createIo();
     const fixture = await createRegisteredProjectFixture();
@@ -524,6 +596,14 @@ class TaskAwareProvider implements AiProvider {
     }
 
     throw new Error(`Unexpected task: ${request.task}`);
+  }
+}
+
+class FailingImageAssetProvider implements ImageAssetProvider {
+  readonly name = "fixture-image";
+
+  async generateImageAsset(): Promise<never> {
+    throw new Error("image provider unavailable");
   }
 }
 

--- a/tests/generate-command.test.ts
+++ b/tests/generate-command.test.ts
@@ -125,7 +125,7 @@ describe("generate command", () => {
           slideIndex: 1,
           assetSlotId: "slide-01-visual",
           provider: "mock",
-          filePath: join(outputDir, "visuals", "01.png"),
+          filePath: "visuals/01.png",
           fallbackState: "provider-unsupported",
           promptSummary: "compact terminal summary"
         },

--- a/tests/visual-assets.test.ts
+++ b/tests/visual-assets.test.ts
@@ -128,7 +128,7 @@ describe("visual asset generation", () => {
         slideIndex: 1,
         assetSlotId: "slide-01-visual",
         provider: "mock",
-        filePath: join(revision.outputDir, "visuals", "01.png"),
+        filePath: "visuals/01.png",
         fallbackState: "provider-unsupported"
       },
       {

--- a/tests/visual-assets.test.ts
+++ b/tests/visual-assets.test.ts
@@ -1,0 +1,317 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import type {
+  AiProviderHttpRequest,
+  AiProviderHttpResponse
+} from "../src/ai-provider.js";
+import { createCarouselHtmlCards } from "../src/carousel-renderer.js";
+import { createDraftRevision } from "../src/draft-storage.js";
+import {
+  createImageAssetProvider,
+  generateCarouselVisualAssets,
+  VisualAssetGenerationError
+} from "../src/visual-assets.js";
+import type {
+  ImageAssetProvider,
+  ImageAssetRequest
+} from "../src/visual-assets.js";
+
+describe("visual asset generation", () => {
+  it("creates an OpenAI image asset provider from the existing AI provider config", async () => {
+    const calls: Array<{ url: string; request: AiProviderHttpRequest }> = [];
+    const provider = createImageAssetProvider(
+      {
+        provider: "openai",
+        persona: "wry coworker",
+        roastLevel: 2
+      },
+      {
+        env: { OPENAI_API_KEY: "sk-test-secret" },
+        transport: createTransport(calls, {
+          data: [
+            {
+              b64_json:
+                "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
+            }
+          ]
+        })
+      }
+    );
+
+    await expect(
+      provider?.generateImageAsset({
+        schemaVersion: 1,
+        slideIndex: 1,
+        assetSlotId: "slide-01-visual",
+        prompt: "safe visual prompt",
+        promptSummary: "safe visual prompt"
+      })
+    ).resolves.toMatchObject({
+      mimeType: "image/png"
+    });
+
+    expect(provider?.name).toBe("openai");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe("https://api.openai.com/v1/images/generations");
+    expect(calls[0]?.request.headers.Authorization).toBe("Bearer sk-test-secret");
+    expect(calls[0]?.request.headers["Content-Type"]).toBe("application/json");
+
+    const body = JSON.parse(calls[0]?.request.body ?? "{}") as {
+      model?: string;
+      prompt?: string;
+      n?: number;
+      size?: string;
+      quality?: string;
+      output_format?: string;
+    };
+
+    expect(body).toEqual({
+      model: "gpt-image-1.5",
+      prompt: "safe visual prompt",
+      n: 1,
+      size: "1024x1536",
+      quality: "low",
+      output_format: "png"
+    });
+    expect(calls[0]?.request.body).not.toContain("sk-test-secret");
+  });
+
+  it("does not create real image adapters for unsupported MVP providers", () => {
+    expect(
+      createImageAssetProvider({
+        provider: "mock",
+        persona: "wry coworker",
+        roastLevel: 2
+      })
+    ).toBeUndefined();
+  });
+
+  it("fails clearly when OpenAI image credentials are missing", () => {
+    expect(() =>
+      createImageAssetProvider(
+        {
+          provider: "openai",
+          persona: "wry coworker",
+          roastLevel: 2
+        },
+        { env: {} }
+      )
+    ).toThrow(
+      new VisualAssetGenerationError(
+        "OPENAI_API_KEY is not set.",
+        "provider-unavailable"
+      )
+    );
+  });
+
+  it("writes deterministic placeholder PNG assets with stable slide filenames", async () => {
+    const revision = await createTestRevision();
+    const cards = createCarouselHtmlCards(createStoryDraft());
+
+    const result = await generateCarouselVisualAssets({
+      revision,
+      cards,
+      fallbackProviderName: "mock"
+    });
+
+    expect(result.files).toEqual([
+      "visuals/01.png",
+      "visuals/02.png",
+      "visuals/03.png"
+    ]);
+    expect(result.assets).toMatchObject([
+      {
+        schemaVersion: 1,
+        slideIndex: 1,
+        assetSlotId: "slide-01-visual",
+        provider: "mock",
+        filePath: join(revision.outputDir, "visuals", "01.png"),
+        fallbackState: "provider-unsupported"
+      },
+      {
+        slideIndex: 2,
+        assetSlotId: "slide-02-visual",
+        fallbackState: "provider-unsupported"
+      },
+      {
+        slideIndex: 3,
+        assetSlotId: "slide-03-visual",
+        fallbackState: "provider-unsupported"
+      }
+    ]);
+
+    const firstPng = await readFile(join(revision.outputDir, "visuals", "01.png"));
+    expect([...firstPng.subarray(0, 8)]).toEqual([
+      0x89,
+      0x50,
+      0x4e,
+      0x47,
+      0x0d,
+      0x0a,
+      0x1a,
+      0x0a
+    ]);
+  });
+
+  it("sends only sanitized visual intent to image providers", async () => {
+    const revision = await createTestRevision();
+    const cards = createCarouselHtmlCards(
+      createStoryDraft({
+        slides: [
+          {
+            index: 1,
+            title: "Sensitive",
+            body: "Do not leak visual input.",
+            visualMood:
+              "terminal near dev@example.com /Users/dev/private OPENAI_API_KEY=sk-live-secret123 `const token = process.env.SECRET`"
+          }
+        ]
+      })
+    );
+    const provider = new RecordingImageProvider();
+
+    const result = await generateCarouselVisualAssets({
+      revision,
+      cards,
+      provider,
+      fallbackProviderName: "mock"
+    });
+
+    expect(provider.requests).toHaveLength(1);
+    expect(provider.requests[0]?.prompt).toContain("4:5 editorial illustration");
+    expect(provider.requests[0]?.prompt).toContain("[redacted-email]");
+    expect(provider.requests[0]?.prompt).toContain("[redacted-path]");
+    expect(provider.requests[0]?.prompt).toContain("[redacted-secret]");
+    expect(provider.requests[0]?.prompt).toContain("[redacted-code]");
+    expect(provider.requests[0]?.prompt).not.toContain("dev@example.com");
+    expect(provider.requests[0]?.prompt).not.toContain("/Users/dev/private");
+    expect(provider.requests[0]?.prompt).not.toContain("OPENAI_API_KEY");
+    expect(provider.requests[0]?.prompt).not.toContain("sk-live-secret123");
+    expect(provider.requests[0]?.prompt).not.toContain("process.env.SECRET");
+    expect(result.assets[0]).toMatchObject({
+      provider: "fixture-image",
+      fallbackState: "none",
+      promptSummary:
+        "terminal near [redacted-email] [redacted-path] [redacted-secret] [redacted-code]"
+    });
+  });
+
+  it("preserves existing draft artifacts when an image provider fails", async () => {
+    const revision = await createTestRevision();
+    const cards = createCarouselHtmlCards(createStoryDraft());
+    const preservedArtifact = join(revision.outputDir, "story.json");
+
+    await mkdir(revision.outputDir, { recursive: true });
+    await writeFile(preservedArtifact, "{\"schemaVersion\":1}\n", "utf8");
+
+    await expect(
+      generateCarouselVisualAssets({
+        revision,
+        cards,
+        provider: new FailingImageProvider(),
+        fallbackProviderName: "mock"
+      })
+    ).rejects.toEqual(
+      new VisualAssetGenerationError(
+        "Visual generation failed. Check image provider configuration.",
+        "provider-failed"
+      )
+    );
+    await expect(readFile(preservedArtifact, "utf8")).resolves.toBe(
+      "{\"schemaVersion\":1}\n"
+    );
+  });
+});
+
+class RecordingImageProvider implements ImageAssetProvider {
+  readonly name = "fixture-image";
+  readonly requests: ImageAssetRequest[] = [];
+
+  async generateImageAsset(request: ImageAssetRequest) {
+    this.requests.push(request);
+
+    return {
+      mimeType: "image/png" as const,
+      data: Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+        "base64"
+      )
+    };
+  }
+}
+
+class FailingImageProvider implements ImageAssetProvider {
+  readonly name = "fixture-image";
+
+  async generateImageAsset(): Promise<never> {
+    throw new Error("remote image API failed with detailed provider trace");
+  }
+}
+
+function createTransport(
+  calls: Array<{ url: string; request: AiProviderHttpRequest }>,
+  body: unknown,
+  status = 200
+) {
+  return async (
+    url: string,
+    request: AiProviderHttpRequest
+  ): Promise<AiProviderHttpResponse> => {
+    calls.push({ url, request });
+
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body
+    };
+  };
+}
+
+async function createTestRevision() {
+  const draftRoot = join(tmpdir(), `uncommitted-visual-assets-${randomUUID()}`);
+
+  await mkdir(draftRoot, { recursive: true });
+
+  return await createDraftRevision({
+    draftRoot,
+    targetDate: "2026-05-20"
+  });
+}
+
+function createStoryDraft(overrides: Record<string, unknown> = {}) {
+  return {
+    schemaVersion: 1,
+    targetDate: "2026-05-20",
+    title: "Visual Asset Day",
+    caption: "Images stay local.",
+    slides: [
+      {
+        index: 1,
+        title: "Signal",
+        body: "Visual intent gets a local asset slot.",
+        visualMood: "compact terminal summary"
+      },
+      {
+        index: 2,
+        title: "Asset",
+        body: "Stable filenames keep rendering predictable.",
+        visualMood: "paper cards on a desk"
+      },
+      {
+        index: 3,
+        title: "Fallback",
+        body: "Unsupported image providers get placeholders.",
+        visualMood: "quiet placeholder frame"
+      }
+    ],
+    hashtags: ["#Uncommitted"],
+    altText: "Uncommitted carousel visual asset draft.",
+    metadata: {
+      projectIds: ["uncommitted"]
+    },
+    ...overrides
+  };
+}


### PR DESCRIPTION
# Goal

Generate local carousel visual assets from each slide's visual intent so later rendering can compose Instagram cards with real illustration-style imagery.

## Related Issue

Closes #57.

## Acceptance Criteria

- [x] A slide visual intent can be converted into a safe image-generation request.
- [x] Generated or placeholder visual assets are stored with stable per-slide filenames.
- [x] Visual asset metadata links each asset to its slide index and `CarouselVisualTreatment.assetSlotId`.
- [x] Sensitive values are redacted or excluded from image prompts before provider calls.
- [x] Provider failure preserves existing draft artifacts and returns a short visual-generation error.
- [x] Image generation falls back to deterministic placeholders when no image provider is configured.
- [x] Tests cover successful asset mapping, prompt sanitization, provider adapter behavior, and failure/fallback behavior.

## Implementation Notes

- Added an `ImageAssetProvider` boundary plus OpenAI Image API adapter using the existing `aiProvider: "openai"` config and `OPENAI_API_KEY`.
- Added deterministic placeholder PNG generation for unsupported providers such as `mock`.
- Wired `generate` to create `visuals/01.png` style assets and record `metadata.visualAssets`.
- Kept Playwright screenshot capture, `render latest`, preview/export, and story/caption rewriting out of scope.

## Validation

- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`

## Remaining Risk

Real OpenAI API smoke testing was not run because it requires live credentials and can incur image-generation cost.
