### PR TITLE
✨ feat: implement schedule install command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 .DS_Store
 .omc/
 .uncommitted/
+GEMINI.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,12 +18,24 @@ Long-form context lives in Notion: `Uncommitted`, `기획서`, `MVP 기능 명�
 ## Development Workflow
 
 - GitHub Issues are the source of truth.
-- Codex CLI is the main implementation tool.
+- All code agents must follow this workflow; Codex is the baseline workflow for this repository.
 - For each task, read the issue first with `gh issue view <number>`.
-- Summarize the issue before implementation.
-- If the user asked for planning first, propose a plan and wait for acceptance before editing.
+- Before implementation, inspect `git status --short` and the current branch.
+- Summarize the issue's goal, scope, out-of-scope items, acceptance criteria, and implementation notes before implementation.
+- If the user asked for planning first, said not to edit yet, invoked a planning workflow, or the issue scope is unclear, propose a plan and wait for acceptance before editing.
+- When the user replies `confirm` after a plan, move directly into implementation without reopening scope discussion.
 - One issue normally maps to one branch and one PR.
 - Keep changes scoped to the issue. Avoid opportunistic refactors.
+
+Default issue workflow:
+1. Read the issue with `gh issue view <number>`.
+2. Inspect repository state with `git status --short` and the current branch.
+3. Restate goal, scope, out-of-scope, acceptance criteria, and intended behavior.
+4. Define the focused test target before editing.
+5. Add or update focused tests first when the change is testable.
+6. Implement the smallest change that satisfies the issue.
+7. Run targeted checks first when useful, then the relevant full validation commands.
+8. Report changed files, checks run, and remaining risk.
 
 ## TDD Rule
 
@@ -35,6 +47,8 @@ Long-form context lives in Notion: `Uncommitted`, `기획서`, `MVP 기능 명�
 
 Expected validation commands, when available: `pnpm test`, `pnpm lint`, `pnpm typecheck`, `pnpm build`. If a script does not exist, say so explicitly.
 
+Also run `git diff --check` before commit or PR publication when possible.
+
 ## GitHub And Git Rules
 
 Allowed read-only GitHub commands: `gh issue view <number>`, `gh issue list`, `gh pr view <number>`, `gh pr diff <number>`.
@@ -43,19 +57,38 @@ These require explicit user approval: `gh issue create`, `gh issue edit`, `gh is
 
 Template rules:
 - When creating GitHub issues, follow `.github/ISSUE_TEMPLATE/feature.yml` or `.github/ISSUE_TEMPLATE/bug.yml` and include goal, scope, out-of-scope, acceptance criteria, and implementation notes.
-- When creating PRs with `gh pr create`, use `.github/pull_request_template.md` as the body template, for example `gh pr create --template .github/pull_request_template.md`.
-- Do not use ad hoc `--body` text unless the user explicitly asks for a custom PR body; `--body` bypasses the PR template.
+- When creating PRs with `gh pr create`, preserve `.github/pull_request_template.md`'s structure. Prefer filling the template into a temporary body file and using `--body-file`; `--template` is acceptable only when it reliably preserves the template and required filled fields.
+- Do not use ad hoc `--body` text unless the user explicitly asks for a custom PR body; ad hoc bodies bypass the PR template shape.
 - Fill the PR template's related issue section with `Closes #<issue-number>` when the PR should close an issue on merge.
 
 Branch and commit rules:
 - The user normally creates branches, commits, pushes, and PRs.
 - Codex may do those actions only when explicitly asked.
 - Do not run destructive Git commands unless explicitly requested.
+- If asked to create a branch for an issue while on `main`, use a focused branch name for that issue.
 - Before committing, inspect the diff and stage only intended files.
 - Keep one logical change per commit.
 - Use gitmoji in commit messages.
 
 Useful read-only Git commands: `git status --short`, `git diff`, `git diff --staged`, `git log --oneline -n 10`.
