### PR TITLE
🤖 Implement export instagram command (UNC-78)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -302,6 +302,7 @@ async function runExport(
 
     io.stdout(`Exported to: ${result.exportDir}`);
     io.stdout(`Files: ${result.exportedFiles.join(", ")}`);
+    io.stdout("Re-running export overwrites this folder. Source draft is never modified.");
     return 0;
   } catch (error) {
     if (error instanceof ExportCommandError) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,6 +27,11 @@ import {
   removeProject,
   type ProjectRecord
 } from "./project-registry.js";
+import { resolveConfigPaths } from "./config-paths.js";
+import {
+  ExportCommandError,
+  runExportCommand
+} from "./export-command.js";
 import {
   RenderCommandError,
   runRenderCommand
@@ -47,6 +52,7 @@ export type CliIo = {
 export type CliOptions = {
   cwd?: string;
   homeDir?: string;
+  draftRoot?: string;
   now?: () => string;
   aiProvider?: AiProvider;
   imageAssetProvider?: ImageAssetProvider;
@@ -140,6 +146,10 @@ export async function runCli(
 
   if (command === "render") {
     return await runRender(commandArgs, io, options);
+  }
+
+  if (command === "export") {
+    return await runExport(commandArgs, io, options);
   }
 
   if (command === "schedule") {
@@ -266,6 +276,58 @@ async function runRender(
       }
 
       return 5;
+    }
+
+    throw error;
+  }
+}
+
+async function runExport(
+  args: string[],
+  io: CliIo,
+  options: CliOptions
+): Promise<number> {
+  const paths = resolveConfigPaths({ homeDir: options.homeDir });
+  const draftRoot = options.draftRoot ?? paths.defaultDraftRoot;
+
+  try {
+    const result = await runExportCommand(args, {
+      draftRoot,
+      now: options.now
+    });
+
+    if (result.safetyStatus === "warning") {
+      io.stderr("Safety warning: draft contains redacted content. Review before posting.");
+    }
+
+    io.stdout(`Exported to: ${result.exportDir}`);
+    io.stdout(`Files: ${result.exportedFiles.join(", ")}`);
+    return 0;
+  } catch (error) {
+    if (error instanceof ExportCommandError) {
+      io.stderr(error.message);
+
+      if (error.code === "invalid-arguments") {
+        return 1;
+      }
+
+      if (error.code === "invalid-config") {
+        return 2;
+      }
+
+      if (error.code === "missing-draft") {
+        return 1;
+      }
+
+      if (error.code === "missing-carousel") {
+        return 5;
+      }
+
+      if (error.code === "safety-blocked") {
+        return 6;
+      }
+
+      return 1;
     }
 
     throw error;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -296,8 +296,8 @@ async function runExport(
       now: options.now
     });
 
-    if (result.safetyStatus === "warning") {
-      io.stderr("Safety warning: draft contains redacted content. Review before posting.");
+    if (result.warningMessage) {
+      io.stderr(result.warningMessage);
     }
 
     io.stdout(`Exported to: ${result.exportDir}`);

--- a/src/export-command.ts
+++ b/src/export-command.ts
@@ -1,4 +1,4 @@
-import { copyFile, mkdir, readdir, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { readLatestDraftPointer } from "./draft-storage.js";
 import type { SafetyStatus } from "./safety-report.js";
@@ -44,6 +44,11 @@ export type ExportCommandResult = {
   safetyStatus: SafetyStatus;
   sourceDraftPath: string;
   exportedAt: string;
+  /**
+   * Present when safetyStatus is "warning". Includes the reason from
+   * safety-report.json. The caller (CLI layer) should print this to stderr.
+   */
+  warningMessage?: string;
 };
 
 export type ExportMetadata = {
@@ -67,15 +72,13 @@ const USAGE = "Usage: uncommitted export instagram";
 /**
  * Run the `export instagram [latest]` command.
  *
- * Happy-path flow (UNC-92 scaffold):
- *  1. Resolve the latest draft via latest.json pointer.
- *  2. Create export folder under {draftRoot}/exports/instagram/{date}/{revision}/.
- *  3. Copy caption.txt verbatim.
- *  4. Copy carousel PNGs with zero-padded names (carousel-01.png, ...).
- *  5. Write metadata.json recording source, timestamp, safety status, file list.
+ * Safety policy (UNC-94):
+ *  - safe: export proceeds silently.
+ *  - warning: export proceeds; result.warningMessage contains the reason.
+ *  - blocked: throws ExportCommandError("safety-blocked") before any folder is created.
  *
- * Safety policy enforcement (UNC-94), missing-file handling (UNC-95), and
- * idempotency (UNC-96) are layered on top in subsequent sub-issues.
+ * Ordering: safety is enforced BEFORE creating the export folder so that a
+ * blocked draft never leaves behind a partial export directory.
  */
 export async function runExportCommand(
   args: string[],
@@ -91,13 +94,13 @@ export async function runExportCommand(
   const pointer = await resolveLatestPointer(draftRoot);
   const sourceDraftPath = pointer.path;
 
-  // 3. Read safety report from the draft
-  const safetyStatus = await readSafetyStatus(sourceDraftPath);
+  // 3. Read safety report (status + reason)
+  const safetyInfo = await readSafetyInfo(sourceDraftPath);
 
-  // 4. Enforce safety policy
-  enforceSafetyPolicy(safetyStatus);
+  // 4. Enforce safety policy BEFORE touching the export folder
+  const policyResult = checkSafetyPolicy(safetyInfo.status, safetyInfo.reason);
 
-  // 5. Collect carousel PNGs
+  // 5. Collect carousel PNGs (validate BEFORE creating export folder)
   const carouselPngs = await collectCarouselPngs(sourceDraftPath);
 
   // 6. Create export folder
@@ -121,7 +124,7 @@ export async function runExportCommand(
     schemaVersion: 1,
     sourceDraftPath,
     exportedAt,
-    safetyStatus,
+    safetyStatus: safetyInfo.status,
     exportedFiles: [...exportedFiles, "metadata.json"]
   });
   exportedFiles.push("metadata.json");
@@ -129,21 +132,25 @@ export async function runExportCommand(
   return {
     exportDir,
     exportedFiles,
-    safetyStatus,
+    safetyStatus: safetyInfo.status,
     sourceDraftPath,
-    exportedAt
+    exportedAt,
+    warningMessage: policyResult.warningMessage
   };
 }
 
 // ---------------------------------------------------------------------------
-// Safety policy helpers (extended in UNC-94)
+// Safety policy helpers
 // ---------------------------------------------------------------------------
 
 /**
- * Returns a warning message when the safety status is "warning", or undefined
- * when safe. Throws ExportCommandError for "blocked".
+ * Enforces the MVP safety policy.
  *
- * This is intentionally a small, isolated function so UNC-94 can wrap it.
+ * - "safe": returns {} (no warning).
+ * - "warning": returns { warningMessage } with the reason string.
+ * - "blocked": throws ExportCommandError with code "safety-blocked".
+ *
+ * Kept as a small dedicated function so future overrides can wrap it.
  */
 export function checkSafetyPolicy(
   safetyStatus: SafetyStatus,
@@ -191,10 +198,18 @@ async function resolveLatestPointer(draftRoot: string) {
   }
 }
 
-async function readSafetyStatus(sourceDraftPath: string): Promise<SafetyStatus> {
-  const { readFile } = await import("node:fs/promises");
+type SafetyInfo = {
+  status: SafetyStatus;
+  /** The human-readable reason from safety-report.json (used as warning reason) */
+  reason?: string;
+};
+
+async function readSafetyInfo(sourceDraftPath: string): Promise<SafetyInfo> {
   try {
-    const raw = await readFile(join(sourceDraftPath, "safety-report.json"), "utf8");
+    const raw = await readFile(
+      join(sourceDraftPath, "safety-report.json"),
+      "utf8"
+    );
     const parsed = JSON.parse(raw) as unknown;
 
     if (
@@ -203,52 +218,40 @@ async function readSafetyStatus(sourceDraftPath: string): Promise<SafetyStatus> 
         parsed.status === "warning" ||
         parsed.status === "blocked")
     ) {
-      return parsed.status as SafetyStatus;
+      const reason =
+        typeof parsed.message === "string" ? parsed.message : undefined;
+      return { status: parsed.status as SafetyStatus, reason };
     }
   } catch {
-    // If no safety report, treat as safe for scaffold (UNC-94 adds strict policy)
+    // If no safety report file, treat as safe (graceful degradation)
   }
 
-  return "safe";
-}
-
-function enforceSafetyPolicy(safetyStatus: SafetyStatus): void {
-  // Scaffold: only block "blocked" status. UNC-94 adds warning output.
-  if (safetyStatus === "blocked") {
-    throw new ExportCommandError(
-      "Export blocked: draft contains sensitive content. Review safety-report.json.",
-      "safety-blocked"
-    );
-  }
+  return { status: "safe" };
 }
 
 async function collectCarouselPngs(sourceDraftPath: string): Promise<string[]> {
   const carouselDir = join(sourceDraftPath, "carousel");
 
+  let entries: string[];
   try {
-    const entries = await readdir(carouselDir);
-    const pngs = entries
-      .filter((e) => e.endsWith(".png"))
-      .sort();
-
-    if (pngs.length === 0) {
-      throw new ExportCommandError(
-        "No carousel PNGs found. Run `uncommitted render latest` first.",
-        "missing-carousel"
-      );
-    }
-
-    return pngs;
-  } catch (error) {
-    if (error instanceof ExportCommandError) {
-      throw error;
-    }
-
+    entries = await readdir(carouselDir);
+  } catch {
     throw new ExportCommandError(
       "No carousel PNGs found. Run `uncommitted render latest` first.",
       "missing-carousel"
     );
   }
+
+  const pngs = entries.filter((e) => e.endsWith(".png")).sort();
+
+  if (pngs.length === 0) {
+    throw new ExportCommandError(
+      "No carousel PNGs found. Run `uncommitted render latest` first.",
+      "missing-carousel"
+    );
+  }
+
+  return pngs;
 }
 
 async function createExportDir(exportDir: string): Promise<void> {

--- a/src/export-command.ts
+++ b/src/export-command.ts
@@ -92,6 +92,7 @@ export async function runExportCommand(
 
   // 2. Resolve latest draft pointer
   const pointer = await resolveLatestPointer(draftRoot);
+  validatePointerDate(pointer.targetDate);
   const sourceDraftPath = pointer.path;
 
   // 3. Read safety report (status + reason)
@@ -332,6 +333,15 @@ async function writeExportMetadata(
     throw new ExportCommandError(
       "Could not write export metadata.",
       "export-failed"
+    );
+  }
+}
+
+function validatePointerDate(targetDate: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(targetDate)) {
+    throw new ExportCommandError(
+      "Draft pointer contains an invalid date.",
+      "invalid-config"
     );
   }
 }

--- a/src/export-command.ts
+++ b/src/export-command.ts
@@ -1,6 +1,6 @@
 import { copyFile, mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { readLatestDraftPointer } from "./draft-storage.js";
+import { DraftStorageError, readLatestDraftPointer } from "./draft-storage.js";
 import type { SafetyStatus } from "./safety-report.js";
 
 // ---------------------------------------------------------------------------
@@ -194,10 +194,16 @@ function validateArgs(args: string[]): void {
 async function resolveLatestPointer(draftRoot: string) {
   try {
     return await readLatestDraftPointer(draftRoot);
-  } catch {
+  } catch (err) {
+    if (err instanceof DraftStorageError && err.message.toLowerCase().includes("missing")) {
+      throw new ExportCommandError(
+        "No latest draft found. Run `uncommitted generate today` and `uncommitted render latest` first.",
+        "missing-draft"
+      );
+    }
     throw new ExportCommandError(
-      "No latest draft found. Run `uncommitted generate today` and `uncommitted render latest` first.",
-      "missing-draft"
+      "Could not read draft pointer. Check your configuration.",
+      "invalid-config"
     );
   }
 }

--- a/src/export-command.ts
+++ b/src/export-command.ts
@@ -53,7 +53,8 @@ export type ExportCommandResult = {
 
 export type ExportMetadata = {
   schemaVersion: 1;
-  sourceDraftPath: string;
+  draftDate: string;
+  draftRevision: string;
   exportedAt: string;
   safetyStatus: SafetyStatus;
   exportedFiles: string[];
@@ -123,7 +124,8 @@ export async function runExportCommand(
   // 8. Write export metadata.json
   await writeExportMetadata(exportDir, {
     schemaVersion: 1,
-    sourceDraftPath,
+    draftDate: pointer.targetDate,
+    draftRevision: pointer.revision,
     exportedAt,
     safetyStatus: safetyInfo.status,
     exportedFiles: [...exportedFiles, "metadata.json"]

--- a/src/export-command.ts
+++ b/src/export-command.ts
@@ -185,6 +185,10 @@ function validateArgs(args: string[]): void {
   if (target !== undefined && target !== "latest") {
     throw new ExportCommandError(USAGE, "invalid-arguments");
   }
+
+  if (args.length > 2) {
+    throw new ExportCommandError(USAGE, "invalid-arguments");
+  }
 }
 
 async function resolveLatestPointer(draftRoot: string) {

--- a/src/export-command.ts
+++ b/src/export-command.ts
@@ -216,28 +216,44 @@ type SafetyInfo = {
 };
 
 async function readSafetyInfo(sourceDraftPath: string): Promise<SafetyInfo> {
+  let raw: string;
   try {
-    const raw = await readFile(
-      join(sourceDraftPath, "safety-report.json"),
-      "utf8"
-    );
-    const parsed = JSON.parse(raw) as unknown;
-
-    if (
-      isRecord(parsed) &&
-      (parsed.status === "safe" ||
-        parsed.status === "warning" ||
-        parsed.status === "blocked")
-    ) {
-      const reason =
-        typeof parsed.message === "string" ? parsed.message : undefined;
-      return { status: parsed.status as SafetyStatus, reason };
+    raw = await readFile(join(sourceDraftPath, "safety-report.json"), "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return { status: "safe" };
     }
-  } catch {
-    // If no safety report file, treat as safe (graceful degradation)
+    throw new ExportCommandError(
+      "Could not read safety-report.json.",
+      "export-failed"
+    );
   }
 
-  return { status: "safe" };
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new ExportCommandError(
+      "safety-report.json has an unrecognized format.",
+      "export-failed"
+    );
+  }
+
+  if (
+    isRecord(parsed) &&
+    (parsed.status === "safe" ||
+      parsed.status === "warning" ||
+      parsed.status === "blocked")
+  ) {
+    const reason =
+      typeof parsed.message === "string" ? parsed.message : undefined;
+    return { status: parsed.status as SafetyStatus, reason };
+  }
+
+  throw new ExportCommandError(
+    "safety-report.json has an unrecognized format.",
+    "export-failed"
+  );
 }
 
 async function collectCarouselPngs(sourceDraftPath: string): Promise<string[]> {

--- a/src/export-command.ts
+++ b/src/export-command.ts
@@ -1,4 +1,4 @@
-import { copyFile, mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { DraftStorageError, readLatestDraftPointer } from "./draft-storage.js";
 import type { SafetyStatus } from "./safety-report.js";
@@ -283,6 +283,7 @@ async function collectCarouselPngs(sourceDraftPath: string): Promise<string[]> {
 
 async function createExportDir(exportDir: string): Promise<void> {
   try {
+    await rm(exportDir, { recursive: true, force: true });
     await mkdir(exportDir, { recursive: true });
   } catch {
     throw new ExportCommandError(

--- a/src/export-command.ts
+++ b/src/export-command.ts
@@ -1,0 +1,328 @@
+import { copyFile, mkdir, readdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { readLatestDraftPointer } from "./draft-storage.js";
+import type { SafetyStatus } from "./safety-report.js";
+
+// ---------------------------------------------------------------------------
+// Error
+// ---------------------------------------------------------------------------
+
+export type ExportCommandErrorCode =
+  | "invalid-arguments"
+  | "invalid-config"
+  | "missing-draft"
+  | "missing-carousel"
+  | "safety-blocked"
+  | "export-failed";
+
+export class ExportCommandError extends Error {
+  constructor(
+    message: string,
+    public readonly code: ExportCommandErrorCode
+  ) {
+    super(message);
+    this.name = "ExportCommandError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ExportCommandOptions = {
+  /** Draft root directory (e.g. ~/Uncommitted/drafts) */
+  draftRoot: string;
+  /** Returns ISO timestamp for export time. Defaults to new Date().toISOString() */
+  now?: () => string;
+};
+
+export type ExportCommandResult = {
+  /** Absolute path to the created export folder */
+  exportDir: string;
+  /** List of file names (relative to exportDir) that were written */
+  exportedFiles: string[];
+  safetyStatus: SafetyStatus;
+  sourceDraftPath: string;
+  exportedAt: string;
+};
+
+export type ExportMetadata = {
+  schemaVersion: 1;
+  sourceDraftPath: string;
+  exportedAt: string;
+  safetyStatus: SafetyStatus;
+  exportedFiles: string[];
+};
+
+// ---------------------------------------------------------------------------
+// Usage hint
+// ---------------------------------------------------------------------------
+
+const USAGE = "Usage: uncommitted export instagram";
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the `export instagram [latest]` command.
+ *
+ * Happy-path flow (UNC-92 scaffold):
+ *  1. Resolve the latest draft via latest.json pointer.
+ *  2. Create export folder under {draftRoot}/exports/instagram/{date}/{revision}/.
+ *  3. Copy caption.txt verbatim.
+ *  4. Copy carousel PNGs with zero-padded names (carousel-01.png, ...).
+ *  5. Write metadata.json recording source, timestamp, safety status, file list.
+ *
+ * Safety policy enforcement (UNC-94), missing-file handling (UNC-95), and
+ * idempotency (UNC-96) are layered on top in subsequent sub-issues.
+ */
+export async function runExportCommand(
+  args: string[],
+  options: ExportCommandOptions
+): Promise<ExportCommandResult> {
+  // 1. Validate arguments
+  validateArgs(args);
+
+  const exportedAt = options.now ? options.now() : new Date().toISOString();
+  const { draftRoot } = options;
+
+  // 2. Resolve latest draft pointer
+  const pointer = await resolveLatestPointer(draftRoot);
+  const sourceDraftPath = pointer.path;
+
+  // 3. Read safety report from the draft
+  const safetyStatus = await readSafetyStatus(sourceDraftPath);
+
+  // 4. Enforce safety policy
+  enforceSafetyPolicy(safetyStatus);
+
+  // 5. Collect carousel PNGs
+  const carouselPngs = await collectCarouselPngs(sourceDraftPath);
+
+  // 6. Create export folder
+  const exportDir = join(
+    draftRoot,
+    "exports",
+    "instagram",
+    pointer.targetDate,
+    pointer.revision
+  );
+  await createExportDir(exportDir);
+
+  // 7. Copy files
+  const exportedFiles: string[] = [];
+
+  await copyCaptionTxt(sourceDraftPath, exportDir, exportedFiles);
+  await copyCarouselPngs(sourceDraftPath, carouselPngs, exportDir, exportedFiles);
+
+  // 8. Write export metadata.json
+  await writeExportMetadata(exportDir, {
+    schemaVersion: 1,
+    sourceDraftPath,
+    exportedAt,
+    safetyStatus,
+    exportedFiles: [...exportedFiles, "metadata.json"]
+  });
+  exportedFiles.push("metadata.json");
+
+  return {
+    exportDir,
+    exportedFiles,
+    safetyStatus,
+    sourceDraftPath,
+    exportedAt
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Safety policy helpers (extended in UNC-94)
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a warning message when the safety status is "warning", or undefined
+ * when safe. Throws ExportCommandError for "blocked".
+ *
+ * This is intentionally a small, isolated function so UNC-94 can wrap it.
+ */
+export function checkSafetyPolicy(
+  safetyStatus: SafetyStatus,
+  warningReason?: string
+): { warningMessage?: string } {
+  if (safetyStatus === "blocked") {
+    throw new ExportCommandError(
+      "Export blocked: draft contains sensitive content. Review safety-report.json.",
+      "safety-blocked"
+    );
+  }
+
+  if (safetyStatus === "warning") {
+    const reason = warningReason ?? "Review redacted content before posting.";
+    return { warningMessage: `Safety warning: ${reason}` };
+  }
+
+  return {};
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function validateArgs(args: string[]): void {
+  const [subcommand, target] = args;
+
+  if (subcommand !== "instagram") {
+    throw new ExportCommandError(USAGE, "invalid-arguments");
+  }
+
+  if (target !== undefined && target !== "latest") {
+    throw new ExportCommandError(USAGE, "invalid-arguments");
+  }
+}
+
+async function resolveLatestPointer(draftRoot: string) {
+  try {
+    return await readLatestDraftPointer(draftRoot);
+  } catch {
+    throw new ExportCommandError(
+      "No latest draft found. Run `uncommitted generate today` and `uncommitted render latest` first.",
+      "missing-draft"
+    );
+  }
+}
+
+async function readSafetyStatus(sourceDraftPath: string): Promise<SafetyStatus> {
+  const { readFile } = await import("node:fs/promises");
+  try {
+    const raw = await readFile(join(sourceDraftPath, "safety-report.json"), "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+
+    if (
+      isRecord(parsed) &&
+      (parsed.status === "safe" ||
+        parsed.status === "warning" ||
+        parsed.status === "blocked")
+    ) {
+      return parsed.status as SafetyStatus;
+    }
+  } catch {
+    // If no safety report, treat as safe for scaffold (UNC-94 adds strict policy)
+  }
+
+  return "safe";
+}
+
+function enforceSafetyPolicy(safetyStatus: SafetyStatus): void {
+  // Scaffold: only block "blocked" status. UNC-94 adds warning output.
+  if (safetyStatus === "blocked") {
+    throw new ExportCommandError(
+      "Export blocked: draft contains sensitive content. Review safety-report.json.",
+      "safety-blocked"
+    );
+  }
+}
+
+async function collectCarouselPngs(sourceDraftPath: string): Promise<string[]> {
+  const carouselDir = join(sourceDraftPath, "carousel");
+
+  try {
+    const entries = await readdir(carouselDir);
+    const pngs = entries
+      .filter((e) => e.endsWith(".png"))
+      .sort();
+
+    if (pngs.length === 0) {
+      throw new ExportCommandError(
+        "No carousel PNGs found. Run `uncommitted render latest` first.",
+        "missing-carousel"
+      );
+    }
+
+    return pngs;
+  } catch (error) {
+    if (error instanceof ExportCommandError) {
+      throw error;
+    }
+
+    throw new ExportCommandError(
+      "No carousel PNGs found. Run `uncommitted render latest` first.",
+      "missing-carousel"
+    );
+  }
+}
+
+async function createExportDir(exportDir: string): Promise<void> {
+  try {
+    await mkdir(exportDir, { recursive: true });
+  } catch {
+    throw new ExportCommandError(
+      "Could not create export folder.",
+      "export-failed"
+    );
+  }
+}
+
+async function copyCaptionTxt(
+  sourceDraftPath: string,
+  exportDir: string,
+  exportedFiles: string[]
+): Promise<void> {
+  const src = join(sourceDraftPath, "caption.txt");
+  const dst = join(exportDir, "caption.txt");
+
+  try {
+    await copyFile(src, dst);
+    exportedFiles.push("caption.txt");
+  } catch {
+    throw new ExportCommandError(
+      "caption.txt is missing from the draft.",
+      "export-failed"
+    );
+  }
+}
+
+async function copyCarouselPngs(
+  sourceDraftPath: string,
+  carouselPngs: string[],
+  exportDir: string,
+  exportedFiles: string[]
+): Promise<void> {
+  for (let i = 0; i < carouselPngs.length; i++) {
+    const srcName = carouselPngs[i];
+    const dstName = `carousel-${String(i + 1).padStart(2, "0")}.png`;
+    const src = join(sourceDraftPath, "carousel", srcName);
+    const dst = join(exportDir, dstName);
+
+    try {
+      await copyFile(src, dst);
+      exportedFiles.push(dstName);
+    } catch {
+      throw new ExportCommandError(
+        `Carousel file ${srcName} could not be copied.`,
+        "export-failed"
+      );
+    }
+  }
+}
+
+async function writeExportMetadata(
+  exportDir: string,
+  metadata: ExportMetadata
+): Promise<void> {
+  try {
+    await writeFile(
+      join(exportDir, "metadata.json"),
+      `${JSON.stringify(metadata, null, 2)}\n`,
+      "utf8"
+    );
+  } catch {
+    throw new ExportCommandError(
+      "Could not write export metadata.",
+      "export-failed"
+    );
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/tests/export-command.test.ts
+++ b/tests/export-command.test.ts
@@ -212,3 +212,157 @@ describe("export-command (UNC-92: scaffold)", () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// UNC-94: Safety policy (safe / warning / blocked)
+// ---------------------------------------------------------------------------
+
+async function scaffoldDraftWithSafety(
+  draftRoot: string,
+  safetyStatus: "safe" | "warning" | "blocked",
+  warningReason?: string
+): Promise<void> {
+  const targetDate = "2026-05-18";
+  const revision = "rev-001";
+  const outputDir = join(draftRoot, targetDate, revision);
+  await mkdir(join(outputDir, "carousel"), { recursive: true });
+
+  await writeFile(join(outputDir, "caption.txt"), "Caption text.\n", "utf8");
+  await writeFile(
+    join(outputDir, "metadata.json"),
+    JSON.stringify({ schemaVersion: 1, targetDate }, null, 2) + "\n",
+    "utf8"
+  );
+  await writeFile(join(outputDir, "carousel", "01.png"), "FAKE_PNG");
+
+  const message =
+    safetyStatus === "blocked"
+      ? "Remove blocked sensitive content."
+      : safetyStatus === "warning"
+        ? warningReason ?? "Review redactions before export."
+        : "Safety check passed.";
+
+  await writeFile(
+    join(outputDir, "safety-report.json"),
+    JSON.stringify({
+      schemaVersion: 1,
+      status: safetyStatus,
+      risks: safetyStatus !== "safe"
+        ? [{ category: "secret", severity: safetyStatus, message }]
+        : [],
+      redactionsApplied: [],
+      exportAllowed: safetyStatus !== "blocked",
+      message
+    }, null, 2) + "\n",
+    "utf8"
+  );
+
+  const pointer = {
+    schemaVersion: 1,
+    targetDate,
+    revision,
+    path: outputDir,
+    updatedAt: "2026-05-18T23:30:00.000Z"
+  };
+  await writeFile(
+    join(draftRoot, "latest.json"),
+    JSON.stringify(pointer, null, 2) + "\n",
+    "utf8"
+  );
+  await writeFile(
+    join(draftRoot, targetDate, "latest.json"),
+    JSON.stringify(pointer, null, 2) + "\n",
+    "utf8"
+  );
+}
+
+describe("export-command (UNC-94: safety policy)", () => {
+  it("safe draft exports with no warning and safetyStatus 'safe' in metadata", async () => {
+    const draftRoot = await createTempDir();
+    await scaffoldDraftWithSafety(draftRoot, "safe");
+
+    const result = await runExportCommand(["instagram"], {
+      draftRoot,
+      now: () => "2026-05-18T23:35:00.000Z"
+    });
+
+    expect(result.safetyStatus).toBe("safe");
+    expect(result.warningMessage).toBeUndefined();
+
+    const meta = JSON.parse(
+      await readFile(join(result.exportDir, "metadata.json"), "utf8")
+    ) as Record<string, unknown>;
+    expect(meta.safetyStatus).toBe("safe");
+  });
+
+  it("warning draft exports successfully and returns a warning message with reason", async () => {
+    const draftRoot = await createTempDir();
+    await scaffoldDraftWithSafety(draftRoot, "warning", "Review redactions before export.");
+
+    const result = await runExportCommand(["instagram"], {
+      draftRoot,
+      now: () => "2026-05-18T23:35:00.000Z"
+    });
+
+    expect(result.safetyStatus).toBe("warning");
+    expect(result.warningMessage).toBeDefined();
+    expect(result.warningMessage).toContain("Review redactions before export.");
+    expect(result.exportedFiles).toContain("caption.txt");
+
+    const meta = JSON.parse(
+      await readFile(join(result.exportDir, "metadata.json"), "utf8")
+    ) as Record<string, unknown>;
+    expect(meta.safetyStatus).toBe("warning");
+  });
+
+  it("blocked draft throws ExportCommandError with safety-blocked code", async () => {
+    const draftRoot = await createTempDir();
+    await scaffoldDraftWithSafety(draftRoot, "blocked");
+
+    await expect(
+      runExportCommand(["instagram"], {
+        draftRoot,
+        now: () => "2026-05-18T23:35:00.000Z"
+      })
+    ).rejects.toThrow(ExportCommandError);
+
+    try {
+      await runExportCommand(["instagram"], {
+        draftRoot,
+        now: () => "2026-05-18T23:35:00.000Z"
+      });
+    } catch (err) {
+      expect(err).toBeInstanceOf(ExportCommandError);
+      expect((err as ExportCommandError).code).toBe("safety-blocked");
+    }
+  });
+
+  it("blocked draft does not create an export folder", async () => {
+    const draftRoot = await createTempDir();
+    await scaffoldDraftWithSafety(draftRoot, "blocked");
+
+    try {
+      await runExportCommand(["instagram"], { draftRoot });
+    } catch {
+      // expected
+    }
+
+    const exportBase = join(draftRoot, "exports", "instagram");
+    await expect(readdir(exportBase)).rejects.toThrow();
+  });
+
+  it("exported metadata.json includes safetyStatus for warning drafts", async () => {
+    const draftRoot = await createTempDir();
+    await scaffoldDraftWithSafety(draftRoot, "warning", "Possible secret detected.");
+
+    const result = await runExportCommand(["instagram"], {
+      draftRoot,
+      now: () => "2026-05-18T23:35:00.000Z"
+    });
+
+    const meta = JSON.parse(
+      await readFile(join(result.exportDir, "metadata.json"), "utf8")
+    ) as Record<string, unknown>;
+    expect(meta.safetyStatus).toBe("warning");
+  });
+});

--- a/tests/export-command.test.ts
+++ b/tests/export-command.test.ts
@@ -1,0 +1,214 @@
+import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  runExportCommand,
+  ExportCommandError
+} from "../src/export-command.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function createTempDir(): Promise<string> {
+  const base = join(tmpdir(), `unc-export-test-${randomUUID()}`);
+  await mkdir(base, { recursive: true });
+  return base;
+}
+
+/**
+ * Build a minimal draft revision on disk and write the latest.json pointer.
+ * Returns the draftRoot and the revision output directory path.
+ */
+async function scaffoldDraft(
+  draftRoot: string,
+  opts: {
+    targetDate?: string;
+    revision?: string;
+    carouselCount?: number;
+    captionText?: string;
+  } = {}
+): Promise<{ outputDir: string; targetDate: string; revision: string }> {
+  const targetDate = opts.targetDate ?? "2026-05-18";
+  const revision = opts.revision ?? "rev-001";
+  const carouselCount = opts.carouselCount ?? 2;
+  const captionText = opts.captionText ?? "Today was productive.\n";
+
+  const outputDir = join(draftRoot, targetDate, revision);
+  await mkdir(join(outputDir, "carousel"), { recursive: true });
+
+  // Write draft files
+  await writeFile(join(outputDir, "caption.txt"), captionText, "utf8");
+  await writeFile(
+    join(outputDir, "metadata.json"),
+    JSON.stringify({ schemaVersion: 1, targetDate, revision }, null, 2) + "\n",
+    "utf8"
+  );
+  await writeFile(
+    join(outputDir, "safety-report.json"),
+    JSON.stringify({
+      schemaVersion: 1,
+      status: "safe",
+      risks: [],
+      redactionsApplied: [],
+      exportAllowed: true,
+      message: "Safety check passed."
+    }, null, 2) + "\n",
+    "utf8"
+  );
+
+  // Write carousel PNGs (fake binary content)
+  for (let i = 1; i <= carouselCount; i++) {
+    const pad = String(i).padStart(2, "0");
+    await writeFile(join(outputDir, "carousel", `${pad}.png`), `FAKE_PNG_${i}`);
+  }
+
+  // Write latest.json pointer
+  const pointer = {
+    schemaVersion: 1,
+    targetDate,
+    revision,
+    path: outputDir,
+    updatedAt: "2026-05-18T23:30:00.000Z"
+  };
+  await writeFile(
+    join(draftRoot, "latest.json"),
+    JSON.stringify(pointer, null, 2) + "\n",
+    "utf8"
+  );
+  await writeFile(
+    join(draftRoot, targetDate, "latest.json"),
+    JSON.stringify(pointer, null, 2) + "\n",
+    "utf8"
+  );
+
+  return { outputDir, targetDate, revision };
+}
+
+// ---------------------------------------------------------------------------
+// UNC-92: Happy path — scaffold export instagram CLI
+// ---------------------------------------------------------------------------
+
+describe("export-command (UNC-92: scaffold)", () => {
+  it("exports a safe draft to a predictable export folder", async () => {
+    const draftRoot = await createTempDir();
+    await scaffoldDraft(draftRoot, { carouselCount: 3 });
+
+    const result = await runExportCommand(["instagram"], {
+      draftRoot,
+      now: () => "2026-05-18T23:35:00.000Z"
+    });
+
+    expect(result.exportDir).toContain("exports/instagram");
+    expect(result.exportedFiles).toContain("caption.txt");
+    expect(result.exportedFiles).toContain("carousel-01.png");
+    expect(result.exportedFiles).toContain("carousel-02.png");
+    expect(result.exportedFiles).toContain("carousel-03.png");
+    expect(result.exportedFiles).toContain("metadata.json");
+  });
+
+  it("copies caption.txt verbatim to export folder", async () => {
+    const draftRoot = await createTempDir();
+    await scaffoldDraft(draftRoot, { captionText: "My caption\n" });
+
+    const result = await runExportCommand(["instagram"], {
+      draftRoot,
+      now: () => "2026-05-18T23:35:00.000Z"
+    });
+
+    const exported = await readFile(join(result.exportDir, "caption.txt"), "utf8");
+    expect(exported).toBe("My caption\n");
+  });
+
+  it("copies carousel PNGs with zero-padded upload-friendly names", async () => {
+    const draftRoot = await createTempDir();
+    await scaffoldDraft(draftRoot, { carouselCount: 2 });
+
+    const result = await runExportCommand(["instagram"], {
+      draftRoot,
+      now: () => "2026-05-18T23:35:00.000Z"
+    });
+
+    const png1 = await readFile(join(result.exportDir, "carousel-01.png"));
+    const png2 = await readFile(join(result.exportDir, "carousel-02.png"));
+    expect(png1.toString()).toBe("FAKE_PNG_1");
+    expect(png2.toString()).toBe("FAKE_PNG_2");
+  });
+
+  it("writes metadata.json with source path, timestamp, safety status, and file list", async () => {
+    const draftRoot = await createTempDir();
+    const { outputDir } = await scaffoldDraft(draftRoot);
+
+    const result = await runExportCommand(["instagram"], {
+      draftRoot,
+      now: () => "2026-05-18T23:35:00.000Z"
+    });
+
+    const meta = JSON.parse(
+      await readFile(join(result.exportDir, "metadata.json"), "utf8")
+    ) as Record<string, unknown>;
+
+    expect(meta.sourceDraftPath).toBe(outputDir);
+    expect(meta.exportedAt).toBe("2026-05-18T23:35:00.000Z");
+    expect(meta.safetyStatus).toBe("safe");
+    expect(Array.isArray(meta.exportedFiles)).toBe(true);
+    expect((meta.exportedFiles as string[])).toContain("caption.txt");
+  });
+
+  it("does not modify source draft files", async () => {
+    const draftRoot = await createTempDir();
+    const { outputDir } = await scaffoldDraft(draftRoot, { captionText: "Original\n" });
+
+    await runExportCommand(["instagram"], {
+      draftRoot,
+      now: () => "2026-05-18T23:35:00.000Z"
+    });
+
+    const caption = await readFile(join(outputDir, "caption.txt"), "utf8");
+    expect(caption).toBe("Original\n");
+    // Source directory should have the same files as before (no extra files)
+    const srcFiles = await readdir(outputDir);
+    expect(srcFiles).not.toContain("carousel-01.png");
+  });
+
+  it("returns export folder path distinct from source draft path", async () => {
+    const draftRoot = await createTempDir();
+    const { outputDir } = await scaffoldDraft(draftRoot);
+
+    const result = await runExportCommand(["instagram"], {
+      draftRoot,
+      now: () => "2026-05-18T23:35:00.000Z"
+    });
+
+    expect(result.exportDir).not.toBe(outputDir);
+    expect(result.exportDir).toContain(draftRoot);
+  });
+
+  it("accepts 'instagram latest' alias", async () => {
+    const draftRoot = await createTempDir();
+    await scaffoldDraft(draftRoot);
+
+    const result = await runExportCommand(["instagram", "latest"], {
+      draftRoot,
+      now: () => "2026-05-18T23:35:00.000Z"
+    });
+
+    expect(result.exportedFiles).toContain("caption.txt");
+  });
+
+  it("throws ExportCommandError with invalid-arguments for unknown subcommand", async () => {
+    const draftRoot = await createTempDir();
+    await expect(
+      runExportCommand(["twitter"], { draftRoot })
+    ).rejects.toThrow(ExportCommandError);
+
+    try {
+      await runExportCommand(["twitter"], { draftRoot });
+    } catch (err) {
+      expect(err).toBeInstanceOf(ExportCommandError);
+      expect((err as ExportCommandError).code).toBe("invalid-arguments");
+    }
+  });
+});

--- a/tests/export-command.test.ts
+++ b/tests/export-command.test.ts
@@ -276,6 +276,187 @@ async function scaffoldDraftWithSafety(
   );
 }
 
+// ---------------------------------------------------------------------------
+// UNC-95: Error handling — missing draft / missing carousel
+// ---------------------------------------------------------------------------
+
+describe("export-command (UNC-95: error handling)", () => {
+  it("throws missing-draft when latest.json is absent", async () => {
+    const draftRoot = await createTempDir();
+    // No draft scaffolded — latest.json does not exist
+
+    try {
+      await runExportCommand(["instagram"], { draftRoot });
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ExportCommandError);
+      expect((err as ExportCommandError).code).toBe("missing-draft");
+      expect((err as ExportCommandError).message).toContain("render latest");
+    }
+  });
+
+  it("error message for missing draft tells user what to run next", async () => {
+    const draftRoot = await createTempDir();
+
+    try {
+      await runExportCommand(["instagram"], { draftRoot });
+    } catch (err) {
+      const msg = (err as ExportCommandError).message;
+      // Should reference generate or render step
+      expect(msg.toLowerCase()).toMatch(/generate|render/);
+    }
+  });
+
+  it("throws missing-carousel when carousel directory is absent", async () => {
+    const draftRoot = await createTempDir();
+    // Scaffold draft WITHOUT carousel directory
+    const targetDate = "2026-05-18";
+    const revision = "rev-001";
+    const outputDir = join(draftRoot, targetDate, revision);
+    await mkdir(outputDir, { recursive: true });
+
+    await writeFile(join(outputDir, "caption.txt"), "Caption.\n", "utf8");
+    await writeFile(
+      join(outputDir, "safety-report.json"),
+      JSON.stringify({
+        schemaVersion: 1,
+        status: "safe",
+        risks: [],
+        redactionsApplied: [],
+        exportAllowed: true,
+        message: "Safety check passed."
+      }, null, 2) + "\n",
+      "utf8"
+    );
+
+    const pointer = {
+      schemaVersion: 1,
+      targetDate,
+      revision,
+      path: outputDir,
+      updatedAt: "2026-05-18T23:30:00.000Z"
+    };
+    await writeFile(
+      join(draftRoot, "latest.json"),
+      JSON.stringify(pointer, null, 2) + "\n",
+      "utf8"
+    );
+    await writeFile(
+      join(draftRoot, targetDate, "latest.json"),
+      JSON.stringify(pointer, null, 2) + "\n",
+      "utf8"
+    );
+
+    try {
+      await runExportCommand(["instagram"], { draftRoot });
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ExportCommandError);
+      expect((err as ExportCommandError).code).toBe("missing-carousel");
+      expect((err as ExportCommandError).message).toContain("render latest");
+    }
+  });
+
+  it("throws missing-carousel when carousel directory exists but has no PNGs", async () => {
+    const draftRoot = await createTempDir();
+    const targetDate = "2026-05-18";
+    const revision = "rev-001";
+    const outputDir = join(draftRoot, targetDate, revision);
+    await mkdir(join(outputDir, "carousel"), { recursive: true });
+    // carousel dir is empty — no PNGs at all
+
+    await writeFile(join(outputDir, "caption.txt"), "Caption.\n", "utf8");
+    await writeFile(
+      join(outputDir, "safety-report.json"),
+      JSON.stringify({
+        schemaVersion: 1,
+        status: "safe",
+        risks: [],
+        redactionsApplied: [],
+        exportAllowed: true,
+        message: "Safety check passed."
+      }, null, 2) + "\n",
+      "utf8"
+    );
+
+    const pointer = {
+      schemaVersion: 1,
+      targetDate,
+      revision,
+      path: outputDir,
+      updatedAt: "2026-05-18T23:30:00.000Z"
+    };
+    await writeFile(
+      join(draftRoot, "latest.json"),
+      JSON.stringify(pointer, null, 2) + "\n",
+      "utf8"
+    );
+    await writeFile(
+      join(draftRoot, targetDate, "latest.json"),
+      JSON.stringify(pointer, null, 2) + "\n",
+      "utf8"
+    );
+
+    try {
+      await runExportCommand(["instagram"], { draftRoot });
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ExportCommandError);
+      expect((err as ExportCommandError).code).toBe("missing-carousel");
+    }
+  });
+
+  it("does not create an export folder when carousel is missing", async () => {
+    const draftRoot = await createTempDir();
+    const targetDate = "2026-05-18";
+    const revision = "rev-001";
+    const outputDir = join(draftRoot, targetDate, revision);
+    await mkdir(outputDir, { recursive: true });
+    // No carousel directory
+
+    await writeFile(join(outputDir, "caption.txt"), "Caption.\n", "utf8");
+    await writeFile(
+      join(outputDir, "safety-report.json"),
+      JSON.stringify({
+        schemaVersion: 1,
+        status: "safe",
+        risks: [],
+        redactionsApplied: [],
+        exportAllowed: true,
+        message: "Safety check passed."
+      }, null, 2) + "\n",
+      "utf8"
+    );
+
+    const pointer = {
+      schemaVersion: 1,
+      targetDate,
+      revision,
+      path: outputDir,
+      updatedAt: "2026-05-18T23:30:00.000Z"
+    };
+    await writeFile(
+      join(draftRoot, "latest.json"),
+      JSON.stringify(pointer, null, 2) + "\n",
+      "utf8"
+    );
+    await writeFile(
+      join(draftRoot, targetDate, "latest.json"),
+      JSON.stringify(pointer, null, 2) + "\n",
+      "utf8"
+    );
+
+    try {
+      await runExportCommand(["instagram"], { draftRoot });
+    } catch {
+      // expected
+    }
+
+    const exportBase = join(draftRoot, "exports", "instagram");
+    await expect(readdir(exportBase)).rejects.toThrow();
+  });
+});
+
 describe("export-command (UNC-94: safety policy)", () => {
   it("safe draft exports with no warning and safetyStatus 'safe' in metadata", async () => {
     const draftRoot = await createTempDir();

--- a/tests/export-command.test.ts
+++ b/tests/export-command.test.ts
@@ -547,3 +547,163 @@ describe("export-command (UNC-94: safety policy)", () => {
     expect(meta.safetyStatus).toBe("warning");
   });
 });
+
+// ---------------------------------------------------------------------------
+// UNC-96: Idempotency — re-run safety and metadata correctness
+// ---------------------------------------------------------------------------
+
+describe("export-command (UNC-96: idempotency)", () => {
+  it("re-running on the same draft overwrites export cleanly (metadata reflects new timestamp)", async () => {
+    const draftRoot = await createTempDir();
+    await scaffoldDraft(draftRoot);
+
+    // First run
+    await runExportCommand(["instagram"], {
+      draftRoot,
+      now: () => "2026-05-18T23:00:00.000Z"
+    });
+
+    // Second run — same draft, different timestamp
+    const result2 = await runExportCommand(["instagram"], {
+      draftRoot,
+      now: () => "2026-05-18T23:35:00.000Z"
+    });
+
+    const meta = JSON.parse(
+      await readFile(join(result2.exportDir, "metadata.json"), "utf8")
+    ) as Record<string, unknown>;
+
+    // metadata.json must reflect the SECOND export's timestamp
+    expect(meta.exportedAt).toBe("2026-05-18T23:35:00.000Z");
+  });
+
+  it("re-run on the same draft does not corrupt the source draft", async () => {
+    const draftRoot = await createTempDir();
+    await scaffoldDraft(draftRoot, { captionText: "Original caption\n" });
+
+    await runExportCommand(["instagram"], {
+      draftRoot,
+      now: () => "2026-05-18T23:00:00.000Z"
+    });
+    await runExportCommand(["instagram"], {
+      draftRoot,
+      now: () => "2026-05-18T23:35:00.000Z"
+    });
+
+    // Source caption must be unchanged
+    const sourceCaption = await readFile(
+      join(draftRoot, "2026-05-18", "rev-001", "caption.txt"),
+      "utf8"
+    );
+    expect(sourceCaption).toBe("Original caption\n");
+  });
+
+  it("re-run after revision advances creates a new export path, leaves old export untouched", async () => {
+    const draftRoot = await createTempDir();
+
+    // First draft: rev-001
+    await scaffoldDraft(draftRoot, {
+      revision: "rev-001",
+      captionText: "Day one\n"
+    });
+    const result1 = await runExportCommand(["instagram"], {
+      draftRoot,
+      now: () => "2026-05-18T23:00:00.000Z"
+    });
+
+    // Second draft: rev-002 — update latest.json to point to rev-002
+    const targetDate = "2026-05-18";
+    const rev2Dir = join(draftRoot, targetDate, "rev-002");
+    await mkdir(join(rev2Dir, "carousel"), { recursive: true });
+    await writeFile(join(rev2Dir, "caption.txt"), "Day two\n", "utf8");
+    await writeFile(
+      join(rev2Dir, "safety-report.json"),
+      JSON.stringify({
+        schemaVersion: 1,
+        status: "safe",
+        risks: [],
+        redactionsApplied: [],
+        exportAllowed: true,
+        message: "Safety check passed."
+      }, null, 2) + "\n",
+      "utf8"
+    );
+    await writeFile(join(rev2Dir, "carousel", "01.png"), "PNG_V2");
+
+    const pointer2 = {
+      schemaVersion: 1,
+      targetDate,
+      revision: "rev-002",
+      path: rev2Dir,
+      updatedAt: "2026-05-18T23:20:00.000Z"
+    };
+    await writeFile(
+      join(draftRoot, "latest.json"),
+      JSON.stringify(pointer2, null, 2) + "\n",
+      "utf8"
+    );
+
+    const result2 = await runExportCommand(["instagram"], {
+      draftRoot,
+      now: () => "2026-05-18T23:35:00.000Z"
+    });
+
+    // Different export dirs
+    expect(result2.exportDir).not.toBe(result1.exportDir);
+
+    // Old export caption still unchanged
+    const oldCaption = await readFile(join(result1.exportDir, "caption.txt"), "utf8");
+    expect(oldCaption).toBe("Day one\n");
+
+    // New export has new caption
+    const newCaption = await readFile(join(result2.exportDir, "caption.txt"), "utf8");
+    expect(newCaption).toBe("Day two\n");
+  });
+
+  it("re-run after partial export folder deletion succeeds and recreates all files", async () => {
+    const draftRoot = await createTempDir();
+    await scaffoldDraft(draftRoot, { carouselCount: 2 });
+
+    // First run
+    const result1 = await runExportCommand(["instagram"], {
+      draftRoot,
+      now: () => "2026-05-18T23:00:00.000Z"
+    });
+
+    // Simulate partial deletion: remove carousel-01.png from export
+    const { unlink } = await import("node:fs/promises");
+    await unlink(join(result1.exportDir, "carousel-01.png"));
+
+    // Re-run should recreate everything
+    const result2 = await runExportCommand(["instagram"], {
+      draftRoot,
+      now: () => "2026-05-18T23:35:00.000Z"
+    });
+
+    // Same export dir (same revision)
+    expect(result2.exportDir).toBe(result1.exportDir);
+
+    // carousel-01.png recreated
+    const png1 = await readFile(join(result2.exportDir, "carousel-01.png"));
+    expect(png1.toString()).toBe("FAKE_PNG_1");
+
+    // metadata.json updated
+    const meta = JSON.parse(
+      await readFile(join(result2.exportDir, "metadata.json"), "utf8")
+    ) as Record<string, unknown>;
+    expect(meta.exportedAt).toBe("2026-05-18T23:35:00.000Z");
+  });
+
+  it("export folder path uses date and revision for disambiguation", async () => {
+    const draftRoot = await createTempDir();
+    await scaffoldDraft(draftRoot, { targetDate: "2026-05-18", revision: "rev-001" });
+
+    const result = await runExportCommand(["instagram"], {
+      draftRoot,
+      now: () => "2026-05-18T23:35:00.000Z"
+    });
+
+    expect(result.exportDir).toContain("2026-05-18");
+    expect(result.exportDir).toContain("rev-001");
+  });
+});

--- a/tests/export-command.test.ts
+++ b/tests/export-command.test.ts
@@ -137,9 +137,9 @@ describe("export-command (UNC-92: scaffold)", () => {
     expect(png2.toString()).toBe("FAKE_PNG_2");
   });
 
-  it("writes metadata.json with source path, timestamp, safety status, and file list", async () => {
+  it("writes metadata.json with date, revision, timestamp, safety status, and file list", async () => {
     const draftRoot = await createTempDir();
-    const { outputDir } = await scaffoldDraft(draftRoot);
+    await scaffoldDraft(draftRoot, { targetDate: "2026-05-18", revision: "rev-001" });
 
     const result = await runExportCommand(["instagram"], {
       draftRoot,
@@ -150,7 +150,9 @@ describe("export-command (UNC-92: scaffold)", () => {
       await readFile(join(result.exportDir, "metadata.json"), "utf8")
     ) as Record<string, unknown>;
 
-    expect(meta.sourceDraftPath).toBe(outputDir);
+    expect(meta.draftDate).toBe("2026-05-18");
+    expect(meta.draftRevision).toBe("rev-001");
+    expect(meta.sourceDraftPath).toBeUndefined();
     expect(meta.exportedAt).toBe("2026-05-18T23:35:00.000Z");
     expect(meta.safetyStatus).toBe("safe");
     expect(Array.isArray(meta.exportedFiles)).toBe(true);


### PR DESCRIPTION
🤖 **Auto-generated by Uncommitted Builder (Routine B)**

## Parent issue
[UNC-78: feat: implement export instagram command](https://linear.app/sangchu/issue/UNC-78/feat-implement-export-instagram-command)

## Sub-issues progress

- [x] UNC-92: scaffold `export instagram` CLI and copy latest draft to local export folder (✅ done 2026-05-19)
- [x] UNC-94: apply MVP safety policy (safe / warning / blocked) (✅ done 2026-05-19)
- [x] UNC-95: handle missing latest draft and missing carousel files (✅ done 2026-05-19)
- [x] UNC-96: make re-runs idempotent and verify metadata correctness (✅ done 2026-05-19)

## Status

- Branch: `claude/UNC-78-implement-export-instagram`
- Tests: ✅ passing (23/23 new export tests, 195/197 total — 2 pre-existing Playwright smoke failures unrelated to this PR)
- Build: ✅ pnpm build clean
- Type check: ✅ clean
- Lint: ✅ clean

## TDD trail

UNC-92:
- Attempt 1: ✅ success on first try (8/8 tests green)

UNC-94:
- Attempt 1: ✅ success on first try (5 new tests, 13/13 total green)

UNC-95:
- Attempt 1: ✅ success on first try (5 new tests, 18/18 total green)

UNC-96:
- Attempt 1: ✅ success on first try (5 new tests, 23/23 total green)

## Idempotency strategy

Re-running `export instagram` **overwrites** the same `exports/instagram/YYYY-MM-DD/rev-XXX/` folder cleanly. The source draft is never modified. Unrelated export folders (other dates/revisions) are never touched. This is documented in the CLI success output.

## Notes

No new environment variables or dependencies added.

Export is strictly local-only. No Instagram/Meta API or auto-publish code introduced.

## Review checklist

- [ ] Review each sub-issue's commits separately
- [ ] Verify TDD test coverage (23 vitest tests)
- [ ] Confirm no lockfile changes (none — lockfile unchanged)
- [ ] Run `pnpm install && pnpm test && pnpm build` locally
- [ ] Confirm no auto-publish code introduced
- [ ] macOS behavior verified (cross-platform fallbacks OK to defer)

---
이 PR은 자동 생성되었습니다. 머지 전 사람의 리뷰가 반드시 필요합니다.