### PR TITLE
✨ feat(caption): ground AI coworker prompt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/diary-generator.ts
+++ b/src/diary-generator.ts
@@ -230,15 +230,14 @@ function buildDiaryInstructions(options: {
 
   return [
     "Return structured JSON for story.json with title, caption, slides, hashtags, and altText.",
-    `Follow the Story Format Plan named ${options.storyFormatPlan.formatName}.`,
-    `Use ${options.storyFormatPlan.voice} as the voice and ${options.storyFormatPlan.tone} as the tone.`,
+    "Follow the Story Format Plan for story title, slide titles, slide bodies, and visualMood only.",
+    "Use the Story Format Plan's voice and tone for the story slides only.",
     `Create ${options.storyFormatPlan.suggestedSlideCount} slides when possible, while staying within 3-8 slides.`,
     "Write from the configured AI coworker's point of view; this is the narrator's own off-the-record diary, not the user's diary.",
     "The configured AI coworker persona is the caption narrator, not a topic, tag, or weak style hint.",
     "Do not explain the persona to the reader.",
     "Use the Story Format Plan for slide structure and story flow.",
-    "Make the selected genre visible in the title, slide titles, and slide bodies without explaining the genre.",
-    "Do not force the selected genre to be visible in the caption; the genre may lightly color the caption, but it must not take over.",
+    "Do not use the Story Format Plan, formatName, voice, tone, or captionStyle to create a concept for the caption.",
     "Caption must be copyable as an Instagram caption, Korean by default, concise, and not report-like.",
     "Write like a real Instagram caption someone might post after work.",
     "Plain, casual, emotionally specific Korean is better than elegant abstract writing.",

--- a/tests/diary-generator.test.ts
+++ b/tests/diary-generator.test.ts
@@ -112,8 +112,13 @@ describe("diary generator", () => {
       "Use the Story Format Plan for slide structure and story flow"
     );
     expect(instructions).toContain(
-      "Do not force the selected genre to be visible in the caption"
+      "Do not use the Story Format Plan, formatName, voice, tone, or captionStyle to create a concept for the caption"
     );
+    expect(instructions).not.toContain("Bug Court Transcript");
+    expect(instructions).not.toContain("tired QA narrator");
+    expect(instructions).not.toContain("deadpan, witty, affectionate");
+    expect(instructions).not.toContain("selected genre");
+    expect(instructions).not.toContain("genre may lightly color the caption");
     expect(instructions).toContain(
       "Mention one or two concrete work moments from the activity summary"
     );


### PR DESCRIPTION
# Goal

Improve caption generation so `caption.txt` reads more like a concrete, casual AI coworker diary caption instead of a genre-heavy concept piece or status report.

## Related Issue

Closes UNC-83

## Acceptance Criteria

- [x] Caption prompt removes genre/concept pressure from caption generation.
- [x] Caption prompt keeps the AI coworker as the narrator.
- [x] Caption guidance prefers concrete work moments plus narrator reaction.
- [x] Caption guidance rejects status-report, changelog, and task-summary shapes.
- [x] Caption guidance rejects literary, inspirational, slogan-like, and abstract metaphor-heavy phrasing.
- [x] Existing safety/privacy tests pass.

## Implementation Notes

- Updated `src/diary-generator.ts` so Story Format Plan details shape story slides only.
- Added prompt-contract assertions in `tests/diary-generator.test.ts` to keep story format names, voice/tone strings, and selected-genre wording out of caption instructions.
- Added `CLAUDE.md` as a symlink to `AGENTS.md`, per user request.

## Validation

- [x] `pnpm test`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `git diff --check`

## Remaining Risk

Generated caption quality still depends on the provider following prompt guidance; this PR tightens the request contract but does not add an automated caption ranking/evaluation system.
