### PR TITLE
feat: add macOS scheduler plist generation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -136,6 +136,20 @@ export type {
   SafetyStatus
 } from "./safety-report.js";
 export {
+  buildLaunchAgentPlist,
+  getLaunchdLabel,
+  parseScheduleTime,
+  resolveLaunchAgentPlistPath,
+  resolveSchedulerLogPaths
+} from "./scheduler.js";
+export type {
+  LaunchAgentPlist,
+  LaunchAgentPlistOptions,
+  SchedulerLogPaths,
+  SchedulerPathOptions,
+  ScheduleTime
+} from "./scheduler.js";
+export {
   GenerateCommandError,
   runGenerateCommand
 } from "./generate-command.js";

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1,0 +1,143 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { resolveConfigPaths } from "./config-paths.js";
+
+export type SchedulerPathOptions = {
+  homeDir?: string;
+};
+
+export type ScheduleTime = {
+  hour: number;
+  minute: number;
+};
+
+export type SchedulerLogPaths = {
+  stdout: string;
+  stderr: string;
+};
+
+export type LaunchAgentPlistOptions = SchedulerPathOptions & {
+  scheduleTime: string;
+};
+
+export type LaunchAgentPlist = {
+  label: string;
+  plistPath: string;
+  stdoutLogPath: string;
+  stderrLogPath: string;
+  hour: number;
+  minute: number;
+  xml: string;
+};
+
+const launchdLabel = "com.uncommitted.schedule";
+const executableName = "uncommitted";
+const scheduleCommand = ["schedule", "run-now"] as const;
+
+export function getLaunchdLabel(): string {
+  return launchdLabel;
+}
+
+export function resolveLaunchAgentPlistPath(
+  options: SchedulerPathOptions = {}
+): string {
+  const homeDir = options.homeDir ?? homedir();
+
+  return join(homeDir, "Library", "LaunchAgents", `${launchdLabel}.plist`);
+}
+
+export function resolveSchedulerLogPaths(
+  options: SchedulerPathOptions = {}
+): SchedulerLogPaths {
+  const paths = resolveConfigPaths({ homeDir: options.homeDir });
+
+  return {
+    stdout: join(paths.logsDir, "schedule.stdout.log"),
+    stderr: join(paths.logsDir, "schedule.stderr.log")
+  };
+}
+
+export function parseScheduleTime(value: string): ScheduleTime {
+  const normalized = value.trim();
+
+  if (!/^(?:[01]\d|2[0-3]):[0-5]\d$/.test(normalized)) {
+    throw new Error("Schedule time must use 24-hour HH:mm format.");
+  }
+
+  const [hour, minute] = normalized.split(":").map(Number);
+
+  return { hour, minute };
+}
+
+export function buildLaunchAgentPlist(
+  options: LaunchAgentPlistOptions
+): LaunchAgentPlist {
+  const { hour, minute } = parseScheduleTime(options.scheduleTime);
+  const plistPath = resolveLaunchAgentPlistPath(options);
+  const logs = resolveSchedulerLogPaths(options);
+  const xml = renderLaunchAgentPlistXml({
+    label: launchdLabel,
+    programArguments: [executableName, ...scheduleCommand],
+    hour,
+    minute,
+    stdoutLogPath: logs.stdout,
+    stderrLogPath: logs.stderr
+  });
+
+  return {
+    label: launchdLabel,
+    plistPath,
+    stdoutLogPath: logs.stdout,
+    stderrLogPath: logs.stderr,
+    hour,
+    minute,
+    xml
+  };
+}
+
+function renderLaunchAgentPlistXml(options: {
+  label: string;
+  programArguments: string[];
+  hour: number;
+  minute: number;
+  stdoutLogPath: string;
+  stderrLogPath: string;
+}): string {
+  const programArgumentXml = options.programArguments
+    .map((argument) => `    <string>${escapePlistString(argument)}</string>`)
+    .join("\n");
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${escapePlistString(options.label)}</string>
+  <key>ProgramArguments</key>
+  <array>
+${programArgumentXml}
+  </array>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key>
+    <integer>${options.hour}</integer>
+    <key>Minute</key>
+    <integer>${options.minute}</integer>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>${escapePlistString(options.stdoutLogPath)}</string>
+  <key>StandardErrorPath</key>
+  <string>${escapePlistString(options.stderrLogPath)}</string>
+</dict>
+</plist>
+`;
+}
+
+function escapePlistString(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll("\"", "&quot;")
+    .replaceAll("'", "&apos;");
+}

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -1,0 +1,105 @@
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  buildLaunchAgentPlist,
+  getLaunchdLabel,
+  parseScheduleTime,
+  resolveLaunchAgentPlistPath,
+  resolveSchedulerLogPaths
+} from "../src/scheduler.js";
+
+describe("macOS scheduler plist helpers", () => {
+  it("uses stable launchd label and user LaunchAgent path conventions", () => {
+    const homeDir = "/tmp/uncommitted-scheduler-home";
+
+    expect(getLaunchdLabel()).toBe("com.uncommitted.schedule");
+    expect(resolveLaunchAgentPlistPath({ homeDir })).toBe(
+      join(homeDir, "Library", "LaunchAgents", "com.uncommitted.schedule.plist")
+    );
+  });
+
+  it("parses 24-hour HH:mm schedule times for launchd", () => {
+    expect(parseScheduleTime("00:00")).toEqual({ hour: 0, minute: 0 });
+    expect(parseScheduleTime("09:05")).toEqual({ hour: 9, minute: 5 });
+    expect(parseScheduleTime("23:59")).toEqual({ hour: 23, minute: 59 });
+  });
+
+  it("resolves stdout and stderr logs under the global config logs directory", () => {
+    const homeDir = "/tmp/uncommitted-scheduler-home";
+
+    expect(resolveSchedulerLogPaths({ homeDir })).toEqual({
+      stdout: join(homeDir, ".uncommitted", "logs", "schedule.stdout.log"),
+      stderr: join(homeDir, ".uncommitted", "logs", "schedule.stderr.log")
+    });
+  });
+
+  it("generates deterministic plist XML for daily schedule run-now execution", () => {
+    const homeDir = "/tmp/uncommitted-scheduler-home";
+
+    const plist = buildLaunchAgentPlist({
+      homeDir,
+      scheduleTime: "23:30"
+    });
+
+    expect(plist).toEqual({
+      label: "com.uncommitted.schedule",
+      plistPath: join(
+        homeDir,
+        "Library",
+        "LaunchAgents",
+        "com.uncommitted.schedule.plist"
+      ),
+      stdoutLogPath: join(
+        homeDir,
+        ".uncommitted",
+        "logs",
+        "schedule.stdout.log"
+      ),
+      stderrLogPath: join(
+        homeDir,
+        ".uncommitted",
+        "logs",
+        "schedule.stderr.log"
+      ),
+      hour: 23,
+      minute: 30,
+      xml: `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.uncommitted.schedule</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>uncommitted</string>
+    <string>schedule</string>
+    <string>run-now</string>
+  </array>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key>
+    <integer>23</integer>
+    <key>Minute</key>
+    <integer>30</integer>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>${join(homeDir, ".uncommitted", "logs", "schedule.stdout.log")}</string>
+  <key>StandardErrorPath</key>
+  <string>${join(homeDir, ".uncommitted", "logs", "schedule.stderr.log")}</string>
+</dict>
+</plist>
+`
+    });
+  });
+
+  it("rejects invalid schedule times with a short actionable error", () => {
+    for (const scheduleTime of ["", "9:30", "24:00", "23:60", "23:30:00"]) {
+      expect(() => parseScheduleTime(scheduleTime)).toThrow(
+        "Schedule time must use 24-hour HH:mm format."
+      );
+      expect(() => buildLaunchAgentPlist({ scheduleTime })).toThrow(
+        "Schedule time must use 24-hour HH:mm format."
+      );
+    }
+  });
+});


### PR DESCRIPTION
# Goal

Define the deterministic macOS launchd plist helper layer that later scheduler install/status/remove commands can reuse without mutating the user's machine.

## Related Issue

Closes #65.

## Acceptance Criteria

- [x] A scheduler module can generate a valid launchd plist for a daily `HH:mm` schedule
- [x] Generated plist uses a stable Uncommitted label and user LaunchAgent conventions
- [x] Generated plist runs `uncommitted schedule run-now`
- [x] Generated plist writes stdout and stderr to files under `~/.uncommitted/logs/`
- [x] Invalid schedule times fail with a short actionable error
- [x] Tests cover plist shape, time parsing, label/path conventions, and log path resolution

## Implementation Notes

- Adds pure scheduler helpers for launchd label, LaunchAgent plist path, log paths, HH:mm parsing, and plist XML generation.
- Exports the helper API from `src/index.ts` for later scheduler command issues.
- Does not call `launchctl` or write to real LaunchAgents directories.

## Validation

- `pnpm test -- tests/scheduler.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`

## Remaining Risk

- This PR intentionally stops at plist generation; install/load/unload/status behavior belongs to later macOS Scheduler issues.
