### PR TITLE
feat: improve AI coworker caption voice

### DIFF
--- a/docs/superpowers/specs/2026-05-16-unc-62-caption-voice-design.md
+++ b/docs/superpowers/specs/2026-05-16-unc-62-caption-voice-design.md
@@ -1,0 +1,132 @@
+# UNC-62 Caption Voice Design
+
+## Context
+
+Issue #62 improves `caption.txt` quality for Uncommitted's AI coworker diary drafts. The current prompt contract can make captions feel too conceptual, too poetic, too report-like, or too visibly driven by the selected story genre.
+
+The implementation should stay prompt-contract only. It should not add a caption scoring system, rule-based Korean style validator, new provider task, new data model, or runtime rejection for captions that merely sound awkward.
+
+## Goal
+
+Generated captions should read like the configured AI coworker persona posting a natural Korean Instagram caption after work.
+
+The caption should mention one or two concrete work moments from the activity summary, then add the narrator's emotionally specific reaction. It should feel like something a person might actually post, not a polished writing exercise.
+
+## Scope
+
+- Strengthen `src/diary-generator.ts` instructions so the configured `persona` is explicitly the narrator.
+- Keep `StoryFormatPlan` useful for story and carousel slide structure.
+- Stop requiring the selected story genre to be visible in the caption.
+- Prefer concrete work moments plus narrator reaction over abstract poetic phrasing.
+- Explicitly reject status-report, changelog, task-summary, literary, inspirational, slogan-like, and abstract metaphor-heavy caption shapes.
+- Add or update focused prompt-contract tests in `tests/diary-generator.test.ts`.
+- Preserve existing safety, privacy, quiet-day honesty, and malformed provider output behavior.
+
+## Out Of Scope
+
+- Changing image prompts, visual asset generation, or carousel rendering.
+- Changing the `StoryFormatPlan` schema.
+- Adding Instagram auto-posting.
+- Sending raw diffs, raw code, private paths, secrets, emails, or private URLs to AI providers.
+- Adding a full caption ranking, scoring, or evaluation system.
+- Rejecting provider output solely because the caption is stylistically weak.
+
+## Design
+
+### Genre Boundary
+
+`StoryFormatPlan` remains the story and carousel planning layer. Its `formatName`, `voice`, `tone`, and `structure` can still shape slide titles, slide bodies, and the overall carousel flow.
+
+The caption should not be required to perform the selected genre. A case file, trial, broadcast, or field note format may influence the surrounding story, but the caption should not be forced into phrases like "today's verdict," "evidence A," or "field report" just to make the genre visible.
+
+The prompt should make this boundary explicit:
+
+- Use the Story Format Plan for slide structure and story flow.
+- Do not force the selected genre to be visible in the caption.
+- It is fine if the genre lightly colors the caption, but the caption must remain natural Instagram copy.
+
+### Persona As Narrator
+
+The configured AI coworker persona is the writer, not a topic, tag, or style hint. The instructions should say that the persona is the narrator of the caption and should not be explained to the reader.
+
+The caption should use the narrator's own reaction to the day. It may describe what the AI coworker noticed, waited for, got confused by, felt relieved about, or found mildly annoying. It must not claim to know the user's private emotions.
+
+### Caption Style
+
+The caption should prefer plain, casual, emotionally specific Korean.
+
+It should sound like a real Instagram caption someone might post after work. A slightly imperfect casual caption is better than a polished metaphor. The prompt should discourage trying to sound literary, profound, inspirational, or clever.
+
+Desired shape:
+
+- Start from one or two real work moments.
+- Add the narrator's reaction to those moments.
+- Use everyday emotions such as frustration, relief, awkwardness, tiredness, doubt, stubbornness, small satisfaction, or mild embarrassment.
+- Keep it copyable as an Instagram caption.
+
+Rejected shapes:
+
+- Status report, changelog, standup update, task summary, executive summary, or task handoff.
+- Metric-led phrasing such as total commits, files changed, insertions, deletions, owner, next steps, or action items.
+- Abstract literary lines, polished metaphors, inspirational phrasing, slogan-like sentences, or overly conceptual endings.
+
+## Code Boundary
+
+The main change belongs in `buildDiaryInstructions()` in `src/diary-generator.ts`.
+
+The current instruction that makes the selected genre visible in the title, caption, slide titles, and slide bodies should be split. The revised contract should keep genre visibility for story and slides while carving caption out as persona-led Instagram copy.
+
+`src/story-format-plan.ts` should remain mostly unchanged. It still owns format variety for the carousel. If implementation needs a small support line there, it should only clarify that `captionStyle` must not force genre performance in the caption.
+
+No new public types, config fields, files, or storage artifacts are required.
+
+## Data Flow
+
+The existing generation flow stays unchanged:
+
+1. `runGenerateCommand()` builds the daily activity summary.
+2. `generateStoryFormatPlan()` creates the story format plan.
+3. `generateDiaryDraft()` builds the draft request using the activity summary, persona, roast level, and story format plan.
+4. `deriveCaptionText()` writes the generated caption and hashtags to `caption.txt`.
+
+The issue is solved by changing the draft request instructions, not by changing provider orchestration.
+
+## Error Handling
+
+No new error code or exception type is needed.
+
+Existing behavior remains:
+
+- malformed provider JSON fails as an AI generation error;
+- unsafe provider output fails as an unsafe diary draft;
+- fabricated quiet-day activity fails existing quiet-day honesty checks;
+- stylistically weak but structurally valid captions are not rejected.
+
+## Testing
+
+Focused tests should assert the prompt contract rather than generated caption quality.
+
+`tests/diary-generator.test.ts` should cover:
+
+- the instructions explicitly present the configured persona as the narrator;
+- the instructions say the caption should not be forced to visibly perform the selected story genre;
+- the instructions prefer concrete work moments plus narrator reaction;
+- the instructions ask for real Instagram-caption-like, plain, casual Korean;
+- the instructions reject report, changelog, task summary, and metric-led shapes;
+- the instructions reject literary, polished, profound, inspirational, slogan-like, and abstract metaphor-heavy phrasing;
+- existing privacy, safety, and quiet-day honesty instructions still appear.
+
+The tests should not require a real provider or assert exact generated Korean output from an LLM.
+
+## Acceptance Criteria Mapping
+
+- Persona as narrator: covered by explicit diary instruction and prompt-contract test.
+- Genre no longer required in caption: covered by split genre boundary and prompt-contract test.
+- Concrete moments plus emotional reaction: covered by caption style instructions and prompt-contract test.
+- Reject status-report shapes: covered by negative caption instruction and prompt-contract test.
+- Reject literary or abstract phrasing: covered by negative caption instruction and prompt-contract test.
+- Safety/privacy tests continue to pass: covered by unchanged validation behavior and full relevant test run.
+
+## Remaining Risk
+
+Prompt-contract changes can improve provider behavior, but they cannot guarantee every generated caption will feel natural. Real output examples should be reviewed after implementation. If captions remain inconsistent, a later issue can design a separate caption revision or evaluation layer with examples and acceptance thresholds.

