### PR TITLE
feat: implement project list and remove commands

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,12 @@ import {
 } from "./note-command.js";
 import { addProject, ProjectAddError } from "./project-add.js";
 import {
+  listProjects,
+  ProjectRegistryError,
+  removeProject,
+  type ProjectRecord
+} from "./project-registry.js";
+import {
   RenderCommandError,
   runRenderCommand
 } from "./render-command.js";
@@ -110,6 +116,14 @@ export async function runCli(
 
   if (command === "project" && subcommand === "add") {
     return await runProjectAdd(value, io, options);
+  }
+
+  if (command === "project" && subcommand === "list") {
+    return await runProjectList(commandArgs.slice(1), io, options);
+  }
+
+  if (command === "project" && subcommand === "remove") {
+    return await runProjectRemove(value, commandArgs.slice(2), io, options);
   }
 
   if (command === "note") {
@@ -433,6 +447,80 @@ async function runProjectAdd(
 
     throw error;
   }
+}
+
+async function runProjectList(
+  args: string[],
+  io: CliIo,
+  options: CliOptions
+): Promise<number> {
+  if (args.length !== 0) {
+    io.stderr("Usage: uncommitted project list");
+    return 1;
+  }
+
+  try {
+    const result = await listProjects(options);
+
+    if (result.projects.length === 0) {
+      io.stdout("No registered projects. Run `uncommitted project add .` first.");
+      return 0;
+    }
+
+    io.stdout("Registered projects:");
+
+    for (const project of result.projects) {
+      io.stdout(formatProject(project));
+    }
+
+    return 0;
+  } catch (error) {
+    if (error instanceof ProjectRegistryError) {
+      io.stderr(error.message);
+      return 2;
+    }
+
+    throw error;
+  }
+}
+
+async function runProjectRemove(
+  projectId: string | undefined,
+  extraArgs: string[],
+  io: CliIo,
+  options: CliOptions
+): Promise<number> {
+  if (!projectId || extraArgs.length !== 0) {
+    io.stderr("Usage: uncommitted project remove <project-id>");
+    return 1;
+  }
+
+  try {
+    const result = await removeProject(projectId, options);
+
+    io.stdout(`Project removed: ${result.removedProject.id}`);
+    io.stdout(result.removedProject.root);
+    return 0;
+  } catch (error) {
+    if (error instanceof ProjectRegistryError) {
+      io.stderr(error.message);
+      return 2;
+    }
+
+    throw error;
+  }
+}
+
+function formatProject(project: ProjectRecord): string {
+  const status = project.enabled ? "enabled" : "disabled";
+
+  return [
+    project.id,
+    project.name,
+    project.gitRoot,
+    status,
+    project.createdAt
+  ].join("\t");
 }
 
 export function isDirectRun(

--- a/src/collect-git-command.ts
+++ b/src/collect-git-command.ts
@@ -6,7 +6,7 @@ import {
   type GitActivity
 } from "./git-activity-collector.js";
 import { resolveConfigPaths } from "./config-paths.js";
-import type { ProjectRecord, ProjectsFile } from "./project-add.js";
+import type { ProjectRecord, ProjectsFile } from "./project-registry.js";
 
 export type CollectGitCommandErrorCode =
   | "invalid-projects-file"

--- a/src/index.ts
+++ b/src/index.ts
@@ -211,10 +211,21 @@ export { addProject, ProjectAddError } from "./project-add.js";
 export type {
   AddProjectOptions,
   AddProjectResult,
-  ProjectAddErrorCode,
-  ProjectRecord,
-  ProjectsFile
+  ProjectAddErrorCode
 } from "./project-add.js";
+export {
+  listProjects,
+  ProjectRegistryError,
+  removeProject
+} from "./project-registry.js";
+export type {
+  ListProjectsResult,
+  ProjectRecord,
+  ProjectRegistryErrorCode,
+  ProjectRegistryOptions,
+  ProjectsFile,
+  RemoveProjectResult
+} from "./project-registry.js";
 export {
   listManualNotes,
   NoteCommandError,

--- a/src/project-add.ts
+++ b/src/project-add.ts
@@ -1,10 +1,19 @@
 import { execFile } from "node:child_process";
 import { constants } from "node:fs";
-import { access, mkdir, readFile, realpath, writeFile } from "node:fs/promises";
+import { access, mkdir, realpath, writeFile } from "node:fs/promises";
 import { basename, join, resolve } from "node:path";
 import process from "node:process";
 import { promisify } from "node:util";
 import { resolveConfigPaths } from "./config-paths.js";
+import {
+  ProjectRegistryError,
+  readProjectsFile,
+  writeProjectsFile,
+  type ProjectRecord,
+  type ProjectsFile
+} from "./project-registry.js";
+
+export type { ProjectRecord, ProjectsFile } from "./project-registry.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -23,21 +32,6 @@ export class ProjectAddError extends Error {
     this.name = "ProjectAddError";
   }
 }
-
-export type ProjectRecord = {
-  schemaVersion: 1;
-  id: string;
-  name: string;
-  root: string;
-  gitRoot: string;
-  enabled: boolean;
-  createdAt: string;
-};
-
-export type ProjectsFile = {
-  schemaVersion: 1;
-  projects: ProjectRecord[];
-};
 
 export type AddProjectOptions = {
   cwd?: string;
@@ -61,7 +55,7 @@ export async function addProject(
   const existingInput = await resolveExistingPath(resolvedInput);
   const gitRoot = await findGitRoot(existingInput);
   const paths = resolveConfigPaths({ homeDir: options.homeDir });
-  const projectsFile = await readProjectsFile(paths.projectsFile);
+  const projectsFile = await readProjectsFileForAdd(paths.projectsFile);
   const existingProject = projectsFile.projects.find(
     (project) => project.gitRoot === gitRoot
   );
@@ -98,7 +92,7 @@ export async function addProject(
   await mkdir(join(gitRoot, ".uncommitted"), { recursive: true });
   await mkdir(paths.configDir, { recursive: true });
   await writeJson(projectFile, project);
-  await writeJson(paths.projectsFile, nextProjectsFile);
+  await writeProjectsFile(paths.projectsFile, nextProjectsFile);
 
   return {
     status: "added",
@@ -148,31 +142,15 @@ async function findGitRoot(path: string): Promise<string> {
   }
 }
 
-async function readProjectsFile(path: string): Promise<ProjectsFile> {
+async function readProjectsFileForAdd(path: string): Promise<ProjectsFile> {
   try {
-    const parsed = JSON.parse(await readFile(path, "utf8")) as unknown;
-
-    if (isProjectsFile(parsed)) {
-      return parsed;
-    }
-
-    throw new ProjectAddError(
-      `Invalid projects file: ${path}`,
-      "invalid-projects-file"
-    );
+    return await readProjectsFile(path, { missingAsEmpty: true });
   } catch (error) {
-    if (error instanceof ProjectAddError) {
-      throw error;
+    if (error instanceof ProjectRegistryError) {
+      throw new ProjectAddError(error.message, "invalid-projects-file");
     }
 
-    if (isNodeError(error) && error.code === "ENOENT") {
-      return { schemaVersion: 1, projects: [] };
-    }
-
-    throw new ProjectAddError(
-      `Invalid projects file: ${path}`,
-      "invalid-projects-file"
-    );
+    throw error;
   }
 }
 
@@ -196,33 +174,4 @@ function slugProjectId(name: string): string {
     .replace(/^-+|-+$/g, "");
 
   return slug || "project";
-}
-
-function isProjectsFile(value: unknown): value is ProjectsFile {
-  if (!isRecord(value) || value.schemaVersion !== 1 || !Array.isArray(value.projects)) {
-    return false;
-  }
-
-  return value.projects.every(isProjectRecord);
-}
-
-function isProjectRecord(value: unknown): value is ProjectRecord {
-  return (
-    isRecord(value) &&
-    value.schemaVersion === 1 &&
-    typeof value.id === "string" &&
-    typeof value.name === "string" &&
-    typeof value.root === "string" &&
-    typeof value.gitRoot === "string" &&
-    typeof value.enabled === "boolean" &&
-    typeof value.createdAt === "string"
-  );
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-function isNodeError(error: unknown): error is NodeJS.ErrnoException {
-  return error instanceof Error && "code" in error;
 }

--- a/src/project-registry.ts
+++ b/src/project-registry.ts
@@ -1,0 +1,174 @@
+import { constants } from "node:fs";
+import { access, readFile, writeFile } from "node:fs/promises";
+import { resolveConfigPaths } from "./config-paths.js";
+
+export type ProjectRecord = {
+  schemaVersion: 1;
+  id: string;
+  name: string;
+  root: string;
+  gitRoot: string;
+  enabled: boolean;
+  createdAt: string;
+};
+
+export type ProjectsFile = {
+  schemaVersion: 1;
+  projects: ProjectRecord[];
+};
+
+export type ProjectRegistryErrorCode =
+  | "missing-config"
+  | "invalid-projects-file"
+  | "unknown-project";
+
+export class ProjectRegistryError extends Error {
+  constructor(
+    message: string,
+    public readonly code: ProjectRegistryErrorCode
+  ) {
+    super(message);
+    this.name = "ProjectRegistryError";
+  }
+}
+
+export type ProjectRegistryOptions = {
+  homeDir?: string;
+};
+
+export type ListProjectsResult = {
+  projects: ProjectRecord[];
+  projectsFile: string;
+};
+
+export type RemoveProjectResult = {
+  removedProject: ProjectRecord;
+  projectsFile: string;
+};
+
+export async function listProjects(
+  options: ProjectRegistryOptions = {}
+): Promise<ListProjectsResult> {
+  const paths = resolveConfigPaths({ homeDir: options.homeDir });
+
+  await ensureInitialized(paths.configFile);
+
+  return {
+    projects: (await readProjectsFile(paths.projectsFile)).projects,
+    projectsFile: paths.projectsFile
+  };
+}
+
+export async function removeProject(
+  projectId: string,
+  options: ProjectRegistryOptions = {}
+): Promise<RemoveProjectResult> {
+  const paths = resolveConfigPaths({ homeDir: options.homeDir });
+
+  await ensureInitialized(paths.configFile);
+
+  const projectsFile = await readProjectsFile(paths.projectsFile);
+  const removedProject = projectsFile.projects.find(
+    (project) => project.id === projectId
+  );
+
+  if (!removedProject) {
+    throw new ProjectRegistryError(
+      `Unknown project id: ${projectId}. Run \`uncommitted project list\`.`,
+      "unknown-project"
+    );
+  }
+
+  await writeProjectsFile(paths.projectsFile, {
+    schemaVersion: 1,
+    projects: projectsFile.projects.filter((project) => project.id !== projectId)
+  });
+
+  return {
+    removedProject,
+    projectsFile: paths.projectsFile
+  };
+}
+
+export async function readProjectsFile(
+  path: string,
+  options: { missingAsEmpty?: boolean } = {}
+): Promise<ProjectsFile> {
+  try {
+    const parsed = JSON.parse(await readFile(path, "utf8")) as unknown;
+
+    if (isProjectsFile(parsed)) {
+      return parsed;
+    }
+
+    throw invalidProjectsFile(path);
+  } catch (error) {
+    if (error instanceof ProjectRegistryError) {
+      throw error;
+    }
+
+    if (
+      options.missingAsEmpty === true &&
+      isNodeError(error) &&
+      error.code === "ENOENT"
+    ) {
+      return { schemaVersion: 1, projects: [] };
+    }
+
+    throw invalidProjectsFile(path);
+  }
+}
+
+export async function writeProjectsFile(
+  path: string,
+  projectsFile: ProjectsFile
+): Promise<void> {
+  await writeFile(path, `${JSON.stringify(projectsFile, null, 2)}\n`, "utf8");
+}
+
+function invalidProjectsFile(path: string): ProjectRegistryError {
+  return new ProjectRegistryError(
+    `Invalid projects file: ${path}`,
+    "invalid-projects-file"
+  );
+}
+
+async function ensureInitialized(configFile: string): Promise<void> {
+  try {
+    await access(configFile, constants.F_OK);
+  } catch {
+    throw new ProjectRegistryError(
+      "Config not found. Run `uncommitted init` first.",
+      "missing-config"
+    );
+  }
+}
+
+function isProjectsFile(value: unknown): value is ProjectsFile {
+  if (!isRecord(value) || value.schemaVersion !== 1 || !Array.isArray(value.projects)) {
+    return false;
+  }
+
+  return value.projects.every(isProjectRecord);
+}
+
+function isProjectRecord(value: unknown): value is ProjectRecord {
+  return (
+    isRecord(value) &&
+    value.schemaVersion === 1 &&
+    typeof value.id === "string" &&
+    typeof value.name === "string" &&
+    typeof value.root === "string" &&
+    typeof value.gitRoot === "string" &&
+    typeof value.enabled === "boolean" &&
+    typeof value.createdAt === "string"
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -4,6 +4,7 @@ import {
   mkdir,
   mkdtemp,
   readFile,
+  realpath,
   symlink,
   writeFile
 } from "node:fs/promises";
@@ -313,6 +314,136 @@ describe("cli", () => {
     expect(exitCode).toBe(2);
     expect(stdout).toEqual([]);
     expect(stderr.join("\n")).toContain("Not a Git repository");
+  });
+
+  it("routes project list to the global project registry", async () => {
+    const { io, stdout, stderr } = createIo();
+    const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-project-list-"));
+    const repoDir = join(directory, "repo");
+    const homeDir = join(directory, "home");
+
+    await initGitRepo(repoDir);
+    await writeConfig(homeDir, join(directory, "drafts"));
+    await addProject(repoDir, {
+      homeDir,
+      now: () => "2026-06-04T00:00:00.000Z"
+    });
+    const realRepoDir = await realpath(repoDir);
+
+    const exitCode = await runCli(["project", "list"], io, { homeDir });
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toEqual([]);
+    expect(stdout).toEqual([
+      "Registered projects:",
+      `repo\trepo\t${realRepoDir}\tenabled\t2026-06-04T00:00:00.000Z`
+    ]);
+  });
+
+  it("routes project list for an empty registry", async () => {
+    const { io, stdout, stderr } = createIo();
+    const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-project-list-"));
+    const homeDir = join(directory, "home");
+
+    await writeConfig(homeDir, join(directory, "drafts"));
+    await writeJson(join(homeDir, ".uncommitted", "projects.json"), {
+      schemaVersion: 1,
+      projects: []
+    });
+
+    const exitCode = await runCli(["project", "list"], io, { homeDir });
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toEqual([]);
+    expect(stdout).toEqual([
+      "No registered projects. Run `uncommitted project add .` first."
+    ]);
+  });
+
+  it("returns config exit code when project list is not initialized", async () => {
+    const { io, stdout, stderr } = createIo();
+    const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-project-list-"));
+
+    const exitCode = await runCli(["project", "list"], io, {
+      homeDir: join(directory, "home")
+    });
+
+    expect(exitCode).toBe(2);
+    expect(stdout).toEqual([]);
+    expect(stderr).toEqual(["Config not found. Run `uncommitted init` first."]);
+  });
+
+  it("returns config exit code when project list finds invalid registry data", async () => {
+    const { io, stdout, stderr } = createIo();
+    const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-project-list-"));
+    const homeDir = join(directory, "home");
+
+    await writeConfig(homeDir, join(directory, "drafts"));
+    await writeFile(join(homeDir, ".uncommitted", "projects.json"), "nope", "utf8");
+
+    const exitCode = await runCli(["project", "list"], io, { homeDir });
+
+    expect(exitCode).toBe(2);
+    expect(stdout).toEqual([]);
+    expect(stderr.join("\n")).toContain("Invalid projects file");
+  });
+
+  it("routes project remove to the global project registry", async () => {
+    const { io, stdout, stderr } = createIo();
+    const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-project-remove-"));
+    const repoDir = join(directory, "repo");
+    const homeDir = join(directory, "home");
+
+    await initGitRepo(repoDir);
+    await writeConfig(homeDir, join(directory, "drafts"));
+    await addProject(repoDir, {
+      homeDir,
+      now: () => "2026-06-04T00:00:00.000Z"
+    });
+    const realRepoDir = await realpath(repoDir);
+
+    const exitCode = await runCli(["project", "remove", "repo"], io, { homeDir });
+    const projectsFile = await readJson(join(homeDir, ".uncommitted", "projects.json"));
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toEqual([]);
+    expect(stdout).toEqual(["Project removed: repo", realRepoDir]);
+    expect(projectsFile).toEqual({
+      schemaVersion: 1,
+      projects: []
+    });
+  });
+
+  it("returns config exit code when project remove cannot find an id", async () => {
+    const { io, stdout, stderr } = createIo();
+    const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-project-remove-"));
+    const homeDir = join(directory, "home");
+
+    await writeConfig(homeDir, join(directory, "drafts"));
+    await writeJson(join(homeDir, ".uncommitted", "projects.json"), {
+      schemaVersion: 1,
+      projects: []
+    });
+
+    const exitCode = await runCli(["project", "remove", "missing"], io, {
+      homeDir
+    });
+
+    expect(exitCode).toBe(2);
+    expect(stdout).toEqual([]);
+    expect(stderr).toEqual([
+      "Unknown project id: missing. Run `uncommitted project list`."
+    ]);
+  });
+
+  it("returns usage when project remove is missing an id", async () => {
+    const { io, stdout, stderr } = createIo();
+
+    const exitCode = await runCli(["project", "remove"], io);
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toEqual([]);
+    expect(stderr).toEqual(["Usage: uncommitted project remove <project-id>"]);
   });
 
   it("renders the latest draft carousel with existing visual assets", async () => {

--- a/tests/project-registry.test.ts
+++ b/tests/project-registry.test.ts
@@ -1,0 +1,141 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  listProjects,
+  ProjectRegistryError,
+  removeProject,
+  type ProjectRecord
+} from "../src/project-registry.js";
+
+describe("project registry", () => {
+  it("lists projects from the global registry", async () => {
+    const homeDir = await createHomeWithProjects([projectRecord("alpha")]);
+
+    const result = await listProjects({ homeDir });
+
+    expect(result.projects).toEqual([projectRecord("alpha")]);
+  });
+
+  it("lists an initialized empty registry", async () => {
+    const homeDir = await createHomeWithProjects([]);
+
+    const result = await listProjects({ homeDir });
+
+    expect(result.projects).toEqual([]);
+  });
+
+  it("fails clearly when Uncommitted has not been initialized", async () => {
+    const homeDir = join("/tmp", `uncommitted-project-registry-home-${randomUUID()}`);
+
+    await expect(listProjects({ homeDir })).rejects.toMatchObject({
+      code: "missing-config",
+      message: "Config not found. Run `uncommitted init` first."
+    });
+  });
+
+  it("removes a matching project from the global registry only", async () => {
+    const removableProject = projectRecord("alpha");
+    const retainedProject = projectRecord("beta");
+    const homeDir = await createHomeWithProjects([removableProject, retainedProject]);
+    const localProjectFile = join(removableProject.gitRoot, ".uncommitted", "project.json");
+    const localEventLog = join(
+      removableProject.gitRoot,
+      ".uncommitted",
+      "events",
+      "manual",
+      "2026-06-04.jsonl"
+    );
+    const draftFile = join(
+      homeDir,
+      "drafts",
+      "2026-06-04",
+      "rev-001",
+      "caption.txt"
+    );
+
+    await mkdir(join(removableProject.gitRoot, ".uncommitted", "events", "manual"), {
+      recursive: true
+    });
+    await mkdir(join(homeDir, "drafts", "2026-06-04", "rev-001"), {
+      recursive: true
+    });
+    await writeJson(localProjectFile, removableProject);
+    await writeFile(localEventLog, "{}\n", "utf8");
+    await writeFile(draftFile, "draft caption\n", "utf8");
+
+    const result = await removeProject("alpha", { homeDir });
+
+    expect(result.removedProject).toEqual(removableProject);
+    expect(await readProjects(homeDir)).toEqual([retainedProject]);
+    await expect(stat(localProjectFile)).resolves.toMatchObject({ size: expect.any(Number) });
+    await expect(stat(localEventLog)).resolves.toMatchObject({ size: expect.any(Number) });
+    await expect(stat(draftFile)).resolves.toMatchObject({ size: expect.any(Number) });
+  });
+
+  it("fails clearly when removing an unknown project id", async () => {
+    const homeDir = await createHomeWithProjects([projectRecord("alpha")]);
+
+    await expect(removeProject("missing", { homeDir })).rejects.toMatchObject({
+      code: "unknown-project",
+      message: "Unknown project id: missing. Run `uncommitted project list`."
+    });
+  });
+
+  it("uses a typed registry error for unreadable registry data", async () => {
+    const homeDir = await createHomeWithProjects([]);
+
+    await writeFile(join(homeDir, ".uncommitted", "projects.json"), "nope", "utf8");
+
+    await expect(listProjects({ homeDir })).rejects.toBeInstanceOf(
+      ProjectRegistryError
+    );
+  });
+});
+
+function projectRecord(id: string): ProjectRecord {
+  const gitRoot = join("/tmp", "uncommitted-project-registry", id);
+
+  return {
+    schemaVersion: 1,
+    id,
+    name: id,
+    root: gitRoot,
+    gitRoot,
+    enabled: true,
+    createdAt: "2026-06-04T00:00:00.000Z"
+  };
+}
+
+async function createHomeWithProjects(projects: ProjectRecord[]): Promise<string> {
+  const homeDir = join("/tmp", `uncommitted-project-registry-home-${randomUUID()}`);
+
+  await mkdir(join(homeDir, ".uncommitted"), { recursive: true });
+  await writeJson(join(homeDir, ".uncommitted", "config.json"), {
+    schemaVersion: 1,
+    draftRoot: join(homeDir, "drafts"),
+    scheduleTime: "23:30",
+    aiProvider: "none",
+    persona: "test persona",
+    roastLevel: 2
+  });
+  await writeJson(join(homeDir, ".uncommitted", "projects.json"), {
+    schemaVersion: 1,
+    projects
+  });
+
+  return homeDir;
+}
+
+async function readProjects(homeDir: string): Promise<ProjectRecord[]> {
+  const parsed = JSON.parse(
+    await readFile(join(homeDir, ".uncommitted", "projects.json"), "utf8")
+  ) as { projects: ProjectRecord[] };
+
+  return parsed.projects;
+}
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}


### PR DESCRIPTION
# Goal

Implement the missing project registry management commands so users can inspect registered projects and remove a project from the global registry without deleting local project data.

## Related Issue

Closes #46.

## Acceptance Criteria

- [x] `uncommitted project list` shows registered projects from `~/.uncommitted/projects.json`
- [x] `uncommitted project list` succeeds with an empty registry and explains that no projects are registered
- [x] `uncommitted project remove <project-id>` removes the matching project from the global registry
- [x] Removing an unknown project id fails with a short actionable config error
- [x] Removal does not delete repository files, local event logs, or generated drafts
- [x] CLI routing exposes both commands under `project`
- [x] Unit tests cover representative success and failure cases

## Implementation Notes

- Added a shared project registry module for reading, validating, listing, and removing registry entries.
- Reused the shared registry helpers from `project add` while preserving the existing add-command error surface.
- Kept remove scoped to the global `projects.json` file only; tests assert local project metadata, event logs, and draft files remain intact.
- `project list` emits concise tab-separated project rows: id, name, Git root, enabled status, and creation timestamp.

## Validation

- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`
- `git diff --staged --check`

## Remaining Risk

No known remaining risk. The new commands intentionally do not delete project-local files or generated user data.
