### PR TITLE
feat: add carousel visual style modes

### DIFF
--- a/src/carousel-renderer.ts
+++ b/src/carousel-renderer.ts
@@ -38,7 +38,9 @@ export type CarouselRenderInput = {
   slides: DiarySlide[];
 };
 
-export type CarouselVisualTreatmentKind = "illustration";
+export type CarouselVisualStyleMode = "photo-first" | "story-card";
+
+export type CarouselVisualTreatmentKind = "photo" | "story-card";
 
 export type CarouselVisualTreatment = {
   kind: CarouselVisualTreatmentKind;
@@ -52,6 +54,7 @@ export type CarouselHtmlCard = {
   slideIndex: number;
   pageNumber: number;
   pageCount: number;
+  visualStyle: CarouselVisualStyleMode;
   visualTreatment: CarouselVisualTreatment;
   html: string;
 };
@@ -105,6 +108,10 @@ export type RenderCarouselPngsOptions = {
   renderer?: CarouselHtmlToPngRenderer;
 };
 
+export type CreateCarouselHtmlCardsOptions = {
+  visualStyle?: CarouselVisualStyleMode;
+};
+
 const invalidStoryMessage =
   "story.json must include ordered slides with title and body.";
 const carouselWidth = 1080;
@@ -139,24 +146,30 @@ export function parseCarouselRenderInput(value: unknown): CarouselRenderInput {
   };
 }
 