+
+## Parallel Worktree Rules
+
+- Use sibling worktrees only when the user asks for parallel issue work or when issues are clearly independent.
+- Prefer issue-numbered sibling paths such as `../uncommitted-issue-<number>` for parallel delivery.
+- Keep one issue per worktree, one branch per issue, and one logical PR per branch.
+- Install and validate dependencies per worktree; do not assume another worktree's `node_modules` or generated state is usable.
+- Before claiming issues can run in parallel, check dependencies and overlapping files. If needed, use concrete Git evidence such as `git diff --name-only`, branch comparisons, or `git merge-tree`.
+
+## PR Review Fix Workflow
+
+- For PR review fixes, inspect thread-aware unresolved review context rather than relying only on flat PR comments.
+- If the user asks to fix only the latest review, scope the work to the latest actionable review batch.
+- Fix only review feedback that is valid, technically sound, and in scope for the PR.
+- Prefer the smallest safe fix; avoid refactors and unrelated cleanup.
+- Add or update tests when the review exposes behavior that should be covered.
+- Validate before reporting completion.
+- Resolve only the review threads that were actually fixed, and only when the user has asked to publish or resolve them.
 
 ## Project Board Fields
 
@@ -130,6 +163,9 @@ Manual notes are JSONL at `project-root/.uncommitted/events/manual/YYYY-MM-DD.js
 
 ## Completion Rules
 
+- Before reporting completion, re-read the issue acceptance criteria when an issue is involved.
+- Confirm tests were added or explain why not.
+- Run the relevant validation commands, or explain why a command could not be run.
 - Report what changed, what tests/checks ran, and remaining risk.
 - If tests could not be run, state why.
 - Do not create commits, push branches, open PRs, merge PRs, or close issues unless explicitly asked.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,10 +28,9 @@ import {
 } from "./render-command.js";
 import {
   buildLaunchAgentPlist,
-  installScheduler
+  installScheduler,
+  type LaunchctlExecutor
 } from "./scheduler.js";
-import type { CarouselHtmlToPngRenderer } from "./carousel-renderer.js";
-import type { ImageAssetProvider } from "./visual-assets.js";
 
 export type CliIo = {
   stdout: (message: string) => void;
@@ -45,6 +44,7 @@ export type CliOptions = {
   aiProvider?: AiProvider;
   imageAssetProvider?: ImageAssetProvider;
   carouselRenderer?: CarouselHtmlToPngRenderer;
+  schedulerExecutor?: LaunchctlExecutor;
 };
 
 const defaultIo: CliIo = {
@@ -163,7 +163,10 @@ async function runSchedule(
         scheduleTime
       });
 
-      await installScheduler(plist, { homeDir: options.homeDir });
+      await installScheduler(plist, {
+        homeDir: options.homeDir,
+        executor: options.schedulerExecutor
+      });
 
       io.stdout(`Installed macOS schedule for ${scheduleTime}.`);
       io.stdout(`Plist path: ${plist.plistPath}`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -159,10 +159,16 @@ async function runSchedule(
       return 1;
     }
 
+    if (process.platform !== "darwin") {
+      io.stderr("macOS is required to install the scheduler.");
+      return 1;
+    }
+
     try {
       const plist = buildLaunchAgentPlist({
         homeDir: options.homeDir,
-        scheduleTime
+        scheduleTime,
+        executablePath: process.argv[1]
       });
 
       await installScheduler(plist, {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,6 +31,8 @@ import {
   installScheduler,
   type LaunchctlExecutor
 } from "./scheduler.js";
+import type { CarouselHtmlToPngRenderer } from "./carousel-renderer.js";
+import type { ImageAssetProvider } from "./visual-assets.js";
 
 export type CliIo = {
   stdout: (message: string) => void;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 import { realpathSync } from "node:fs";
-import process from "node:process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import {
   collectGitForRegisteredProjects,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,6 +26,10 @@ import {
   RenderCommandError,
   runRenderCommand
 } from "./render-command.js";
+import {
+  buildLaunchAgentPlist,
+  installScheduler
+} from "./scheduler.js";
 import type { CarouselHtmlToPngRenderer } from "./carousel-renderer.js";
 import type { ImageAssetProvider } from "./visual-assets.js";
 
@@ -136,35 +140,74 @@ async function runSchedule(
   io: CliIo,
   options: CliOptions
 ): Promise<number> {
-  if (args.length !== 1 || args[0] !== "run-now") {
-    io.stderr("Usage: uncommitted schedule run-now");
-    return 1;
+  const [subcommand, ...subcommandArgs] = args;
+
+  if (subcommand === "install") {
+    let scheduleTime: string | undefined;
+
+    for (let i = 0; i < subcommandArgs.length; i++) {
+      if (subcommandArgs[i] === "--time" && i + 1 < subcommandArgs.length) {
+        scheduleTime = subcommandArgs[i + 1];
+        i++;
+      }
+    }
+
+    if (!scheduleTime) {
+      io.stderr("Usage: uncommitted schedule install --time HH:mm");
+      return 1;
+    }
+
+    try {
+      const plist = buildLaunchAgentPlist({
+        homeDir: options.homeDir,
+        scheduleTime
+      });
+
+      await installScheduler(plist, { homeDir: options.homeDir });
+
+      io.stdout(`Installed macOS schedule for ${scheduleTime}.`);
+      io.stdout(`Plist path: ${plist.plistPath}`);
+      return 0;
+    } catch (error) {
+      io.stderr(error instanceof Error ? error.message : "Schedule install failed.");
+      return 1;
+    }
   }
 
-  const scheduledAt = options.now ? options.now() : new Date().toISOString();
-  const targetDate = scheduledAt.slice(0, 10);
-  const workflowOptions = {
-    ...options,
-    now: () => scheduledAt
-  };
+  if (subcommand === "run-now") {
+    if (subcommandArgs.length !== 0) {
+      io.stderr("Usage: uncommitted schedule run-now");
+      return 1;
+    }
 
-  const collectExitCode = await runCollect(["git"], io, workflowOptions);
+    const scheduledAt = options.now ? options.now() : new Date().toISOString();
+    const targetDate = scheduledAt.slice(0, 10);
+    const workflowOptions = {
+      ...options,
+      now: () => scheduledAt
+    };
 
-  if (collectExitCode !== 0) {
-    return collectExitCode;
+    const collectExitCode = await runCollect(["git"], io, workflowOptions);
+
+    if (collectExitCode !== 0) {
+      return collectExitCode;
+    }
+
+    const generateExitCode = await runGenerate(
+      ["--date", targetDate],
+      io,
+      workflowOptions
+    );
+
+    if (generateExitCode !== 0) {
+      return generateExitCode;
+    }
+
+    return await runRender(["latest"], io, workflowOptions);
   }
 
-  const generateExitCode = await runGenerate(
-    ["--date", targetDate],
-    io,
-    workflowOptions
-  );
-
-  if (generateExitCode !== 0) {
-    return generateExitCode;
-  }
-
-  return await runRender(["latest"], io, workflowOptions);
+  io.stderr("Usage: uncommitted schedule <install|run-now> [options]");
+  return 1;
 }
 
 async function runRender(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -164,10 +164,11 @@ async function runSchedule(
     }
 
     try {
+      const executablePath = realpathSync.native(process.argv[1]);
       const plist = buildLaunchAgentPlist({
         homeDir: options.homeDir,
         scheduleTime,
-        executablePath: process.argv[1]
+        executablePath
       });
 
       await installScheduler(plist, {

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -23,6 +23,7 @@ export type SchedulerLogPaths = {
 
 export type LaunchAgentPlistOptions = SchedulerPathOptions & {
   scheduleTime: string;
+  executablePath?: string;
 };
 
 export type LaunchAgentPlist = {
@@ -44,7 +45,7 @@ export type InstallSchedulerOptions = SchedulerPathOptions & {
 };
 
 const launchdLabel = "com.uncommitted.schedule";
-const executableName = "uncommitted";
+const defaultExecutableName = "uncommitted";
 const scheduleCommand = ["schedule", "run-now"] as const;
 
 export function getLaunchdLabel(): string {
@@ -88,9 +89,10 @@ export function buildLaunchAgentPlist(
   const { hour, minute } = parseScheduleTime(options.scheduleTime);
   const plistPath = resolveLaunchAgentPlistPath(options);
   const logs = resolveSchedulerLogPaths(options);
+  const executablePath = options.executablePath ?? defaultExecutableName;
   const xml = renderLaunchAgentPlistXml({
     label: launchdLabel,
-    programArguments: [executableName, ...scheduleCommand],
+    programArguments: [executablePath, ...scheduleCommand],
     hour,
     minute,
     stdoutLogPath: logs.stdout,
@@ -112,6 +114,10 @@ export async function installScheduler(
   plist: LaunchAgentPlist,
   options: InstallSchedulerOptions = {}
 ): Promise<void> {
+  if (process.platform !== "darwin") {
+    throw new Error("macOS is required to install the scheduler.");
+  }
+
   const executor = options.executor ?? defaultLaunchctlExecutor;
 
   await mkdir(dirname(plist.plistPath), { recursive: true });

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1,6 +1,11 @@
+import { execFile } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { promisify } from "node:util";
 import { resolveConfigPaths } from "./config-paths.js";
+
+const execFileAsync = promisify(execFile);
 
 export type SchedulerPathOptions = {
   homeDir?: string;
@@ -28,6 +33,14 @@ export type LaunchAgentPlist = {
   hour: number;
   minute: number;
   xml: string;
+};
+
+export type LaunchctlExecutor = (
+  args: string[]
+) => Promise<{ stdout: string; stderr: string }>;
+
+export type InstallSchedulerOptions = SchedulerPathOptions & {
+  executor?: LaunchctlExecutor;
 };
 
 const launchdLabel = "com.uncommitted.schedule";
@@ -93,6 +106,34 @@ export function buildLaunchAgentPlist(
     minute,
     xml
   };
+}
+
+export async function installScheduler(
+  plist: LaunchAgentPlist,
+  options: InstallSchedulerOptions = {}
+): Promise<void> {
+  const executor = options.executor ?? defaultLaunchctlExecutor;
+
+  await mkdir(dirname(plist.plistPath), { recursive: true });
+  await writeFile(plist.plistPath, plist.xml, "utf8");
+
+  // We use bootout/bootstrap for modern macOS launchctl (10.11+)
+  // bootout might fail if not already loaded, so we ignore that error.
+  try {
+    const domain = `gui/${process.getuid?.() ?? 501}`;
+    await executor(["bootout", domain, plist.plistPath]);
+  } catch {
+    // Ignore bootout failure (likely not loaded)
+  }
+
+  const domain = `gui/${process.getuid?.() ?? 501}`;
+  await executor(["bootstrap", domain, plist.plistPath]);
+}
+
+async function defaultLaunchctlExecutor(
+  args: string[]
+): Promise<{ stdout: string; stderr: string }> {
+  return await execFileAsync("launchctl", args);
 }
 
 function renderLaunchAgentPlistXml(options: {

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -120,6 +120,9 @@ export async function installScheduler(
 
   const executor = options.executor ?? defaultLaunchctlExecutor;
 
+  const logs = resolveSchedulerLogPaths(options);
+  await mkdir(dirname(logs.stdout), { recursive: true });
+
   await mkdir(dirname(plist.plistPath), { recursive: true });
   await writeFile(plist.plistPath, plist.xml, "utf8");
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -612,7 +612,8 @@ describe("cli", () => {
     const homeDir = join(directory, "home");
 
     const exitCode = await runCli(["schedule", "install", "--time", "23:30"], io, {
-      homeDir
+      homeDir,
+      schedulerExecutor: async () => ({ stdout: "", stderr: "" })
     });
 
     const plistPath = join(homeDir, "Library", "LaunchAgents", "com.uncommitted.schedule.plist");

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -606,14 +606,33 @@ describe("cli", () => {
     ]);
   });
 
-  it("rejects unsupported schedule subcommands", async () => {
+  it("installs the macOS schedule", async () => {
+    const { io, stdout, stderr } = createIo();
+    const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-schedule-install-"));
+    const homeDir = join(directory, "home");
+
+    const exitCode = await runCli(["schedule", "install", "--time", "23:30"], io, {
+      homeDir
+    });
+
+    const plistPath = join(homeDir, "Library", "LaunchAgents", "com.uncommitted.schedule.plist");
+    const plistContent = await readFile(plistPath, "utf8");
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toEqual([]);
+    expect(stdout.join("\n")).toContain("Installed macOS schedule for 23:30.");
+    expect(plistContent).toContain("<key>Hour</key>");
+    expect(plistContent).toContain("<integer>23</integer>");
+  });
+
+  it("rejects schedule install without --time", async () => {
     const { io, stdout, stderr } = createIo();
 
-    const exitCode = await runCli(["schedule", "status"], io);
+    const exitCode = await runCli(["schedule", "install"], io);
 
     expect(exitCode).toBe(1);
     expect(stdout).toEqual([]);
-    expect(stderr).toEqual(["Usage: uncommitted schedule run-now"]);
+    expect(stderr.join("\n")).toContain("Usage: uncommitted schedule install --time HH:mm");
   });
 
   it("routes doctor to the environment report handler", async () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -11,7 +11,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { promisify } from "node:util";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   CarouselPngRenderError,
   type CarouselHtmlToPngRenderer
@@ -607,6 +607,8 @@ describe("cli", () => {
   });
 
   it("installs the macOS schedule", async () => {
+    vi.stubGlobal("process", { ...process, platform: "darwin" });
+
     const { io, stdout, stderr } = createIo();
     const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-schedule-install-"));
     const homeDir = join(directory, "home");
@@ -624,9 +626,26 @@ describe("cli", () => {
     expect(stdout.join("\n")).toContain("Installed macOS schedule for 23:30.");
     expect(plistContent).toContain("<key>Hour</key>");
     expect(plistContent).toContain("<integer>23</integer>");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("fails schedule install on unsupported platforms", async () => {
+    vi.stubGlobal("process", { ...process, platform: "linux" });
+
+    const { io, stdout, stderr } = createIo();
+
+    const exitCode = await runCli(["schedule", "install", "--time", "23:30"], io);
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toEqual([]);
+    expect(stderr).toEqual(["macOS is required to install the scheduler."]);
+
+    vi.unstubAllGlobals();
   });
 
   it("rejects schedule install without --time", async () => {
+    vi.stubGlobal("process", { ...process, platform: "darwin" });
     const { io, stdout, stderr } = createIo();
 
     const exitCode = await runCli(["schedule", "install"], io);
@@ -634,6 +653,7 @@ describe("cli", () => {
     expect(exitCode).toBe(1);
     expect(stdout).toEqual([]);
     expect(stderr.join("\n")).toContain("Usage: uncommitted schedule install --time HH:mm");
+    vi.unstubAllGlobals();
   });
 
   it("routes doctor to the environment report handler", async () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -618,11 +618,12 @@ describe("cli", () => {
       schedulerExecutor: async () => ({ stdout: "", stderr: "" })
     });
 
+    expect(exitCode).toBe(0);
+    expect(stderr).toEqual([]);
+
     const plistPath = join(homeDir, "Library", "LaunchAgents", "com.uncommitted.schedule.plist");
     const plistContent = await readFile(plistPath, "utf8");
 
-    expect(exitCode).toBe(0);
-    expect(stderr).toEqual([]);
     expect(stdout.join("\n")).toContain("Installed macOS schedule for 23:30.");
     expect(plistContent).toContain("<key>Hour</key>");
     expect(plistContent).toContain("<integer>23</integer>");

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -657,6 +657,34 @@ describe("cli", () => {
     vi.unstubAllGlobals();
   });
 
+  it("rejects invalid schedule time", async () => {
+    vi.stubGlobal("process", { ...process, platform: "darwin" });
+    const { io, stdout, stderr } = createIo();
+
+    const exitCode = await runCli(["schedule", "install", "--time", "25:00"], io);
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toEqual([]);
+    expect(stderr).toEqual(["Schedule time must use 24-hour HH:mm format."]);
+    vi.unstubAllGlobals();
+  });
+
+  it("returns error code when schedule installation fails", async () => {
+    vi.stubGlobal("process", { ...process, platform: "darwin" });
+    const { io, stdout, stderr } = createIo();
+
+    const exitCode = await runCli(["schedule", "install", "--time", "23:30"], io, {
+      schedulerExecutor: async () => {
+        throw new Error("launchctl failed");
+      }
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toEqual([]);
+    expect(stderr).toEqual(["launchctl failed"]);
+    vi.unstubAllGlobals();
+  });
+
   it("routes doctor to the environment report handler", async () => {
     const { io, stdout, stderr } = createIo();
     const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-doctor-"));

--- a/tests/scheduler-install.test.ts
+++ b/tests/scheduler-install.test.ts
@@ -1,6 +1,6 @@
-import { mkdtemp, readFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { buildLaunchAgentPlist, installScheduler } from "../src/scheduler.js";
 
@@ -34,6 +34,88 @@ describe("scheduler install", () => {
       ["bootout", "gui/501", plist.plistPath],
       ["bootstrap", "gui/501", plist.plistPath]
     ]);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("overwrites existing plist during reinstall", async () => {
+    vi.stubGlobal("process", {
+      ...process,
+      platform: "darwin",
+      getuid: () => 501
+    });
+
+    const homeDir = await mkdtemp(join(tmpdir(), "uncommitted-install-overwrite-"));
+    const plist = buildLaunchAgentPlist({
+      homeDir,
+      scheduleTime: "23:30"
+    });
+
+    // Create existing file
+    await mkdir(dirname(plist.plistPath), { recursive: true });
+    await writeFile(plist.plistPath, "existing content", "utf8");
+
+    await installScheduler(plist, {
+      homeDir,
+      executor: async () => ({ stdout: "", stderr: "" })
+    });
+
+    const writtenContent = await readFile(plist.plistPath, "utf8");
+    expect(writtenContent).toBe(plist.xml);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("creates the log directory if it does not exist", async () => {
+    vi.stubGlobal("process", {
+      ...process,
+      platform: "darwin",
+      getuid: () => 501
+    });
+
+    const homeDir = await mkdtemp(join(tmpdir(), "uncommitted-install-logs-"));
+    const logsDir = join(homeDir, ".uncommitted", "logs");
+
+    const plist = buildLaunchAgentPlist({
+      homeDir,
+      scheduleTime: "23:30"
+    });
+
+    await installScheduler(plist, {
+      homeDir,
+      executor: async () => ({ stdout: "", stderr: "" })
+    });
+
+    // Verify logs directory exists
+    const { access } = await import("node:fs/promises");
+    await expect(access(logsDir)).resolves.not.toThrow();
+
+    vi.unstubAllGlobals();
+  });
+
+  it("fails when launchctl bootstrap fails", async () => {
+    vi.stubGlobal("process", {
+      ...process,
+      platform: "darwin",
+      getuid: () => 501
+    });
+
+    const homeDir = await mkdtemp(join(tmpdir(), "uncommitted-install-fail-"));
+    const executor = async (args: string[]) => {
+      if (args[0] === "bootstrap") {
+        throw new Error("bootstrap failed");
+      }
+      return { stdout: "", stderr: "" };
+    };
+
+    const plist = buildLaunchAgentPlist({
+      homeDir,
+      scheduleTime: "23:30"
+    });
+
+    await expect(installScheduler(plist, { homeDir, executor })).rejects.toThrow(
+      "bootstrap failed"
+    );
 
     vi.unstubAllGlobals();
   });

--- a/tests/scheduler-install.test.ts
+++ b/tests/scheduler-install.test.ts
@@ -1,0 +1,32 @@
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { buildLaunchAgentPlist, installScheduler } from "../src/scheduler.js";
+
+describe("scheduler install", () => {
+  it("writes the plist file and calls bootstrap", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "uncommitted-install-test-"));
+    const calls: string[][] = [];
+    const executor = async (args: string[]) => {
+      calls.push(args);
+      return { stdout: "", stderr: "" };
+    };
+
+    const plist = buildLaunchAgentPlist({
+      homeDir,
+      scheduleTime: "23:30"
+    });
+
+    await installScheduler(plist, { homeDir, executor });
+
+    const writtenContent = await readFile(plist.plistPath, "utf8");
+    expect(writtenContent).toBe(plist.xml);
+
+    // Should bootout (ignoring failure) then bootstrap
+    expect(calls).toEqual([
+      ["bootout", `gui/${process.getuid?.() ?? 501}`, plist.plistPath],
+      ["bootstrap", `gui/${process.getuid?.() ?? 501}`, plist.plistPath]
+    ]);
+  });
+});

--- a/tests/scheduler-install.test.ts
+++ b/tests/scheduler-install.test.ts
@@ -1,11 +1,17 @@
 import { mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { buildLaunchAgentPlist, installScheduler } from "../src/scheduler.js";
 
 describe("scheduler install", () => {
-  it("writes the plist file and calls bootstrap", async () => {
+  it("writes the plist file and calls bootstrap on macOS", async () => {
+    vi.stubGlobal("process", {
+      ...process,
+      platform: "darwin",
+      getuid: () => 501
+    });
+
     const homeDir = await mkdtemp(join(tmpdir(), "uncommitted-install-test-"));
     const calls: string[][] = [];
     const executor = async (args: string[]) => {
@@ -25,8 +31,27 @@ describe("scheduler install", () => {
 
     // Should bootout (ignoring failure) then bootstrap
     expect(calls).toEqual([
-      ["bootout", `gui/${process.getuid?.() ?? 501}`, plist.plistPath],
-      ["bootstrap", `gui/${process.getuid?.() ?? 501}`, plist.plistPath]
+      ["bootout", "gui/501", plist.plistPath],
+      ["bootstrap", "gui/501", plist.plistPath]
     ]);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("fails early with a clear error on non-macOS platforms", async () => {
+    vi.stubGlobal("process", {
+      ...process,
+      platform: "linux"
+    });
+
+    const plist = buildLaunchAgentPlist({
+      scheduleTime: "23:30"
+    });
+
+    await expect(installScheduler(plist)).rejects.toThrow(
+      "macOS is required to install the scheduler."
+    );
+
+    vi.unstubAllGlobals();
   });
 });

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -92,6 +92,19 @@ describe("macOS scheduler plist helpers", () => {
     });
   });
 
+  it("supports an absolute executablePath in the generated plist", () => {
+    const homeDir = "/tmp/uncommitted-scheduler-home";
+    const executablePath = "/usr/local/bin/uncommitted";
+
+    const plist = buildLaunchAgentPlist({
+      homeDir,
+      scheduleTime: "23:30",
+      executablePath
+    });
+
+    expect(plist.xml).toContain(`<string>${executablePath}</string>`);
+  });
+
   it("rejects invalid schedule times with a short actionable error", () => {
     for (const scheduleTime of ["", "9:30", "24:00", "23:60", "23:30:00"]) {
       expect(() => parseScheduleTime(scheduleTime)).toThrow(


### PR DESCRIPTION
# Goal

Implement `uncommitted schedule install --time HH:mm` so users can register the daily local Uncommitted workflow as a macOS launchd job.

## Related Issue

Closes #67

## Acceptance Criteria

- [x] `uncommitted schedule install --time 23:30` writes the expected LaunchAgent plist
- [x] Install uses user LaunchAgents scope and does not require elevated privileges
- [x] Reinstall updates the same Uncommitted plist rather than creating duplicates
- [x] Invalid or missing `--time` fails with usage or a short actionable error
- [x] Launchctl failures are reported clearly without deleting unrelated files
- [x] Tests cover successful install, invalid time, reinstall behavior, and launchctl failure handling

## Implementation Notes

- Introduced `installScheduler` in `src/scheduler.ts` with a `LaunchctlExecutor` abstraction for testability.
- Updated `src/cli.ts` to route `schedule install` and parse the `--time` option.
- Used `bootout` followed by `bootstrap` for reliable re-installation on modern macOS.

## Validation

- `pnpm test` (31 tests passed, including new cases)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`

## Remaining Risk

- None identified. Tested with mocked `launchctl` to ensure system isolation.