### PR TITLE
feat: render visual carousel PNGs with Playwright

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.59.0",
     "vitest": "^3.1.2"
+  },
+  "dependencies": {
+    "playwright": "^1.60.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      playwright:
+        specifier: ^1.60.0
+        version: 1.60.0
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
@@ -629,6 +633,11 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -741,6 +750,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.5.12:
     resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
@@ -1470,6 +1489,9 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -1561,6 +1583,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.12:
     dependencies:

--- a/src/carousel-renderer.ts
+++ b/src/carousel-renderer.ts
@@ -1,5 +1,5 @@
 import { readFile } from "node:fs/promises";
-import { isAbsolute, join, normalize } from "node:path";
+import { isAbsolute, normalize, relative, resolve, sep, win32 } from "node:path";
 import { chromium, type Browser } from "playwright";
 import type { DiarySlide } from "./diary-generator.js";
 import {
@@ -269,9 +269,9 @@ async function composeCardHtml(options: {
   }
 
   const image = await readFile(
-    join(
+    resolveDraftArtifactPath(
       options.revision.outputDir,
-      normalizeDraftArtifactPath(options.visualAsset.filePath)
+      options.visualAsset.filePath
     )
   );
   const dataUri = `data:image/png;base64,${image.toString("base64")}`;
@@ -319,14 +319,20 @@ function findVisualAsset(
   );
 }
 
-function normalizeDraftArtifactPath(filePath: string): string {
-  const normalized = normalize(filePath);
+function resolveDraftArtifactPath(outputDir: string, filePath: string): string {
+  const root = resolve(outputDir);
+  const separatorNormalized = filePath.replace(/\\/g, "/");
+  const normalized = normalize(separatorNormalized);
+  const resolved = resolve(root, normalized);
+  const relativePath = relative(root, resolved);
 
   if (
+    filePath.trim().length === 0 ||
     isAbsolute(normalized) ||
-    normalized === ".." ||
-    normalized.startsWith(`..${"/"}`) ||
-    normalized.includes(`${"/"}..${"/"}`)
+    win32.isAbsolute(filePath) ||
+    relativePath === ".." ||
+    relativePath.startsWith(`..${sep}`) ||
+    isAbsolute(relativePath)
   ) {
     throw new CarouselPngRenderError(
       "Could not render carousel PNGs.",
@@ -334,7 +340,7 @@ function normalizeDraftArtifactPath(filePath: string): string {
     );
   }
 
-  return normalized;
+  return resolved;
 }
 
 function assertPng(value: Uint8Array): void {

--- a/src/carousel-renderer.ts
+++ b/src/carousel-renderer.ts
@@ -1,6 +1,15 @@
+import { readFile } from "node:fs/promises";
+import { isAbsolute, join, normalize } from "node:path";
+import { chromium, type Browser } from "playwright";
 import type { DiarySlide } from "./diary-generator.js";
+import {
+  type DraftRevision,
+  DraftStorageError,
+  writeDraftArtifactBinary
+} from "./draft-storage.js";
 
 export type CarouselRenderInputErrorCode = "invalid-story";
+export type CarouselPngRenderErrorCode = "render-failed" | "write-failed";
 
 export class CarouselRenderInputError extends Error {
   constructor(
@@ -9,6 +18,16 @@ export class CarouselRenderInputError extends Error {
   ) {
     super(message);
     this.name = "CarouselRenderInputError";
+  }
+}
+
+export class CarouselPngRenderError extends Error {
+  constructor(
+    message: string,
+    public readonly code: CarouselPngRenderErrorCode
+  ) {
+    super(message);
+    this.name = "CarouselPngRenderError";
   }
 }
 
@@ -36,8 +55,48 @@ export type CarouselHtmlCard = {
   html: string;
 };
 
+export type CarouselPngVisualAsset = {
+  slideIndex: number;
+  assetSlotId: string;
+  filePath: string;
+};
+
+export type CarouselHtmlToPngRenderer = {
+  renderHtmlToPng(options: {
+    html: string;
+    width: number;
+    height: number;
+  }): Promise<Uint8Array>;
+  close?(): Promise<void>;
+};
+
+export type CarouselPngMetadata = {
+  schemaVersion: 1;
+  slideIndex: number;
+  assetSlotId: string;
+  sourceHtmlFileName: string;
+  filePath: string;
+  visualAssetPath?: string;
+};
+
+export type CarouselPngRenderResult = {
+  schemaVersion: 1;
+  files: string[];
+  images: CarouselPngMetadata[];
+};
+
+export type RenderCarouselPngsOptions = {
+  revision: DraftRevision;
+  cards: CarouselHtmlCard[];
+  visualAssets?: CarouselPngVisualAsset[];
+  renderer?: CarouselHtmlToPngRenderer;
+};
+
 const invalidStoryMessage =
   "story.json must include ordered slides with title and body.";
+const carouselWidth = 1080;
+const carouselHeight = 1350;
+const pngSignature = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
 
 export function parseCarouselRenderInput(value: unknown): CarouselRenderInput {
   if (!isRecord(value)) {
@@ -88,6 +147,207 @@ export function createCarouselHtmlCards(value: unknown): CarouselHtmlCard[] {
       })
     };
   });
+}
+
+export async function renderCarouselPngs(
+  options: RenderCarouselPngsOptions
+): Promise<CarouselPngRenderResult> {
+  const renderer = options.renderer ?? new PlaywrightCarouselPngRenderer();
+  const shouldCloseRenderer = options.renderer === undefined;
+  const files: string[] = [];
+  const images: CarouselPngMetadata[] = [];
+
+  try {
+    for (const [index, card] of options.cards.entries()) {
+      const visualAsset = findVisualAsset(card, options.visualAssets ?? []);
+      const html = await composeCardHtml({
+        revision: options.revision,
+        card,
+        visualAsset
+      });
+      const png = await renderer.renderHtmlToPng({
+        html,
+        width: carouselWidth,
+        height: carouselHeight
+      });
+
+      assertPng(png);
+
+      const filePath = `carousel/${String(index + 1).padStart(2, "0")}.png`;
+
+      await writeDraftArtifactBinary(options.revision, filePath, png);
+
+      files.push(filePath);
+      images.push({
+        schemaVersion: 1,
+        slideIndex: card.slideIndex,
+        assetSlotId: card.visualTreatment.assetSlotId,
+        sourceHtmlFileName: card.fileName,
+        filePath,
+        ...(visualAsset ? { visualAssetPath: visualAsset.filePath } : {})
+      });
+    }
+  } catch (error) {
+    if (error instanceof CarouselPngRenderError) {
+      throw error;
+    }
+
+    if (error instanceof DraftStorageError) {
+      throw new CarouselPngRenderError(error.message, "write-failed");
+    }
+
+    throw new CarouselPngRenderError(
+      "Could not render carousel PNGs.",
+      "render-failed"
+    );
+  } finally {
+    if (shouldCloseRenderer) {
+      await renderer.close?.();
+    }
+  }
+
+  return {
+    schemaVersion: 1,
+    files,
+    images
+  };
+}
+
+class PlaywrightCarouselPngRenderer implements CarouselHtmlToPngRenderer {
+  private browser: Browser | undefined;
+
+  async renderHtmlToPng(options: {
+    html: string;
+    width: number;
+    height: number;
+  }): Promise<Uint8Array> {
+    const browser = await this.getBrowser();
+    const page = await browser.newPage({
+      viewport: {
+        width: options.width,
+        height: options.height
+      },
+      deviceScaleFactor: 1
+    });
+
+    try {
+      await page.setContent(options.html, { waitUntil: "load" });
+
+      return await page.screenshot({
+        type: "png",
+        clip: {
+          x: 0,
+          y: 0,
+          width: options.width,
+          height: options.height
+        }
+      });
+    } finally {
+      await page.close();
+    }
+  }
+
+  async close(): Promise<void> {
+    await this.browser?.close();
+    this.browser = undefined;
+  }
+
+  private async getBrowser(): Promise<Browser> {
+    this.browser ??= await chromium.launch({ headless: true });
+
+    return this.browser;
+  }
+}
+
+async function composeCardHtml(options: {
+  revision: DraftRevision;
+  card: CarouselHtmlCard;
+  visualAsset?: CarouselPngVisualAsset;
+}): Promise<string> {
+  if (!options.visualAsset) {
+    return options.card.html;
+  }
+
+  const image = await readFile(
+    join(
+      options.revision.outputDir,
+      normalizeDraftArtifactPath(options.visualAsset.filePath)
+    )
+  );
+  const dataUri = `data:image/png;base64,${image.toString("base64")}`;
+  const visualAssetCss = `
+    .visual-stage.has-visual-asset {
+      background: #eef2f7;
+    }
+
+    .visual-asset {
+      position: absolute;
+      inset: 0;
+      z-index: 0;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+
+    .visual-stage.has-visual-asset .visual-placeholder {
+      padding: 18px 22px;
+      background: rgba(247, 247, 245, 0.82);
+      border: 2px solid rgba(15, 23, 42, 0.12);
+    }
+`;
+  const imgHtml = `<img class="visual-asset" src="${dataUri}" alt="${escapeHtml(
+    options.card.visualTreatment.altText
+  )}">`;
+
+  return options.card.html
+    .replace("</style>", `${visualAssetCss}  </style>`)
+    .replace('class="visual-stage"', 'class="visual-stage has-visual-asset"')
+    .replace(
+      '<div class="visual-placeholder">',
+      `${imgHtml}\n      <div class="visual-placeholder">`
+    );
+}
+
+function findVisualAsset(
+  card: CarouselHtmlCard,
+  visualAssets: CarouselPngVisualAsset[]
+): CarouselPngVisualAsset | undefined {
+  return visualAssets.find(
+    (asset) =>
+      asset.slideIndex === card.slideIndex &&
+      asset.assetSlotId === card.visualTreatment.assetSlotId
+  );
+}
+
+function normalizeDraftArtifactPath(filePath: string): string {
+  const normalized = normalize(filePath);
+
+  if (
+    isAbsolute(normalized) ||
+    normalized === ".." ||
+    normalized.startsWith(`..${"/"}`) ||
+    normalized.includes(`${"/"}..${"/"}`)
+  ) {
+    throw new CarouselPngRenderError(
+      "Could not render carousel PNGs.",
+      "render-failed"
+    );
+  }
+
+  return normalized;
+}
+
+function assertPng(value: Uint8Array): void {
+  const hasPngSignature = pngSignature.every(
+    (byte, index) => value[index] === byte
+  );
+
+  if (!hasPngSignature) {
+    throw new CarouselPngRenderError(
+      "Could not render carousel PNGs.",
+      "render-failed"
+    );
+  }
 }
 
 function parseDiarySlide(value: unknown, index: number): DiarySlide {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,16 +17,24 @@ export type { CliIo, CliOptions } from "./cli.js";
 export { commands, isKnownCommand } from "./commands.js";
 export type { Command } from "./commands.js";
 export {
+  CarouselPngRenderError,
   CarouselRenderInputError,
   createCarouselHtmlCards,
-  parseCarouselRenderInput
+  parseCarouselRenderInput,
+  renderCarouselPngs
 } from "./carousel-renderer.js";
 export type {
+  CarouselHtmlToPngRenderer,
   CarouselHtmlCard,
+  CarouselPngMetadata,
+  CarouselPngRenderErrorCode,
+  CarouselPngRenderResult,
+  CarouselPngVisualAsset,
   CarouselRenderInput,
   CarouselRenderInputErrorCode,
   CarouselVisualTreatment,
-  CarouselVisualTreatmentKind
+  CarouselVisualTreatmentKind,
+  RenderCarouselPngsOptions
 } from "./carousel-renderer.js";
 export {
   collectGitForRegisteredProjects,

--- a/tests/carousel-renderer.test.ts
+++ b/tests/carousel-renderer.test.ts
@@ -1,9 +1,16 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   CarouselRenderInputError,
+  CarouselPngRenderError,
   createCarouselHtmlCards,
-  parseCarouselRenderInput
+  parseCarouselRenderInput,
+  renderCarouselPngs
 } from "../src/carousel-renderer.js";
+import { createDraftRevision } from "../src/draft-storage.js";
 import type { DiaryDraft } from "../src/diary-generator.js";
 
 describe("carousel renderer", () => {
@@ -117,7 +124,148 @@ describe("carousel renderer", () => {
       )
     );
   });
+
+  it("renders ordered carousel PNG files under the draft revision", async () => {
+    const revision = await createTestRevision();
+    const cards = createCarouselHtmlCards(createStoryDraft());
+    const renderer = new RecordingPngRenderer();
+
+    await writeDraftTextFixtures(revision.outputDir);
+    await mkdir(join(revision.outputDir, "visuals"), { recursive: true });
+    await writeFile(
+      join(revision.outputDir, "visuals", "01.png"),
+      fixturePng,
+      "binary"
+    );
+
+    const result = await renderCarouselPngs({
+      revision,
+      cards,
+      visualAssets: [
+        {
+          slideIndex: 1,
+          assetSlotId: "slide-01-visual",
+          filePath: "visuals/01.png"
+        }
+      ],
+      renderer
+    });
+
+    expect(result.files).toEqual([
+      "carousel/01.png",
+      "carousel/02.png",
+      "carousel/03.png"
+    ]);
+    expect(result.images).toMatchObject([
+      {
+        schemaVersion: 1,
+        slideIndex: 1,
+        assetSlotId: "slide-01-visual",
+        filePath: "carousel/01.png",
+        visualAssetPath: "visuals/01.png"
+      },
+      {
+        slideIndex: 2,
+        assetSlotId: "slide-02-visual",
+        filePath: "carousel/02.png"
+      },
+      {
+        slideIndex: 3,
+        assetSlotId: "slide-03-visual",
+        filePath: "carousel/03.png"
+      }
+    ]);
+    expect(renderer.calls).toHaveLength(3);
+    expect(renderer.calls[0]?.html).toContain("data-asset-slot-id=\"slide-01-visual\"");
+    expect(renderer.calls[0]?.html).toContain("data:image/png;base64,");
+    expect(renderer.calls[0]?.html).toContain("class=\"visual-asset\"");
+
+    const firstPng = await readFile(join(revision.outputDir, "carousel", "01.png"));
+    expect([...firstPng.subarray(0, 8)]).toEqual([
+      0x89,
+      0x50,
+      0x4e,
+      0x47,
+      0x0d,
+      0x0a,
+      0x1a,
+      0x0a
+    ]);
+    await expect(readFile(join(revision.outputDir, "story.json"), "utf8")).resolves.toBe(
+      "{\"schemaVersion\":1}\n"
+    );
+  });
+
+  it("surfaces screenshot failures as carousel PNG render errors", async () => {
+    const revision = await createTestRevision();
+    const cards = createCarouselHtmlCards(createStoryDraft());
+
+    await expect(
+      renderCarouselPngs({
+        revision,
+        cards,
+        renderer: new FailingPngRenderer()
+      })
+    ).rejects.toEqual(
+      new CarouselPngRenderError(
+        "Could not render carousel PNGs.",
+        "render-failed"
+      )
+    );
+  });
 });
+
+const fixturePng = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+  "base64"
+);
+
+class RecordingPngRenderer {
+  readonly calls: Array<{ html: string; width: number; height: number }> = [];
+
+  async renderHtmlToPng(options: {
+    html: string;
+    width: number;
+    height: number;
+  }): Promise<Uint8Array> {
+    this.calls.push(options);
+
+    return fixturePng;
+  }
+}
+
+class FailingPngRenderer {
+  async renderHtmlToPng(): Promise<never> {
+    throw new Error("browser failed with internal detail");
+  }
+}
+
+async function createTestRevision() {
+  const draftRoot = join(tmpdir(), `uncommitted-carousel-render-${randomUUID()}`);
+
+  await mkdir(draftRoot, { recursive: true });
+
+  return await createDraftRevision({
+    draftRoot,
+    targetDate: "2026-05-18"
+  });
+}
+
+async function writeDraftTextFixtures(outputDir: string): Promise<void> {
+  await writeFile(join(outputDir, "story.json"), "{\"schemaVersion\":1}\n", "utf8");
+  await writeFile(join(outputDir, "caption.txt"), "Caption\n", "utf8");
+  await writeFile(
+    join(outputDir, "activity-summary.json"),
+    "{\"schemaVersion\":1}\n",
+    "utf8"
+  );
+  await writeFile(join(outputDir, "metadata.json"), "{\"schemaVersion\":1}\n", "utf8");
+  await writeFile(
+    join(outputDir, "safety-report.json"),
+    "{\"schemaVersion\":1}\n",
+    "utf8"
+  );
+}
 
 function createStoryDraft(overrides: Partial<DiaryDraft> = {}): DiaryDraft {
   return {

--- a/tests/carousel-renderer.test.ts
+++ b/tests/carousel-renderer.test.ts
@@ -213,6 +213,35 @@ describe("carousel renderer", () => {
       )
     );
   });
+
+  it("rejects backslash traversal in visual asset paths", async () => {
+    const revision = await createTestRevision();
+    const cards = createCarouselHtmlCards(createStoryDraft());
+    const renderer = new RecordingPngRenderer();
+
+    await writeFile(join(revision.outputDir, "..\\secret.png"), fixturePng);
+
+    await expect(
+      renderCarouselPngs({
+        revision,
+        cards: [cards[0]],
+        visualAssets: [
+          {
+            slideIndex: 1,
+            assetSlotId: "slide-01-visual",
+            filePath: "..\\secret.png"
+          }
+        ],
+        renderer
+      })
+    ).rejects.toEqual(
+      new CarouselPngRenderError(
+        "Could not render carousel PNGs.",
+        "render-failed"
+      )
+    );
+    expect(renderer.calls).toHaveLength(0);
+  });
 });
 
 const fixturePng = Buffer.from(


### PR DESCRIPTION
# Goal

Render visual carousel HTML cards into Instagram-ready PNG files under each draft revision's `carousel/` directory.

## Related Issue

Closes #48.

## Acceptance Criteria

- [x] Given valid rendered-card HTML, the renderer writes PNG files under `carousel/`.
- [x] PNG filenames are zero-padded and match slide order, starting at `01.png`.
- [x] Output files are non-empty PNG files.
- [x] HTML visual slots can be composed with prepared local visual assets or deterministic placeholders.
- [x] Render results retain metadata linking each PNG to its slide and visual asset slot.
- [x] Existing draft artifacts are preserved.
- [x] Renderer tests use temporary draft fixtures.
- [x] Rendering failures surface as renderer-specific errors.

## Implementation Notes

- Added `renderCarouselPngs` with a default Playwright-backed renderer at 1080 x 1350.
- Composes prepared local visual assets into the existing visual slot as data URI images before capture.
- Writes final PNGs through draft storage as `carousel/NN.png` and returns trace metadata.
- Keeps CLI wiring for `uncommitted render latest` out of scope.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- Built renderer smoke test wrote `carousel/01.png` successfully.

## Remaining Risk

- Playwright browser binaries must be installed in the runtime environment before the default renderer can launch Chromium.