-export function createCarouselHtmlCards(value: unknown): CarouselHtmlCard[] {
+export function createCarouselHtmlCards(
+  value: unknown,
+  options: CreateCarouselHtmlCardsOptions = {}
+): CarouselHtmlCard[] {
   const input = parseCarouselRenderInput(value);
   const pageCount = input.slides.length;
+  const visualStyle = options.visualStyle ?? "story-card";
 
   return input.slides.map((slide, index) => {
     const pageNumber = index + 1;
-    const visualTreatment = createVisualTreatment(slide, pageNumber);
+    const visualTreatment = createVisualTreatment(slide, pageNumber, visualStyle);
 
     return {
       fileName: `${String(pageNumber).padStart(2, "0")}.html`,
       slideIndex: slide.index,
       pageNumber,
       pageCount,
+      visualStyle,
       visualTreatment,
       html: renderCardHtml({
         targetDate: input.targetDate,
         projectMarker: input.projectMarker,
         slide,
+        visualStyle,
         visualTreatment,
         pageNumber,
         pageCount
@@ -383,31 +396,47 @@ function validateRenderedCard(): { ok: true } | { ok: false } {
 
   const card = document.querySelector<HTMLElement>(".card");
   const visualStage = document.querySelector<HTMLElement>(".visual-stage");
-  const content = document.querySelector<HTMLElement>(".content");
   const footer = document.querySelector<HTMLElement>(".footer");
-  const title = document.querySelector<HTMLElement>("h1");
-  const body = document.querySelector<HTMLElement>(".body");
   const visualImage = document.querySelector<HTMLImageElement>(".visual-asset");
+  const visualStyle = card?.dataset.carouselVisualStyle;
 
-  if (!card || !visualStage || !content || !footer || !title || !body) {
+  if (!card || !visualStage || !footer) {
     return { ok: false };
   }
 
   const cardRect = card.getBoundingClientRect();
   const visualRect = visualStage.getBoundingClientRect();
-  const contentRect = content.getBoundingClientRect();
   const footerRect = footer.getBoundingClientRect();
 
   if (
     overflowsOwnBox(card) ||
-    overflowsOwnBox(title) ||
-    overflowsOwnBox(body) ||
     overflowsCard(cardRect, visualRect) ||
-    overflowsCard(cardRect, contentRect) ||
-    overflowsCard(cardRect, footerRect) ||
-    visualRect.bottom > contentRect.top - 16 ||
-    contentRect.bottom > footerRect.top - 16
+    overflowsCard(cardRect, footerRect)
   ) {
+    return { ok: false };
+  }
+
+  if (visualStyle !== "photo-first") {
+    const content = document.querySelector<HTMLElement>(".content");
+    const title = document.querySelector<HTMLElement>("h1");
+    const body = document.querySelector<HTMLElement>(".body");
+
+    if (!content || !title || !body) {
+      return { ok: false };
+    }
+
+    const contentRect = content.getBoundingClientRect();
+
+    if (
+      overflowsOwnBox(title) ||
+      overflowsOwnBox(body) ||
+      overflowsCard(cardRect, contentRect) ||
+      visualRect.bottom > contentRect.top - 16 ||
+      contentRect.bottom > footerRect.top - 16
+    ) {
+      return { ok: false };
+    }
+  } else if (visualRect.bottom > footerRect.top - 16) {
     return { ok: false };
   }
 
@@ -443,7 +472,8 @@ async function composeCardHtml(options: {
 
   const dataUri = `data:image/png;base64,${image.toString("base64")}`;
   const visualAssetCss = `
-    .visual-stage.has-visual-asset {
+    .visual-stage.has-visual-asset,
+    .photo-stage.has-visual-asset {
       background: #eef2f7;
     }
 
@@ -456,7 +486,7 @@ async function composeCardHtml(options: {
       object-fit: cover;
     }
 
-    .visual-stage.has-visual-asset .visual-placeholder {
+    .visual-stage.has-visual-asset:not(.photo-stage) .visual-placeholder {
       padding: 18px 22px;
       background: rgba(247, 247, 245, 0.82);
       border: 2px solid rgba(15, 23, 42, 0.12);
@@ -468,7 +498,14 @@ async function composeCardHtml(options: {
 
   return options.card.html
     .replace("</style>", `${visualAssetCss}  </style>`)
-    .replace('class="visual-stage"', 'class="visual-stage has-visual-asset"')
+    .replace(
+      'class="photo-stage visual-stage"',
+      'class="photo-stage has-visual-asset visual-stage"'
+    )
+    .replace(
+      'class="visual-stage"',
+      'class="visual-stage has-visual-asset"'
+    )
     .replace(
       '<div class="visual-placeholder">',
       `${imgHtml}\n      <div class="visual-placeholder">`
@@ -591,14 +628,20 @@ function renderCardHtml(options: {
   targetDate: string;
   projectMarker: string;
   slide: DiarySlide;
+  visualStyle: CarouselVisualStyleMode;
   visualTreatment: CarouselVisualTreatment;
   pageNumber: number;
   pageCount: number;
 }): string {
+  if (options.visualStyle === "photo-first") {
+    return renderPhotoFirstCardHtml(options);
+  }
+
   const title = escapeHtml(options.slide.title.trim());
   const body = escapeHtml(options.slide.body.trim());
   const targetDate = escapeHtml(options.targetDate.trim());
   const projectMarker = escapeHtml(options.projectMarker.trim());
+  const visualStyle = escapeHtml(options.visualStyle);
   const visualAssetSlotId = escapeHtml(options.visualTreatment.assetSlotId);
   const visualKind = escapeHtml(options.visualTreatment.kind);
   const visualPrompt = escapeHtml(options.visualTreatment.prompt);
@@ -806,7 +849,7 @@ function renderCardHtml(options: {
 <body>
   <article class="card" aria-label="Uncommitted carousel card ${escapeHtml(
     pageIndicator
-  )}" data-layout-fit="base">
+  )}" data-layout-fit="base" data-carousel-visual-style="${visualStyle}">
     <header class="topline">
       <div class="project-marker">${projectMarker}</div>
       <time datetime="${targetDate}">${targetDate}</time>
@@ -836,16 +879,163 @@ function renderCardHtml(options: {
 
 function createVisualTreatment(
   slide: DiarySlide,
-  pageNumber: number
+  pageNumber: number,
+  visualStyle: CarouselVisualStyleMode
 ): CarouselVisualTreatment {
   const prompt = slide.visualMood.trim();
+  const isPhotoFirst = visualStyle === "photo-first";
 
   return {
-    kind: "illustration",
+    kind: isPhotoFirst ? "photo" : "story-card",
     assetSlotId: `slide-${String(pageNumber).padStart(2, "0")}-visual`,
     prompt,
-    altText: `Illustration concept: ${prompt}`
+    altText: `${isPhotoFirst ? "Photo-first" : "Story-card"} visual concept: ${prompt}`
   };
+}
+
+function renderPhotoFirstCardHtml(options: {
+  targetDate: string;
+  projectMarker: string;
+  slide: DiarySlide;
+  visualStyle: CarouselVisualStyleMode;
+  visualTreatment: CarouselVisualTreatment;
+  pageNumber: number;
+  pageCount: number;
+}): string {
+  const title = escapeHtml(options.slide.title.trim());
+  const targetDate = escapeHtml(options.targetDate.trim());
+  const projectMarker = escapeHtml(options.projectMarker.trim());
+  const visualStyle = escapeHtml(options.visualStyle);
+  const visualAssetSlotId = escapeHtml(options.visualTreatment.assetSlotId);
+  const visualKind = escapeHtml(options.visualTreatment.kind);
+  const visualPrompt = escapeHtml(options.visualTreatment.prompt);
+  const visualAltText = escapeHtml(options.visualTreatment.altText);
+  const pageIndicator = `${options.pageNumber} / ${options.pageCount}`;
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=1080, initial-scale=1">
+  <title>${title}</title>
+  <style>
+    :root {
+      color-scheme: light;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: #f7f7f5;
+      color: #161616;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      background: #f7f7f5;
+    }
+
+    .card {
+      width: 1080px;
+      height: 1350px;
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      padding: 42px 46px 46px;
+      background: #f7f7f5;
+      color: #161616;
+      overflow: hidden;
+    }
+
+    .topline,
+    .footer {
+      position: relative;
+      z-index: 2;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 28px;
+      font-size: 28px;
+      font-weight: 800;
+      letter-spacing: 0;
+      line-height: 1.2;
+      color: #f8fafc;
+      text-shadow: 0 2px 16px rgba(15, 23, 42, 0.62);
+    }
+
+    .project-marker {
+      max-width: 640px;
+      overflow-wrap: anywhere;
+    }
+
+    .photo-stage {
+      position: absolute;
+      inset: 0;
+      z-index: 0;
+      background:
+        linear-gradient(135deg, rgba(15, 118, 110, 0.18), rgba(15, 23, 42, 0) 42%),
+        linear-gradient(315deg, rgba(234, 179, 8, 0.18), rgba(15, 23, 42, 0) 44%),
+        #dfe7ef;
+      overflow: hidden;
+    }
+
+    .photo-stage::after {
+      position: absolute;
+      inset: 0;
+      z-index: 1;
+      content: "";
+      background:
+        linear-gradient(180deg, rgba(15, 23, 42, 0.36), rgba(15, 23, 42, 0) 24%),
+        linear-gradient(0deg, rgba(15, 23, 42, 0.46), rgba(15, 23, 42, 0) 28%);
+      pointer-events: none;
+    }
+
+    .visual-placeholder {
+      position: absolute;
+      inset: 180px 120px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 0;
+      border: 2px solid rgba(15, 23, 42, 0.14);
+      background: rgba(248, 250, 252, 0.32);
+      color: transparent;
+      overflow: hidden;
+    }
+
+    .mark {
+      font-size: 34px;
+      font-weight: 900;
+      color: #f8fafc;
+    }
+  </style>
+</head>
+<body>
+  <article class="card" aria-label="Uncommitted carousel card ${escapeHtml(
+    pageIndicator
+  )}" data-layout-fit="base" data-carousel-visual-style="${visualStyle}">
+    <header class="topline">
+      <div class="project-marker">${projectMarker}</div>
+      <time datetime="${targetDate}">${targetDate}</time>
+    </header>
+    <section
+      class="photo-stage visual-stage"
+      data-visual-kind="${visualKind}"
+      data-asset-slot-id="${visualAssetSlotId}"
+      data-visual-prompt="${visualPrompt}"
+      aria-label="${visualAltText}"
+    >
+      <div class="visual-placeholder">${visualPrompt}</div>
+    </section>
+    <footer class="footer">
+      <div class="mark">Uncommitted</div>
+      <div>${escapeHtml(pageIndicator)}</div>
+    </footer>
+  </article>
+</body>
+</html>
+`;
 }
 
 function deriveProjectMarker(value: Record<string, unknown>): string {

--- a/src/carousel-renderer.ts
+++ b/src/carousel-renderer.ts
@@ -436,8 +436,6 @@ function validateRenderedCard(): { ok: true } | { ok: false } {
     ) {
       return { ok: false };
     }
-  } else if (visualRect.bottom > footerRect.top - 16) {
-    return { ok: false };
   }
 
   if (

--- a/src/generate-command.ts
+++ b/src/generate-command.ts
@@ -10,7 +10,10 @@ import {
   type AiProviderConfig,
   type AiProviderName
 } from "./ai-provider.js";
-import { createCarouselHtmlCards } from "./carousel-renderer.js";
+import {
+  createCarouselHtmlCards,
+  type CarouselVisualStyleMode
+} from "./carousel-renderer.js";
 import type { GitActivityEvent } from "./collect-git-command.js";
 import { resolveConfigPaths } from "./config-paths.js";
 import {
@@ -90,12 +93,14 @@ export type GenerateCommandResult = {
 
 type GenerateConfig = AiProviderConfig & {
   draftRoot: string;
+  carouselVisualStyle: CarouselVisualStyleMode;
 };
 
 type GenerateConfigFile = {
   schemaVersion: 1;
   draftRoot: string;
   aiProvider: AiProviderName;
+  carouselVisualStyle?: CarouselVisualStyleMode;
   persona: string;
   roastLevel: number;
 };
@@ -126,6 +131,8 @@ type DraftMetadataBase = {
   exported: false;
   published: false;
   files: string[];
+  requestedCarouselVisualStyle: CarouselVisualStyleMode;
+  carouselVisualStyle: CarouselVisualStyleMode;
 };
 
 type DraftMetadata = DraftMetadataBase & {
@@ -206,10 +213,6 @@ export async function runGenerateCommand(
   );
 
   const provider = options.aiProvider ?? createAiProvider(config);
-  const imageAssetProvider = await runVisualAssetGeneration(
-    async () => options.imageAssetProvider ?? createImageAssetProvider(config),
-    draftRevision.outputDir
-  );
   const recentFormats = await loadRecentStoryFormatHistory({
     homeDir: options.homeDir
   });
@@ -253,7 +256,9 @@ export async function runGenerateCommand(
     status: "draft",
     exported: false,
     published: false,
-    files: [...baseDraftFiles]
+    files: [...baseDraftFiles],
+    requestedCarouselVisualStyle: config.carouselVisualStyle,
+    carouselVisualStyle: config.carouselVisualStyle
   };
   const safetyReport = createSafetyReport(
     buildDraftSafetyText({ draft, caption, metadata: baseMetadata })
@@ -291,20 +296,23 @@ export async function runGenerateCommand(
     );
   }
 
-  const visualAssets = await runVisualAssetGeneration(
-    () =>
-      generateCarouselVisualAssets({
-        revision: draftRevision,
-        cards: createCarouselHtmlCards(draft),
-        provider: imageAssetProvider,
-        fallbackProviderName: config.provider
-      }),
-    draftRevision.outputDir
-  );
+  const imageAssetProvider = await resolveImageAssetProvider({
+    config,
+    injectedProvider: options.imageAssetProvider
+  });
+  const { visualAssets, visualStyle } = await generateVisualAssetsForDraft({
+    revision: draftRevision,
+    draft,
+    requestedVisualStyle: config.carouselVisualStyle,
+    provider: imageAssetProvider,
+    fallbackProviderName: config.provider,
+    outputDir: draftRevision.outputDir
+  });
   const metadata = buildDraftMetadata({
     baseMetadata,
     safetyReport,
-    visualAssets
+    visualAssets,
+    visualStyle
   });
 
   await runDraftStorageOperation(async () => {
@@ -338,9 +346,12 @@ function buildDraftMetadata(options: {
   baseMetadata: DraftMetadataBase;
   safetyReport: SafetyReport;
   visualAssets: VisualAssetGenerationResult;
+  visualStyle?: CarouselVisualStyleMode;
 }): DraftMetadata {
   return {
     ...options.baseMetadata,
+    carouselVisualStyle:
+      options.visualStyle ?? options.baseMetadata.carouselVisualStyle,
     files: [...baseDraftFiles, ...options.visualAssets.files],
     exportPolicy: options.safetyReport.status,
     exportReady: options.safetyReport.exportAllowed,
@@ -399,6 +410,104 @@ async function runVisualAssetGeneration<T>(
   }
 }
 
+async function resolveImageAssetProvider(options: {
+  config: GenerateConfig;
+  injectedProvider?: ImageAssetProvider;
+}): Promise<ImageAssetProvider | undefined> {
+  if (options.config.carouselVisualStyle === "story-card") {
+    return undefined;
+  }
+
+  if (options.injectedProvider) {
+    return options.injectedProvider;
+  }
+
+  try {
+    return createImageAssetProvider(options.config);
+  } catch (error) {
+    if (error instanceof VisualAssetGenerationError) {
+      return undefined;
+    }
+
+    throw error;
+  }
+}
+
+async function generateVisualAssetsForDraft(options: {
+  revision: Parameters<typeof generateCarouselVisualAssets>[0]["revision"];
+  draft: DiaryDraft;
+  requestedVisualStyle: CarouselVisualStyleMode;
+  provider?: ImageAssetProvider;
+  fallbackProviderName: AiProviderName;
+  outputDir: string;
+}): Promise<{
+  visualAssets: VisualAssetGenerationResult;
+  visualStyle: CarouselVisualStyleMode;
+}> {
+  const initialVisualStyle =
+    options.requestedVisualStyle === "photo-first" && !options.provider
+      ? "story-card"
+      : options.requestedVisualStyle;
+  const fallbackState =
+    initialVisualStyle === "story-card" &&
+    options.requestedVisualStyle === "story-card"
+      ? "image-generation-disabled"
+      : initialVisualStyle === "story-card" &&
+          options.requestedVisualStyle === "photo-first"
+        ? options.fallbackProviderName === "none"
+          ? "no-provider"
+          : "provider-unsupported"
+        : undefined;
+
+  try {
+    const visualAssets = await runVisualAssetGeneration(
+      () =>
+        generateCarouselVisualAssets({
+          revision: options.revision,
+          cards: createCarouselHtmlCards(options.draft, {
+            visualStyle: initialVisualStyle
+          }),
+          provider: options.provider,
+          fallbackProviderName: options.fallbackProviderName,
+          fallbackState
+        }),
+      options.outputDir
+    );
+
+    return {
+      visualAssets,
+      visualStyle: initialVisualStyle
+    };
+  } catch (error) {
+    if (
+      error instanceof GenerateCommandError &&
+      error.code === "visual-generation-failed" &&
+      options.requestedVisualStyle === "photo-first" &&
+      options.provider
+    ) {
+      const visualAssets = await runVisualAssetGeneration(
+        () =>
+          generateCarouselVisualAssets({
+            revision: options.revision,
+            cards: createCarouselHtmlCards(options.draft, {
+              visualStyle: "story-card"
+            }),
+            fallbackProviderName: options.fallbackProviderName,
+            fallbackState: "provider-failed"
+          }),
+        options.outputDir
+      );
+
+      return {
+        visualAssets,
+        visualStyle: "story-card"
+      };
+    }
+
+    throw error;
+  }
+}
+
 function parseGenerateDate(
   args: string[],
   now: (() => string) | undefined
@@ -450,6 +559,7 @@ async function readGenerateConfig(
         draftRoot: parsed.draftRoot
       }).defaultDraftRoot,
       provider: parsed.aiProvider,
+      carouselVisualStyle: parsed.carouselVisualStyle ?? "photo-first",
       persona: parsed.persona,
       roastLevel: parsed.roastLevel
     };
@@ -597,12 +707,20 @@ function isGenerateConfigFile(value: unknown): value is GenerateConfigFile {
     value.schemaVersion === 1 &&
     typeof value.draftRoot === "string" &&
     isAiProviderName(value.aiProvider) &&
+    (value.carouselVisualStyle === undefined ||
+      isCarouselVisualStyleMode(value.carouselVisualStyle)) &&
     typeof value.persona === "string" &&
     typeof value.roastLevel === "number" &&
     Number.isInteger(value.roastLevel) &&
     value.roastLevel >= 0 &&
     value.roastLevel <= 5
   );
+}
+
+function isCarouselVisualStyleMode(
+  value: unknown
+): value is CarouselVisualStyleMode {
+  return value === "photo-first" || value === "story-card";
 }
 
 function isProjectsFile(value: unknown): value is ProjectsFile {

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ export type {
   CarouselPngVisualAsset,
   CarouselRenderInput,
   CarouselRenderInputErrorCode,
+  CarouselVisualStyleMode,
   CarouselVisualTreatment,
   CarouselVisualTreatmentKind,
   RenderCarouselPngsOptions

--- a/src/init-command.ts
+++ b/src/init-command.ts
@@ -8,6 +8,7 @@ export type InitAnswers = {
   draftRoot?: string;
   scheduleTime?: string;
   aiProvider?: string;
+  carouselVisualStyle?: string;
   persona?: string;
   roastLevel?: string;
 };
@@ -22,6 +23,7 @@ export type InitConfig = {
   draftRoot: string;
   scheduleTime: string;
   aiProvider: string;
+  carouselVisualStyle: "photo-first" | "story-card";
   persona: string;
   roastLevel: number;
 };
@@ -35,6 +37,7 @@ const defaultAnswers = {
   draftRoot: "~/Uncommitted/drafts",
   scheduleTime: "23:30",
   aiProvider: "none",
+  carouselVisualStyle: "photo-first",
   persona: "project-local AI coworker writing its own off-the-record diary",
   roastLevel: "2"
 };
@@ -57,6 +60,9 @@ export async function runInitCommand(
   const answers = await resolveAnswers(options.answers);
   const scheduleTime = parseScheduleTime(answers.scheduleTime);
   const aiProvider = parseAiProvider(answers.aiProvider);
+  const carouselVisualStyle = parseCarouselVisualStyle(
+    answers.carouselVisualStyle
+  );
   const roastLevel = parseRoastLevel(answers.roastLevel);
   const paths = resolveConfigPaths({
     homeDir: options.homeDir,
@@ -74,6 +80,7 @@ export async function runInitCommand(
     draftRoot: paths.defaultDraftRoot,
     scheduleTime,
     aiProvider,
+    carouselVisualStyle,
     persona: answers.persona,
     roastLevel
   };
@@ -106,6 +113,8 @@ async function resolveAnswers(answers: InitAnswers = {}): Promise<Required<InitA
       draftRoot: answers.draftRoot ?? defaultAnswers.draftRoot,
       scheduleTime: answers.scheduleTime ?? defaultAnswers.scheduleTime,
       aiProvider: answers.aiProvider ?? defaultAnswers.aiProvider,
+      carouselVisualStyle:
+        answers.carouselVisualStyle ?? defaultAnswers.carouselVisualStyle,
       persona: answers.persona ?? defaultAnswers.persona,
       roastLevel: answers.roastLevel ?? defaultAnswers.roastLevel
     };
@@ -121,6 +130,11 @@ async function resolveAnswers(answers: InitAnswers = {}): Promise<Required<InitA
         readline,
         "AI provider, or none to decide later",
         defaultAnswers.aiProvider
+      ),
+      carouselVisualStyle: await ask(
+        readline,
+        "Carousel visual style",
+        defaultAnswers.carouselVisualStyle
       ),
       persona: await ask(readline, "Persona", defaultAnswers.persona),
       roastLevel: await ask(readline, "Roast level 0-5", defaultAnswers.roastLevel)
@@ -166,6 +180,16 @@ function parseAiProvider(value: string): string {
     throw new Error(
       `AI provider must be one of: ${supportedAiProviders.join(", ")}.`
     );
+  }
+
+  return normalized;
+}
+
+function parseCarouselVisualStyle(value: string): "photo-first" | "story-card" {
+  const normalized = value.trim().toLowerCase();
+
+  if (normalized !== "photo-first" && normalized !== "story-card") {
+    throw new Error("Carousel visual style must be one of: photo-first, story-card.");
   }
 
   return normalized;

--- a/src/render-command.ts
+++ b/src/render-command.ts
@@ -4,6 +4,7 @@ import {
   CarouselPngRenderError,
   CarouselRenderInputError,
   createCarouselHtmlCards,
+  type CarouselVisualStyleMode,
   renderCarouselPngs,
   type CarouselHtmlToPngRenderer,
   type CarouselHtmlCard,
@@ -88,7 +89,7 @@ export async function runRenderCommand(
 
   assertDraftIsRenderable(metadata);
 
-  const cards = createCards(story);
+  const cards = createCardsWithStyle(story, readCarouselVisualStyle(metadata));
   const visualAssets = readVisualAssets(metadata);
   assertVisualAssetsCoverCards(cards, visualAssets);
 
@@ -210,9 +211,9 @@ function assertDraftIsRenderable(metadata: Record<string, unknown>): void {
   }
 }
 
-function createCards(story: unknown) {
+function createCardsWithStyle(story: unknown, visualStyle: CarouselVisualStyleMode) {
   try {
-    return createCarouselHtmlCards(story);
+    return createCarouselHtmlCards(story, { visualStyle });
   } catch (error) {
     if (error instanceof CarouselRenderInputError) {
       throw new RenderCommandError(
@@ -223,6 +224,12 @@ function createCards(story: unknown) {
 
     throw error;
   }
+}
+
+function readCarouselVisualStyle(
+  metadata: Record<string, unknown>
+): CarouselVisualStyleMode {
+  return metadata.carouselVisualStyle === "photo-first" ? "photo-first" : "story-card";
 }
 
 function readVisualAssets(

--- a/src/visual-assets.ts
+++ b/src/visual-assets.ts
@@ -6,7 +6,10 @@ import type {
   AiProviderHttpTransport,
   AiProviderName
 } from "./ai-provider.js";
-import type { CarouselHtmlCard } from "./carousel-renderer.js";
+import type {
+  CarouselHtmlCard,
+  CarouselVisualStyleMode
+} from "./carousel-renderer.js";
 import {
   type DraftRevision,
   DraftStorageError,
@@ -17,7 +20,9 @@ import { checkDraftSafety } from "./safety-report.js";
 export type VisualAssetFallbackState =
   | "none"
   | "no-provider"
-  | "provider-unsupported";
+  | "provider-unsupported"
+  | "image-generation-disabled"
+  | "provider-failed";
 
 export type VisualAssetGenerationErrorCode =
   | "provider-failed"
@@ -58,6 +63,7 @@ export type VisualAssetMetadata = {
   schemaVersion: 1;
   slideIndex: number;
   assetSlotId: string;
+  visualStyle: CarouselVisualStyleMode;
   promptSummary: string;
   provider: string;
   filePath: string;
@@ -75,6 +81,7 @@ export type GenerateCarouselVisualAssetsOptions = {
   cards: CarouselHtmlCard[];
   provider?: ImageAssetProvider;
   fallbackProviderName: AiProviderName | string;
+  fallbackState?: VisualAssetFallbackState;
 };
 
 export type CreateImageAssetProviderOptions = {
@@ -126,7 +133,8 @@ export async function generateCarouselVisualAssets(
   for (const [index, card] of options.cards.entries()) {
     const fileName = `visuals/${String(index + 1).padStart(2, "0")}.png`;
     const request = createImageAssetRequest(card);
-    const provider = options.provider;
+    const provider =
+      card.visualStyle === "photo-first" ? options.provider : undefined;
     const image = provider
       ? await generateProviderImage(provider, request)
       : {
@@ -152,12 +160,17 @@ export async function generateCarouselVisualAssets(
       schemaVersion: 1,
       slideIndex: card.slideIndex,
       assetSlotId: card.visualTreatment.assetSlotId,
+      visualStyle: card.visualStyle,
       promptSummary: request.promptSummary,
       provider: provider?.name ?? options.fallbackProviderName,
       filePath: fileName,
       fallbackState: provider
         ? "none"
-        : deriveFallbackState(options.fallbackProviderName)
+        : deriveFallbackState({
+            card,
+            fallbackProviderName: options.fallbackProviderName,
+            fallbackState: options.fallbackState
+          })
     });
   }
 
@@ -170,19 +183,37 @@ export async function generateCarouselVisualAssets(
 
 function createImageAssetRequest(card: CarouselHtmlCard): ImageAssetRequest {
   const promptSummary = sanitizeVisualPrompt(card.visualTreatment.prompt);
+  const prompt =
+    card.visualStyle === "photo-first"
+      ? createPhotoFirstPrompt(promptSummary)
+      : createStoryCardPrompt(promptSummary);
 
   return {
     schemaVersion: 1,
     slideIndex: card.slideIndex,
     assetSlotId: card.visualTreatment.assetSlotId,
     promptSummary,
-    prompt: [
-      "Create a 4:5 editorial illustration for an Uncommitted developer diary carousel.",
-      "Use abstract UI objects, terminals, notes, browser frames, charts, or desk objects.",
-      "Do not include readable secrets, raw code, private URLs, emails, tokens, or local file paths.",
-      `Visual intent: ${promptSummary}`
-    ].join("\n")
+    prompt
   };
+}
+
+function createPhotoFirstPrompt(promptSummary: string): string {
+  return [
+    "Create a natural 4:5 editorial photo for an Instagram photo dump.",
+    "Use cinematic but casual workspace mood, detail shot, aftermath shot, desk object, or quiet developer environment language.",
+    "No readable text, no code, no UI screenshots, no logos, no people faces, no file paths, no emails, no tokens, and no private URLs.",
+    "Not a poster, not an infographic, not an explanatory card, and not a text-overlay concept.",
+    `Visual intent: ${promptSummary}`
+  ].join("\n");
+}
+
+function createStoryCardPrompt(promptSummary: string): string {
+  return [
+    "Create a 4:5 local visual treatment for an Uncommitted story-card carousel.",
+    "Use abstract UI objects, terminals, notes, browser frames, charts, or desk objects.",
+    "Do not include readable secrets, raw code, private URLs, emails, tokens, logos, UI screenshots, or local file paths.",
+    `Visual intent: ${promptSummary}`
+  ].join("\n");
 }
 
 function sanitizeVisualPrompt(value: string): string {
@@ -386,10 +417,22 @@ function resolveEnvValue(
   return options.env === undefined ? process.env[key] : options.env[key];
 }
 
-function deriveFallbackState(
-  providerName: AiProviderName | string
-): VisualAssetFallbackState {
-  return providerName === "none" ? "no-provider" : "provider-unsupported";
+function deriveFallbackState(options: {
+  card: CarouselHtmlCard;
+  fallbackProviderName: AiProviderName | string;
+  fallbackState?: VisualAssetFallbackState;
+}): VisualAssetFallbackState {
+  if (options.fallbackState) {
+    return options.fallbackState;
+  }
+
+  if (options.card.visualStyle === "story-card") {
+    return "image-generation-disabled";
+  }
+
+  return options.fallbackProviderName === "none"
+    ? "no-provider"
+    : "provider-unsupported";
 }
 
 function isOpenAiImageResponse(value: unknown): value is {

--- a/tests/carousel-renderer.test.ts
+++ b/tests/carousel-renderer.test.ts
@@ -32,14 +32,35 @@ describe("carousel renderer", () => {
     expect(cards[0]?.html).toContain("1 / 3");
     expect(cards[0]?.html).toContain("Uncommitted");
     expect(cards[0]?.visualTreatment).toEqual({
-      kind: "illustration",
+      kind: "story-card",
       assetSlotId: "slide-01-visual",
       prompt: "clean card",
-      altText: "Illustration concept: clean card"
+      altText: "Story-card visual concept: clean card"
     });
+    expect(cards[0]?.visualStyle).toBe("story-card");
     expect(cards[0]?.html).toContain("class=\"visual-stage\"");
-    expect(cards[0]?.html).toContain("data-visual-kind=\"illustration\"");
+    expect(cards[0]?.html).toContain("data-carousel-visual-style=\"story-card\"");
+    expect(cards[0]?.html).toContain("data-visual-kind=\"story-card\"");
     expect(cards[0]?.html).toContain("data-asset-slot-id=\"slide-01-visual\"");
+  });
+
+  it("creates photo-first cards with image-forward markup and no large body copy", () => {
+    const cards = createCarouselHtmlCards(createStoryDraft(), {
+      visualStyle: "photo-first"
+    });
+
+    expect(cards[0]?.visualStyle).toBe("photo-first");
+    expect(cards[0]?.visualTreatment).toMatchObject({
+      kind: "photo",
+      assetSlotId: "slide-01-visual",
+      altText: "Photo-first visual concept: clean card"
+    });
+    expect(cards[0]?.html).toContain("data-carousel-visual-style=\"photo-first\"");
+    expect(cards[0]?.html).toContain("data-visual-kind=\"photo\"");
+    expect(cards[0]?.html).not.toContain(
+      "The renderer now has a contract before it gets a camera."
+    );
+    expect(cards[0]?.html).not.toContain("<p class=\"body\"");
   });
 
   it("escapes slide and visual treatment content before writing HTML", () => {
@@ -193,6 +214,39 @@ describe("carousel renderer", () => {
     ]);
     await expect(readFile(join(revision.outputDir, "story.json"), "utf8")).resolves.toBe(
       "{\"schemaVersion\":1}\n"
+    );
+  });
+
+  it("renders photo-first PNGs with visual assets as the primary surface", async () => {
+    const revision = await createTestRevision();
+    const cards = createCarouselHtmlCards(createStoryDraft(), {
+      visualStyle: "photo-first"
+    });
+    const renderer = new RecordingPngRenderer();
+
+    await mkdir(join(revision.outputDir, "visuals"), { recursive: true });
+    await writeFile(join(revision.outputDir, "visuals", "01.png"), fixturePng);
+
+    await renderCarouselPngs({
+      revision,
+      cards: [cards[0]],
+      visualAssets: [
+        {
+          slideIndex: 1,
+          assetSlotId: "slide-01-visual",
+          filePath: "visuals/01.png"
+        }
+      ],
+      renderer
+    });
+
+    expect(renderer.calls[0]?.html).toContain("class=\"visual-asset\"");
+    expect(renderer.calls[0]?.html).toContain(
+      "class=\"photo-stage has-visual-asset visual-stage\""
+    );
+    expect(renderer.calls[0]?.html).not.toContain("<p class=\"body\"");
+    expect(renderer.calls[0]?.html).not.toContain(
+      "The renderer now has a contract before it gets a camera."
     );
   });
 

--- a/tests/generate-command.test.ts
+++ b/tests/generate-command.test.ts
@@ -14,7 +14,7 @@ import type { GitActivityEvent } from "../src/collect-git-command.js";
 import type { DiaryDraft } from "../src/diary-generator.js";
 import { addProject, type ProjectRecord } from "../src/project-add.js";
 import type { StoryFormatPlan } from "../src/story-format-plan.js";
-import type { ImageAssetProvider } from "../src/visual-assets.js";
+import type { ImageAssetProvider, ImageAssetRequest } from "../src/visual-assets.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -50,7 +50,9 @@ describe("generate command", () => {
     const activitySummary = await readJson(join(outputDir, "activity-summary.json"));
     const story = await readJson(join(outputDir, "story.json"));
     const caption = await readFile(join(outputDir, "caption.txt"), "utf8");
-    const metadata = await readJson(join(outputDir, "metadata.json"));
+    const metadata = (await readJson(join(outputDir, "metadata.json"))) as {
+      visualAssets: unknown[];
+    };
     const safetyReport = await readJson(join(outputDir, "safety-report.json"));
     const visualAsset = await readFile(join(outputDir, "visuals", "01.png"));
 
@@ -109,6 +111,8 @@ describe("generate command", () => {
       },
       exported: false,
       published: false,
+      carouselVisualStyle: "story-card",
+      requestedCarouselVisualStyle: "photo-first",
       files: [
         "activity-summary.json",
         "story.json",
@@ -124,6 +128,7 @@ describe("generate command", () => {
           schemaVersion: 1,
           slideIndex: 1,
           assetSlotId: "slide-01-visual",
+          visualStyle: "story-card",
           provider: "mock",
           filePath: "visuals/01.png",
           fallbackState: "provider-unsupported",
@@ -176,7 +181,9 @@ describe("generate command", () => {
       aiProvider: provider
     });
     const outputDir = join(fixture.draftRoot, "2026-05-12", "rev-001");
-    const metadata = await readJson(join(outputDir, "metadata.json"));
+    const metadata = (await readJson(join(outputDir, "metadata.json"))) as {
+      visualAssets: unknown[];
+    };
     const safetyReport = await readJson(join(outputDir, "safety-report.json"));
 
     expect(exitCode).toBe(0);
@@ -221,7 +228,9 @@ describe("generate command", () => {
     const activitySummary = await readJson(join(outputDir, "activity-summary.json"));
     const story = await readJson(join(outputDir, "story.json"));
     const caption = await readFile(join(outputDir, "caption.txt"), "utf8");
-    const metadata = await readJson(join(outputDir, "metadata.json"));
+    const metadata = (await readJson(join(outputDir, "metadata.json"))) as {
+      visualAssets: unknown[];
+    };
     const safetyReport = await readJson(join(outputDir, "safety-report.json"));
     const latest = await readJson(join(fixture.draftRoot, "latest.json"));
 
@@ -494,11 +503,9 @@ describe("generate command", () => {
     });
     const outputDir = join(fixture.draftRoot, "2026-05-12", "rev-001");
 
-    expect(exitCode).toBe(5);
-    expect(stdout).toEqual([]);
-    expect(stderr).toEqual([
-      "Visual generation failed. Check image provider configuration."
-    ]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toEqual([`Generated text draft for 2026-05-12: ${outputDir}`]);
+    expect(stderr).toEqual([]);
     await expect(readJson(join(outputDir, "activity-summary.json"))).resolves.toMatchObject({
       targetDate: "2026-05-12"
     });
@@ -511,8 +518,51 @@ describe("generate command", () => {
     await expect(readJson(join(outputDir, "safety-report.json"))).resolves.toMatchObject({
       status: "safe"
     });
-    await expect(readFile(join(outputDir, "metadata.json"), "utf8")).rejects.toMatchObject({
-      code: "ENOENT"
+    const metadata = (await readJson(join(outputDir, "metadata.json"))) as {
+      visualAssets: unknown[];
+    };
+
+    expect(metadata).toMatchObject({
+      carouselVisualStyle: "story-card",
+      requestedCarouselVisualStyle: "photo-first"
+    });
+    expect(metadata.visualAssets[0]).toMatchObject({
+      visualStyle: "story-card",
+      fallbackState: "provider-failed",
+      filePath: "visuals/01.png"
+    });
+  });
+
+  it("keeps photo-first mode when image generation succeeds", async () => {
+    const { io, stdout, stderr } = createIo();
+    const fixture = await createRegisteredProjectFixture();
+    const imageAssetProvider = new RecordingImageAssetProvider();
+
+    await writeGitEvent(fixture.project, "2026-05-12");
+
+    const exitCode = await runCli(["generate", "today"], io, {
+      homeDir: fixture.homeDir,
+      now: () => "2026-05-12T23:30:00.000Z",
+      aiProvider: new TaskAwareProvider(),
+      imageAssetProvider
+    });
+    const outputDir = join(fixture.draftRoot, "2026-05-12", "rev-001");
+    const metadata = (await readJson(join(outputDir, "metadata.json"))) as {
+      visualAssets: unknown[];
+    };
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toEqual([]);
+    expect(stdout).toEqual([`Generated text draft for 2026-05-12: ${outputDir}`]);
+    expect(imageAssetProvider.requests[0]?.prompt).toContain("editorial photo");
+    expect(metadata).toMatchObject({
+      carouselVisualStyle: "photo-first",
+      requestedCarouselVisualStyle: "photo-first"
+    });
+    expect(metadata.visualAssets[0]).toMatchObject({
+      visualStyle: "photo-first",
+      fallbackState: "none",
+      filePath: "visuals/01.png"
     });
   });
 
@@ -604,6 +654,23 @@ class FailingImageAssetProvider implements ImageAssetProvider {
 
   async generateImageAsset(): Promise<never> {
     throw new Error("image provider unavailable");
+  }
+}
+
+class RecordingImageAssetProvider implements ImageAssetProvider {
+  readonly name = "fixture-image";
+  readonly requests: ImageAssetRequest[] = [];
+
+  async generateImageAsset(request: ImageAssetRequest) {
+    this.requests.push(request);
+
+    return {
+      mimeType: "image/png" as const,
+      data: Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+        "base64"
+      )
+    };
   }
 }
 

--- a/tests/init-command.test.ts
+++ b/tests/init-command.test.ts
@@ -15,6 +15,7 @@ describe("init command", () => {
         draftRoot,
         scheduleTime: "23:30",
         aiProvider: "openai",
+        carouselVisualStyle: "photo-first",
         persona: "dry coworker",
         roastLevel: "3"
       }
@@ -27,6 +28,7 @@ describe("init command", () => {
         draftRoot: join(homeDir, "diary-drafts"),
         scheduleTime: "23:30",
         aiProvider: "openai",
+        carouselVisualStyle: "photo-first",
         persona: "dry coworker",
         roastLevel: 3
       });
@@ -118,8 +120,14 @@ describe("init command", () => {
 
     const config = JSON.parse(
       await readFile(join(homeDir, ".uncommitted", "config.json"), "utf8")
-    ) as { aiProvider: string; persona: string; roastLevel: number };
+    ) as {
+      aiProvider: string;
+      carouselVisualStyle: string;
+      persona: string;
+      roastLevel: number;
+    };
     expect(config.aiProvider).toBe("none");
+    expect(config.carouselVisualStyle).toBe("photo-first");
     expect(config.persona).toBe(
       "project-local AI coworker writing its own off-the-record diary"
     );

--- a/tests/visual-assets.test.ts
+++ b/tests/visual-assets.test.ts
@@ -127,19 +127,20 @@ describe("visual asset generation", () => {
         schemaVersion: 1,
         slideIndex: 1,
         assetSlotId: "slide-01-visual",
+        visualStyle: "story-card",
         provider: "mock",
         filePath: "visuals/01.png",
-        fallbackState: "provider-unsupported"
+        fallbackState: "image-generation-disabled"
       },
       {
         slideIndex: 2,
         assetSlotId: "slide-02-visual",
-        fallbackState: "provider-unsupported"
+        fallbackState: "image-generation-disabled"
       },
       {
         slideIndex: 3,
         assetSlotId: "slide-03-visual",
-        fallbackState: "provider-unsupported"
+        fallbackState: "image-generation-disabled"
       }
     ]);
 
@@ -169,7 +170,8 @@ describe("visual asset generation", () => {
               "terminal near dev@example.com /Users/dev/private OPENAI_API_KEY=sk-live-secret123 `const token = process.env.SECRET`"
           }
         ]
-      })
+      }),
+      { visualStyle: "photo-first" }
     );
     const provider = new RecordingImageProvider();
 
@@ -181,7 +183,14 @@ describe("visual asset generation", () => {
     });
 
     expect(provider.requests).toHaveLength(1);
-    expect(provider.requests[0]?.prompt).toContain("4:5 editorial illustration");
+    expect(provider.requests[0]?.prompt).toContain("4:5 editorial photo");
+    expect(provider.requests[0]?.prompt).toContain("Instagram photo dump");
+    expect(provider.requests[0]?.prompt).toContain("No readable text");
+    expect(provider.requests[0]?.prompt).toContain("no code");
+    expect(provider.requests[0]?.prompt).toContain("no UI screenshots");
+    expect(provider.requests[0]?.prompt).toContain("no logos");
+    expect(provider.requests[0]?.prompt).toContain("no people faces");
+    expect(provider.requests[0]?.prompt).toContain("no private URLs");
     expect(provider.requests[0]?.prompt).toContain("[redacted-email]");
     expect(provider.requests[0]?.prompt).toContain("[redacted-path]");
     expect(provider.requests[0]?.prompt).toContain("[redacted-secret]");
@@ -194,14 +203,40 @@ describe("visual asset generation", () => {
     expect(result.assets[0]).toMatchObject({
       provider: "fixture-image",
       fallbackState: "none",
+      visualStyle: "photo-first",
       promptSummary:
         "terminal near [redacted-email] [redacted-path] [redacted-secret] [redacted-code]"
     });
   });
 
+  it("does not call hosted image providers for story-card mode", async () => {
+    const revision = await createTestRevision();
+    const cards = createCarouselHtmlCards(createStoryDraft(), {
+      visualStyle: "story-card"
+    });
+    const provider = new RecordingImageProvider();
+
+    const result = await generateCarouselVisualAssets({
+      revision,
+      cards: [cards[0]],
+      provider,
+      fallbackProviderName: "mock"
+    });
+
+    expect(provider.requests).toHaveLength(0);
+    expect(result.assets[0]).toMatchObject({
+      visualStyle: "story-card",
+      provider: "mock",
+      fallbackState: "image-generation-disabled",
+      filePath: "visuals/01.png"
+    });
+  });
+
   it("preserves existing draft artifacts when an image provider fails", async () => {
     const revision = await createTestRevision();
-    const cards = createCarouselHtmlCards(createStoryDraft());
+    const cards = createCarouselHtmlCards(createStoryDraft(), {
+      visualStyle: "photo-first"
+    });
     const preservedArtifact = join(revision.outputDir, "story.json");
 
     await mkdir(revision.outputDir, { recursive: true });


### PR DESCRIPTION
# Goal

Add explicit carousel visual style modes so Uncommitted can produce photo-first image-forward carousel drafts while preserving story-card rendering as the deterministic fallback.

## Related Issue

Closes #63.

## Acceptance Criteria

- [x] Carousel rendering has an explicit visual style mode contract.
- [x] Story-card mode remains supported without hosted image generation.
- [x] Photo-first mode treats visual assets as the primary surface and avoids large explanatory overlays.
- [x] Image generation unavailable/disabled/failure paths fall back to usable story-card output without deleting draft artifacts.
- [x] Photo-first prompts use editorial photo-dump direction and explicit privacy constraints.
- [x] Visual metadata keeps safe relative paths such as `visuals/01.png`.
- [x] Tests cover representative style-mode behavior, fallback behavior, prompt construction, renderer behavior, and privacy constraints.

## Implementation Notes

- Added `photo-first` and `story-card` style mode contracts through carousel cards, generated visual metadata, draft metadata, and `render latest`.
- Added photo-first HTML rendering that makes the generated visual asset the main surface and keeps only lightweight date, brand, and page metadata on-card.
- Updated visual asset prompts so photo-first uses editorial photo / photo-dump language and forbids readable text, code, UI screenshots, logos, faces, emails, tokens, private URLs, and local paths.
- Added `carouselVisualStyle` config support with `photo-first` as the default direction.
- Changed generation fallback so missing or failed image generation falls back to story-card placeholder assets and preserves text draft artifacts.

## Validation

- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`

## Remaining Risk

- Photo-first layout is covered by HTML/renderer tests, but this PR does not add a real visual QA screenshot fixture with full Playwright output.