--- a/src/diary-generator.ts
+++ b/src/diary-generator.ts
@@ -224,6 +224,9 @@ function buildDiaryInstructions(options: {
   const quietInstruction = options.quiet
     ? "For quiet days, acknowledge no recorded work and pivot to waiting, observation, or an honest quiet-day monologue."
     : "Use only the concrete work signals in the activity summary.";
+  const captionMomentInstruction = options.quiet
+    ? "For quiet-day captions, mention the absence of recorded work honestly, then add the narrator's reaction to the quiet."
+    : "Mention one or two concrete work moments from the activity summary, then add the narrator's reaction.";
 
   return [
     "Return structured JSON for story.json with title, caption, slides, hashtags, and altText.",
@@ -231,15 +234,23 @@ function buildDiaryInstructions(options: {
     `Use ${options.storyFormatPlan.voice} as the voice and ${options.storyFormatPlan.tone} as the tone.`,
     `Create ${options.storyFormatPlan.suggestedSlideCount} slides when possible, while staying within 3-8 slides.`,
     "Write from the configured AI coworker's point of view; this is the narrator's own off-the-record diary, not the user's diary.",
-    "Make the selected genre visible in the title, caption, slide titles, and slide bodies without explaining the genre.",
+    "The configured AI coworker persona is the caption narrator, not a topic, tag, or weak style hint.",
+    "Do not explain the persona to the reader.",
+    "Use the Story Format Plan for slide structure and story flow.",
+    "Make the selected genre visible in the title, slide titles, and slide bodies without explaining the genre.",
+    "Do not force the selected genre to be visible in the caption; the genre may lightly color the caption, but it must not take over.",
     "Caption must be copyable as an Instagram caption, Korean by default, concise, and not report-like.",
-    "Write like the AI coworker is recording how the shared workday felt to it, not what a manager needs to know.",
-    "Do not write a status report, executive summary, changelog, standup update, or task handoff.",
+    "Write like a real Instagram caption someone might post after work.",
+    "Plain, casual, emotionally specific Korean is better than elegant abstract writing.",
+    "Do not try to sound literary, polished, profound, inspirational, or clever.",
+    captionMomentInstruction,
+    "Use everyday reactions such as frustration, relief, awkwardness, tiredness, doubt, stubbornness, small satisfaction, or mild embarrassment.",
+    "Do not write a status report, executive summary, changelog, standup update, task summary, task handoff, or metric-led recap.",
     "Avoid report words and shapes such as summary, snapshot, total commits, files changed, insertions, deletions, next steps, owner, or action items.",
     "Avoid metric-led phrasing such as total commits, files changed, insertion/deletion counts, project-by-project bullets, or next-action owner lines.",
-    "Use specific work details sparingly as texture; lead with mood, friction, small relief, embarrassment, momentum, or unfinished tension.",
+    "Avoid abstract literary lines, polished metaphors, slogan-like sentences, and overly conceptual endings.",
     "Do not claim to know the user's inner feelings; frame emotional language as the narrator's reaction or the atmosphere around the work.",
-    "Prefer scenes, metaphors, and concrete moments over task lists.",
+    "Prefer concrete moments and the narrator's everyday reaction over task lists.",
     "Each slide must include index, title, body, and visualMood.",
     "Prefer 3-5 slides for quiet or low activity days; this is guidance, not a hard validation limit.",
     "Do not invent work, commits, bugs, features, shipped changes, or user activity.",

--- a/tests/diary-generator.test.ts
+++ b/tests/diary-generator.test.ts
@@ -96,27 +96,41 @@ describe("diary generator", () => {
         }
       }
     });
-    expect(provider.requests[0]?.instructions).toContain(
-      "Return structured JSON for story.json"
-    );
-    expect(provider.requests[0]?.instructions).toContain(
+    const instructions = provider.requests[0]?.instructions ?? "";
+    expect(instructions).toContain("Return structured JSON for story.json");
+    expect(instructions).toContain(
       "Caption must be copyable as an Instagram caption"
     );
-    expect(provider.requests[0]?.instructions).toContain("Do not invent work");
-    expect(provider.requests[0]?.instructions).toContain(
-      "Write like the AI coworker is recording how the shared workday felt to it"
+    expect(instructions).toContain("Do not invent work");
+    expect(instructions).toContain(
+      "The configured AI coworker persona is the caption narrator"
     );
-    expect(provider.requests[0]?.instructions).toContain(
-      "Do not write a status report"
+    expect(instructions).toContain(
+      "Do not explain the persona to the reader"
     );
-    expect(provider.requests[0]?.instructions).toContain(
-      "not the user's diary"
+    expect(instructions).toContain(
+      "Use the Story Format Plan for slide structure and story flow"
     );
-    expect(provider.requests[0]?.instructions).toContain(
-      "Make the selected genre visible"
+    expect(instructions).toContain(
+      "Do not force the selected genre to be visible in the caption"
     );
-    expect(provider.requests[0]?.instructions).toContain(
+    expect(instructions).toContain(
+      "Mention one or two concrete work moments from the activity summary"
+    );
+    expect(instructions).toContain("then add the narrator's reaction");
+    expect(instructions).toContain(
+      "Write like a real Instagram caption someone might post after work"
+    );
+    expect(instructions).toContain(
+      "Plain, casual, emotionally specific Korean is better than elegant abstract writing"
+    );
+    expect(instructions).toContain("Do not write a status report");
+    expect(instructions).toContain("Avoid abstract literary lines");
+    expect(instructions).toContain(
       "Do not claim to know the user's inner feelings"
+    );
+    expect(instructions).not.toContain(
+      "Make the selected genre visible in the title, caption"
     );
   });
 
@@ -208,6 +222,13 @@ describe("diary generator", () => {
     );
     expect(provider.requests[0]?.instructions).toContain(
       "For quiet days, acknowledge no recorded work"
+    );
+    const instructions = provider.requests[0]?.instructions ?? "";
+    expect(instructions).toContain(
+      "For quiet-day captions, mention the absence of recorded work honestly"
+    );
+    expect(instructions).not.toContain(
+      "Mention one or two concrete work moments from the activity summary"
     );
   });
 


### PR DESCRIPTION
# Goal

Improve `caption.txt` generation so captions read like a natural Korean Instagram post from the configured AI coworker persona, while keeping story genre useful for carousel/story structure.

## Related Issue

Closes #62

## Acceptance Criteria

- [x] The configured persona is explicitly presented as the caption narrator.
- [x] Caption instructions no longer require the selected story genre to be visible in the caption.
- [x] Caption guidance prefers concrete work moments plus narrator reaction over abstract poetic phrasing.
- [x] Caption guidance rejects status-report/changelog/task-summary shapes.
- [x] Caption guidance rejects overly literary, inspirational, slogan-like, and abstract metaphor-heavy phrasing.
- [x] Tests cover the improved prompt contract for persona, caption tone, and non-report/non-poetic constraints.
- [x] Existing safety/privacy behavior remains covered by the test suite.

## Implementation Notes

- Updated `buildDiaryInstructions()` so `StoryFormatPlan` still drives title/slides/story flow, but captions are not forced to perform the selected genre.
- Added caption guidance for plain, casual, emotionally specific Korean that feels like a real after-work Instagram caption.
- Added a quiet-day-specific caption instruction so quiet drafts mention the absence of recorded work honestly instead of inventing concrete work moments.
- Added focused prompt-contract assertions in `tests/diary-generator.test.ts`.

## Validation

- [x] `pnpm test -- tests/diary-generator.test.ts tests/generate-command.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `git diff --check`

## Remaining Risk

Prompt-contract tests verify the request instructions, not real model output quality. Actual generated captions should still be reviewed during dogfooding.
