### PR TITLE
feat: implement render latest command

### DIFF
--- a/src/carousel-renderer.ts
+++ b/src/carousel-renderer.ts
@@ -680,7 +680,7 @@ function renderCardHtml(options: {
     .visual-stage::before {
       width: 430px;
       height: 430px;
-      right: -92px;
+      right: 28px;
       top: 70px;
       border-radius: 999px;
       background: rgba(255, 255, 255, 0.42);

--- a/src/carousel-renderer.ts
+++ b/src/carousel-renderer.ts
@@ -477,8 +477,8 @@ async function composeCardHtml(options: {
 
 function applyLayoutFit(html: string, layoutFit: CarouselLayoutFit): string {
   return html.replace(
-    /data-layout-fit="[^"]+"/,
-    `data-layout-fit="${layoutFit}"`
+    /(<article\b[^>]*\sdata-layout-fit=")[^"]+"/,
+    `$1${layoutFit}"`
   );
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -153,6 +153,10 @@ async function runRender(
         return 2;
       }
 
+      if (error.code === "safety-blocked") {
+        return 6;
+      }
+
       return 5;
     }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,11 @@ import {
   recordManualNote
 } from "./note-command.js";
 import { addProject, ProjectAddError } from "./project-add.js";
+import {
+  RenderCommandError,
+  runRenderCommand
+} from "./render-command.js";
+import type { CarouselHtmlToPngRenderer } from "./carousel-renderer.js";
 import type { ImageAssetProvider } from "./visual-assets.js";
 
 export type CliIo = {
@@ -35,6 +40,7 @@ export type CliOptions = {
   now?: () => string;
   aiProvider?: AiProvider;
   imageAssetProvider?: ImageAssetProvider;
+  carouselRenderer?: CarouselHtmlToPngRenderer;
 };
 
 const defaultIo: CliIo = {
@@ -113,8 +119,45 @@ export async function runCli(
     return await runGenerate(commandArgs, io, options);
   }
 
+  if (command === "render") {
+    return await runRender(commandArgs, io, options);
+  }
+
   io.stderr(`Command not implemented yet: ${command}`);
   return 1;
+}
+
+async function runRender(
+  args: string[],
+  io: CliIo,
+  options: CliOptions
+): Promise<number> {
+  try {
+    const result = await runRenderCommand(args, {
+      homeDir: options.homeDir,
+      renderer: options.carouselRenderer
+    });
+
+    io.stdout(`Rendered carousel for ${result.targetDate}: ${result.outputDir}`);
+    io.stdout(`Carousel files: ${result.carouselDir}`);
+    return 0;
+  } catch (error) {
+    if (error instanceof RenderCommandError) {
+      io.stderr(error.message);
+
+      if (error.code === "invalid-arguments") {
+        return 1;
+      }
+
+      if (error.code === "invalid-config") {
+        return 2;
+      }
+
+      return 5;
+    }
+
+    throw error;
+  }
 }
 
 async function runGenerate(

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,6 +144,15 @@ export type {
   GenerateCommandResult
 } from "./generate-command.js";
 export {
+  RenderCommandError,
+  runRenderCommand
+} from "./render-command.js";
+export type {
+  RenderCommandErrorCode,
+  RenderCommandOptions,
+  RenderCommandResult
+} from "./render-command.js";
+export {
   createDraftRevision,
   DraftStorageError,
   readLatestDraftPointer,

--- a/src/render-command.ts
+++ b/src/render-command.ts
@@ -21,7 +21,8 @@ import {
 export type RenderCommandErrorCode =
   | "invalid-arguments"
   | "invalid-config"
-  | "render-failed";
+  | "render-failed"
+  | "safety-blocked";
 
 export class RenderCommandError extends Error {
   constructor(
@@ -204,7 +205,7 @@ function assertDraftIsRenderable(metadata: Record<string, unknown>): void {
   ) {
     throw new RenderCommandError(
       "Draft is blocked by safety checks. Regenerate or edit before rendering.",
-      "render-failed"
+      "safety-blocked"
     );
   }
 }

--- a/src/render-command.ts
+++ b/src/render-command.ts
@@ -1,0 +1,333 @@
+import { readFile } from "node:fs/promises";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import {
+  CarouselPngRenderError,
+  CarouselRenderInputError,
+  createCarouselHtmlCards,
+  renderCarouselPngs,
+  type CarouselHtmlToPngRenderer,
+  type CarouselHtmlCard,
+  type CarouselPngRenderResult,
+  type CarouselPngVisualAsset
+} from "./carousel-renderer.js";
+import { resolveConfigPaths } from "./config-paths.js";
+import {
+  DraftStorageError,
+  readLatestDraftPointer,
+  type DraftRevision,
+  writeDraftArtifactJson
+} from "./draft-storage.js";
+
+export type RenderCommandErrorCode =
+  | "invalid-arguments"
+  | "invalid-config"
+  | "render-failed";
+
+export class RenderCommandError extends Error {
+  constructor(
+    message: string,
+    public readonly code: RenderCommandErrorCode
+  ) {
+    super(message);
+    this.name = "RenderCommandError";
+  }
+}
+
+export type RenderCommandOptions = {
+  homeDir?: string;
+  renderer?: CarouselHtmlToPngRenderer;
+};
+
+export type RenderCommandResult = {
+  targetDate: string;
+  outputDir: string;
+  carouselDir: string;
+  renderResult: CarouselPngRenderResult;
+};
+
+type RenderConfigFile = {
+  schemaVersion: 1;
+  draftRoot: string;
+};
+
+const usage = "Usage: uncommitted render latest";
+
+export async function runRenderCommand(
+  args: string[],
+  options: RenderCommandOptions = {}
+): Promise<RenderCommandResult> {
+  if (args.length !== 1 || args[0] !== "latest") {
+    throw new RenderCommandError(usage, "invalid-arguments");
+  }
+
+  const paths = resolveConfigPaths({ homeDir: options.homeDir });
+  const draftRoot = await readDraftRoot(paths.configFile, options.homeDir);
+  const pointer = await readLatestPointer(draftRoot);
+
+  if (!isPathInside(draftRoot, pointer.path)) {
+    throw new RenderCommandError(
+      "Latest draft pointer is invalid. Regenerate the draft.",
+      "render-failed"
+    );
+  }
+
+  const revision: DraftRevision = {
+    targetDate: pointer.targetDate,
+    revision: pointer.revision,
+    dateDir: dirname(pointer.path),
+    outputDir: pointer.path,
+    latestPointerPath: join(draftRoot, "latest.json"),
+    dateLatestPointerPath: join(draftRoot, pointer.targetDate, "latest.json")
+  };
+  const story = await readJsonArtifact(
+    join(revision.outputDir, "story.json"),
+    "Draft story is not renderable. Regenerate the draft."
+  );
+  const metadata = await readMetadata(revision.outputDir);
+
+  assertDraftIsRenderable(metadata);
+
+  const cards = createCards(story);
+  const visualAssets = readVisualAssets(metadata);
+  assertVisualAssetsCoverCards(cards, visualAssets);
+
+  try {
+    const renderResult = await renderCarouselPngs({
+      revision,
+      cards,
+      visualAssets,
+      renderer: options.renderer
+    });
+
+    await writeDraftArtifactJson(
+      revision,
+      "metadata.json",
+      buildRenderedMetadata(metadata, renderResult)
+    );
+
+    return {
+      targetDate: revision.targetDate,
+      outputDir: revision.outputDir,
+      carouselDir: join(revision.outputDir, "carousel"),
+      renderResult
+    };
+  } catch (error) {
+    if (error instanceof CarouselPngRenderError) {
+      throw new RenderCommandError(error.message, "render-failed");
+    }
+
+    if (error instanceof DraftStorageError) {
+      throw new RenderCommandError(error.message, "render-failed");
+    }
+
+    throw error;
+  }
+}
+
+async function readDraftRoot(
+  configFile: string,
+  homeDir: string | undefined
+): Promise<string> {
+  try {
+    const parsed = JSON.parse(await readFile(configFile, "utf8")) as unknown;
+
+    if (!isRenderConfigFile(parsed)) {
+      throw new RenderCommandError("AI config is invalid.", "invalid-config");
+    }
+
+    return resolveConfigPaths({
+      homeDir,
+      draftRoot: parsed.draftRoot
+    }).defaultDraftRoot;
+  } catch (error) {
+    if (error instanceof RenderCommandError) {
+      throw error;
+    }
+
+    if (isNodeError(error) && error.code === "ENOENT") {
+      throw new RenderCommandError(
+        "AI config is missing. Run `uncommitted init` first.",
+        "invalid-config"
+      );
+    }
+
+    throw new RenderCommandError("AI config is invalid.", "invalid-config");
+  }
+}
+
+async function readLatestPointer(draftRoot: string) {
+  try {
+    return await readLatestDraftPointer(draftRoot);
+  } catch (error) {
+    if (error instanceof DraftStorageError) {
+      throw new RenderCommandError(
+        "No latest draft found. Run `uncommitted generate today` first.",
+        "render-failed"
+      );
+    }
+
+    throw error;
+  }
+}
+
+async function readJsonArtifact(
+  path: string,
+  failureMessage: string
+): Promise<unknown> {
+  try {
+    return JSON.parse(await readFile(path, "utf8")) as unknown;
+  } catch {
+    throw new RenderCommandError(failureMessage, "render-failed");
+  }
+}
+
+async function readMetadata(outputDir: string): Promise<Record<string, unknown>> {
+  const metadata = await readJsonArtifact(
+    join(outputDir, "metadata.json"),
+    "Draft metadata is invalid. Regenerate the draft."
+  );
+
+  if (!isRecord(metadata)) {
+    throw new RenderCommandError(
+      "Draft metadata is invalid. Regenerate the draft.",
+      "render-failed"
+    );
+  }
+
+  return metadata;
+}
+
+function assertDraftIsRenderable(metadata: Record<string, unknown>): void {
+  if (
+    metadata.exportPolicy === "blocked" ||
+    (isRecord(metadata.safety) && metadata.safety.status === "blocked")
+  ) {
+    throw new RenderCommandError(
+      "Draft is blocked by safety checks. Regenerate or edit before rendering.",
+      "render-failed"
+    );
+  }
+}
+
+function createCards(story: unknown) {
+  try {
+    return createCarouselHtmlCards(story);
+  } catch (error) {
+    if (error instanceof CarouselRenderInputError) {
+      throw new RenderCommandError(
+        "Draft story is not renderable. Regenerate the draft.",
+        "render-failed"
+      );
+    }
+
+    throw error;
+  }
+}
+
+function readVisualAssets(
+  metadata: Record<string, unknown>
+): CarouselPngVisualAsset[] {
+  if (!Array.isArray(metadata.visualAssets) || metadata.visualAssets.length === 0) {
+    throw new RenderCommandError(
+      "Draft visual assets are missing. Regenerate the draft.",
+      "render-failed"
+    );
+  }
+
+  const visualAssets = metadata.visualAssets.map((asset) => {
+    if (!isVisualAssetMetadata(asset)) {
+      throw new RenderCommandError(
+        "Draft visual asset metadata is invalid. Regenerate the draft.",
+        "render-failed"
+      );
+    }
+
+    return {
+      slideIndex: asset.slideIndex,
+      assetSlotId: asset.assetSlotId,
+      filePath: asset.filePath
+    };
+  });
+
+  return visualAssets;
+}
+
+function assertVisualAssetsCoverCards(
+  cards: CarouselHtmlCard[],
+  visualAssets: CarouselPngVisualAsset[]
+): void {
+  const hasMissingAsset = cards.some(
+    (card) =>
+      !visualAssets.some(
+        (asset) =>
+          asset.slideIndex === card.slideIndex &&
+          asset.assetSlotId === card.visualTreatment.assetSlotId
+      )
+  );
+
+  if (hasMissingAsset) {
+    throw new RenderCommandError(
+      "Draft visual assets are missing. Regenerate the draft.",
+      "render-failed"
+    );
+  }
+}
+
+function buildRenderedMetadata(
+  metadata: Record<string, unknown>,
+  renderResult: CarouselPngRenderResult
+): Record<string, unknown> {
+  return {
+    ...metadata,
+    files: mergeFiles(metadata.files, renderResult.files),
+    carousel: renderResult
+  };
+}
+
+function mergeFiles(existingFiles: unknown, renderedFiles: string[]): string[] {
+  const files = Array.isArray(existingFiles)
+    ? existingFiles.filter((file): file is string => typeof file === "string")
+    : [];
+
+  return Array.from(new Set([...files, ...renderedFiles]));
+}
+
+function isRenderConfigFile(value: unknown): value is RenderConfigFile {
+  return (
+    isRecord(value) &&
+    value.schemaVersion === 1 &&
+    typeof value.draftRoot === "string"
+  );
+}
+
+function isVisualAssetMetadata(value: unknown): value is CarouselPngVisualAsset {
+  return (
+    isRecord(value) &&
+    typeof value.slideIndex === "number" &&
+    Number.isInteger(value.slideIndex) &&
+    value.slideIndex > 0 &&
+    typeof value.assetSlotId === "string" &&
+    value.assetSlotId.trim().length > 0 &&
+    typeof value.filePath === "string" &&
+    value.filePath.trim().length > 0
+  );
+}
+
+function isPathInside(rootPath: string, valuePath: string): boolean {
+  const relativePath = relative(resolve(rootPath), resolve(valuePath));
+
+  return (
+    relativePath === "" ||
+    (relativePath !== ".." &&
+      !relativePath.startsWith(`..${sep}`) &&
+      !isAbsolute(relativePath))
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}

--- a/tests/carousel-renderer.test.ts
+++ b/tests/carousel-renderer.test.ts
@@ -500,7 +500,7 @@ class FailingPngRenderer {
 }
 
 function extractLayoutFit(html: string): string | undefined {
-  return /data-layout-fit="([^"]+)"/.exec(html)?.[1];
+  return /<article\b[^>]*\sdata-layout-fit="([^"]+)"/.exec(html)?.[1];
 }
 
 async function createTestRevision() {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -12,7 +12,15 @@ import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
+import {
+  CarouselPngRenderError,
+  type CarouselHtmlToPngRenderer
+} from "../src/carousel-renderer.js";
 import { isDirectRun, runCli } from "../src/cli.js";
+import {
+  createDraftRevision,
+  writeLatestDraftPointer
+} from "../src/draft-storage.js";
 import { addProject } from "../src/project-add.js";
 
 const execFileAsync = promisify(execFile);
@@ -302,6 +310,128 @@ describe("cli", () => {
     expect(stderr.join("\n")).toContain("Not a Git repository");
   });
 
+  it("renders the latest draft carousel with existing visual assets", async () => {
+    const { io, stdout, stderr } = createIo();
+    const fixture = await createLatestDraftFixture();
+    const renderer = new RecordingPngRenderer();
+
+    const exitCode = await runCli(["render", "latest"], io, {
+      homeDir: fixture.homeDir,
+      carouselRenderer: renderer
+    });
+    const carouselPng = await readFile(
+      join(fixture.revision.outputDir, "carousel", "01.png")
+    );
+    const metadata = await readJson(join(fixture.revision.outputDir, "metadata.json"));
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toEqual([]);
+    expect(stdout).toEqual([
+      `Rendered carousel for ${fixture.revision.targetDate}: ${fixture.revision.outputDir}`,
+      `Carousel files: ${join(fixture.revision.outputDir, "carousel")}`
+    ]);
+    expect(carouselPng).toEqual(pngBytes);
+    expect(renderer.calls).toHaveLength(1);
+    expect(renderer.calls[0]?.html).toContain("class=\"visual-asset\"");
+    expect(renderer.calls[0]?.html).toContain("data:image/png;base64,");
+    expect(metadata).toMatchObject({
+      files: [
+        "activity-summary.json",
+        "story.json",
+        "caption.txt",
+        "metadata.json",
+        "safety-report.json",
+        "visuals/01.png",
+        "carousel/01.png"
+      ],
+      carousel: {
+        schemaVersion: 1,
+        status: "rendered",
+        files: ["carousel/01.png"],
+        images: [
+          {
+            schemaVersion: 1,
+            slideIndex: 1,
+            assetSlotId: "slide-01-visual",
+            sourceHtmlFileName: "01.html",
+            filePath: "carousel/01.png",
+            visualAssetPath: "visuals/01.png"
+          }
+        ]
+      }
+    });
+  });
+
+  it("returns a rendering error when no latest draft exists", async () => {
+    const { io, stdout, stderr } = createIo();
+    const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-render-missing-"));
+    const homeDir = join(directory, "home");
+    const draftRoot = join(directory, "drafts");
+
+    await writeConfig(homeDir, draftRoot);
+
+    const exitCode = await runCli(["render", "latest"], io, {
+      homeDir,
+      carouselRenderer: new RecordingPngRenderer()
+    });
+
+    expect(exitCode).toBe(5);
+    expect(stdout).toEqual([]);
+    expect(stderr).toEqual([
+      "No latest draft found. Run `uncommitted generate today` first."
+    ]);
+  });
+
+  it("returns a rendering error for invalid latest draft story data", async () => {
+    const { io, stdout, stderr } = createIo();
+    const fixture = await createLatestDraftFixture({
+      story: { schemaVersion: 1, targetDate: "2026-05-18", slides: [] }
+    });
+
+    const exitCode = await runCli(["render", "latest"], io, {
+      homeDir: fixture.homeDir,
+      carouselRenderer: new RecordingPngRenderer()
+    });
+
+    expect(exitCode).toBe(5);
+    expect(stdout).toEqual([]);
+    expect(stderr).toEqual(["Draft story is not renderable. Regenerate the draft."]);
+    await expect(
+      readFile(join(fixture.revision.outputDir, "story.json"), "utf8")
+    ).resolves.toContain("\"slides\": []");
+  });
+
+  it("returns a rendering error for missing declared visual asset files", async () => {
+    const { io, stdout, stderr } = createIo();
+    const fixture = await createLatestDraftFixture({ writeVisualAsset: false });
+
+    const exitCode = await runCli(["render", "latest"], io, {
+      homeDir: fixture.homeDir,
+      carouselRenderer: new RecordingPngRenderer()
+    });
+
+    expect(exitCode).toBe(5);
+    expect(stdout).toEqual([]);
+    expect(stderr).toEqual(["Could not render carousel PNGs."]);
+    await expect(
+      access(join(fixture.revision.outputDir, "carousel", "01.png"))
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("returns rendering exit code when the PNG renderer fails", async () => {
+    const { io, stdout, stderr } = createIo();
+    const fixture = await createLatestDraftFixture();
+
+    const exitCode = await runCli(["render", "latest"], io, {
+      homeDir: fixture.homeDir,
+      carouselRenderer: new FailingPngRenderer()
+    });
+
+    expect(exitCode).toBe(5);
+    expect(stdout).toEqual([]);
+    expect(stderr).toEqual(["Could not render carousel PNGs."]);
+  });
+
   it("routes doctor to the environment report handler", async () => {
     const { io, stdout, stderr } = createIo();
     const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-doctor-"));
@@ -401,4 +531,140 @@ async function git(
 
 async function readJson(path: string): Promise<unknown> {
   return JSON.parse(await readFile(path, "utf8")) as unknown;
+}
+
+const pngBytes = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+  "base64"
+);
+
+type LatestDraftFixtureOptions = {
+  story?: unknown;
+  metadata?: Record<string, unknown>;
+  writeVisualAsset?: boolean;
+};
+
+async function createLatestDraftFixture(options: LatestDraftFixtureOptions = {}) {
+  const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-render-"));
+  const homeDir = join(directory, "home");
+  const draftRoot = join(directory, "drafts");
+  const revision = await createDraftRevision({
+    draftRoot,
+    targetDate: "2026-05-18"
+  });
+  const story = options.story ?? createStoryDraft();
+  const metadata = options.metadata ?? createDraftMetadata();
+
+  await writeConfig(homeDir, draftRoot);
+  await writeJson(join(revision.outputDir, "activity-summary.json"), {
+    schemaVersion: 1
+  });
+  await writeJson(join(revision.outputDir, "story.json"), story);
+  await writeFile(join(revision.outputDir, "caption.txt"), "Render latest\n", "utf8");
+  await writeJson(join(revision.outputDir, "safety-report.json"), {
+    schemaVersion: 1,
+    status: "safe"
+  });
+  await writeJson(join(revision.outputDir, "metadata.json"), metadata);
+
+  if (options.writeVisualAsset !== false) {
+    await mkdir(join(revision.outputDir, "visuals"), { recursive: true });
+    await writeFile(join(revision.outputDir, "visuals", "01.png"), pngBytes);
+  }
+
+  await writeLatestDraftPointer(revision, "2026-05-18T23:30:00.000Z");
+
+  return {
+    homeDir,
+    draftRoot,
+    revision
+  };
+}
+
+async function writeConfig(homeDir: string, draftRoot: string): Promise<void> {
+  await mkdir(join(homeDir, ".uncommitted"), { recursive: true });
+  await writeJson(join(homeDir, ".uncommitted", "config.json"), {
+    schemaVersion: 1,
+    draftRoot,
+    scheduleTime: "23:30",
+    aiProvider: "none",
+    persona: "test persona",
+    roastLevel: 2
+  });
+}
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function createStoryDraft(): Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    targetDate: "2026-05-18",
+    title: "Render Latest Day",
+    slides: [
+      {
+        index: 1,
+        title: "Latest draft gets rendered",
+        body: "The image was already generated, so render latest should use it.",
+        visualMood: "polished local AI illustration"
+      }
+    ],
+    metadata: {
+      projectIds: ["uncommitted"]
+    }
+  };
+}
+
+function createDraftMetadata(): Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    version: 1,
+    artifactVersion: 1,
+    targetDate: "2026-05-18",
+    date: "2026-05-18",
+    status: "draft",
+    files: [
+      "activity-summary.json",
+      "story.json",
+      "caption.txt",
+      "metadata.json",
+      "safety-report.json",
+      "visuals/01.png"
+    ],
+    visualAssets: [
+      {
+        schemaVersion: 1,
+        slideIndex: 1,
+        assetSlotId: "slide-01-visual",
+        promptSummary: "polished local AI illustration",
+        provider: "openai",
+        filePath: "visuals/01.png",
+        fallbackState: "none"
+      }
+    ]
+  };
+}
+
+class RecordingPngRenderer implements CarouselHtmlToPngRenderer {
+  readonly calls: { html: string; width: number; height: number }[] = [];
+
+  async renderHtmlToPng(options: {
+    html: string;
+    width: number;
+    height: number;
+  }): Promise<Uint8Array> {
+    this.calls.push(options);
+
+    return pngBytes;
+  }
+}
+
+class FailingPngRenderer implements CarouselHtmlToPngRenderer {
+  async renderHtmlToPng(): Promise<never> {
+    throw new CarouselPngRenderError(
+      "Could not render carousel PNGs.",
+      "render-failed"
+    );
+  }
 }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -401,6 +401,35 @@ describe("cli", () => {
     ).resolves.toContain("\"slides\": []");
   });
 
+  it("returns safety-blocked exit code for blocked latest drafts", async () => {
+    const { io, stdout, stderr } = createIo();
+    const fixture = await createLatestDraftFixture({
+      metadata: {
+        ...createDraftMetadata(),
+        exportPolicy: "blocked",
+        safety: {
+          status: "blocked",
+          message: "Safety blocked.",
+          riskCount: 1
+        }
+      }
+    });
+
+    const exitCode = await runCli(["render", "latest"], io, {
+      homeDir: fixture.homeDir,
+      carouselRenderer: new RecordingPngRenderer()
+    });
+
+    expect(exitCode).toBe(6);
+    expect(stdout).toEqual([]);
+    expect(stderr).toEqual([
+      "Draft is blocked by safety checks. Regenerate or edit before rendering."
+    ]);
+    await expect(
+      access(join(fixture.revision.outputDir, "carousel", "01.png"))
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("returns a rendering error for missing declared visual asset files", async () => {
     const { io, stdout, stderr } = createIo();
     const fixture = await createLatestDraftFixture({ writeVisualAsset: false });


### PR DESCRIPTION
# Goal

Implement `uncommitted render latest` so the latest generated draft can produce Instagram-ready carousel PNGs from the already-generated visual assets.

## Related Issue

Closes #49.

## Acceptance Criteria

- [x] `uncommitted render latest` renders the latest draft revision's carousel PNGs
- [x] Success output includes enough path information for the user to find the local carousel files
- [x] Rendered metadata preserves slide order and visual asset-slot references
- [x] Missing latest draft fails with a short actionable message
- [x] Invalid or unsafe render input fails without deleting existing draft artifacts
- [x] Renderer failures exit with code `5`
- [x] Tests cover the CLI success path and representative failure paths

## Implementation Notes

- Added a render command module that resolves the configured draft root, reads `latest.json`, loads `story.json` and `metadata.json`, passes existing `metadata.visualAssets` into the carousel PNG renderer, and writes `metadata.carousel` plus rendered file paths back to `metadata.json`.
- Wired `uncommitted render latest` through the CLI with render failures mapped to exit code `5`.
- Added a narrow renderer CSS adjustment so the decorative visual-stage element stays within the Playwright overflow validation box.

## Validation

- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- Built `runCli` smoke with real Playwright renderer against a temporary latest draft; verified `carousel/01.png` and `metadata.carousel.files`.

## Remaining Risk

Direct subprocess smoke via `node dist/cli.js render latest` returned exit code `5` in this sandboxed session, while the built `runCli` path with the real Playwright renderer succeeded. The command implementation and renderer path are covered by tests and the in-process smoke check.
