### PR TITLE
🤖 Feedback Command 추가 (UNC-98)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -424,16 +424,77 @@ async function runFeedback(
   io: CliIo,
   options: CliOptions
 ): Promise<number> {
-  const [subcommand = "latest"] = args;
+  // Parse args: `feedback [latest] [--date YYYY-MM-DD] [--fun N] [--share N]
+  //   [--accuracy N] [--would-post] [--safety-concern] [--reasons a,b]
+  //   [--note "..."] [--yes]`
+  const [maybeSubcommand, ...rest] = args;
+  const subcommand =
+    maybeSubcommand && !maybeSubcommand.startsWith("-")
+      ? maybeSubcommand
+      : "latest";
+  const flagArgs = maybeSubcommand?.startsWith("-")
+    ? [maybeSubcommand, ...rest]
+    : rest;
+
+  let targetDate: string | undefined;
+  let fun: number | undefined;
+  let share: number | undefined;
+  let accuracy: number | undefined;
+  let safetyConcern: boolean | undefined;
+  let wouldPost: boolean | undefined;
+  let reasons: string[] | undefined;
+  let note: string | undefined;
+  let yes = false;
+  let hasNonInteractiveFlag = false;
+
+  for (let i = 0; i < flagArgs.length; i++) {
+    const flag = flagArgs[i];
+
+    if (flag === "--date" && i + 1 < flagArgs.length) {
+      targetDate = flagArgs[++i];
+    } else if (flag === "--fun" && i + 1 < flagArgs.length) {
+      fun = Number(flagArgs[++i]);
+      hasNonInteractiveFlag = true;
+    } else if (flag === "--share" && i + 1 < flagArgs.length) {
+      share = Number(flagArgs[++i]);
+      hasNonInteractiveFlag = true;
+    } else if (flag === "--accuracy" && i + 1 < flagArgs.length) {
+      accuracy = Number(flagArgs[++i]);
+      hasNonInteractiveFlag = true;
+    } else if (flag === "--would-post") {
+      wouldPost = true;
+      hasNonInteractiveFlag = true;
+    } else if (flag === "--safety-concern") {
+      safetyConcern = true;
+      hasNonInteractiveFlag = true;
+    } else if (flag === "--reasons" && i + 1 < flagArgs.length) {
+      reasons = flagArgs[++i].split(",").map((r) => r.trim()).filter(Boolean);
+      hasNonInteractiveFlag = true;
+    } else if (flag === "--note" && i + 1 < flagArgs.length) {
+      note = flagArgs[++i];
+      hasNonInteractiveFlag = true;
+    } else if (flag === "--yes" || flag === "-y") {
+      yes = true;
+      hasNonInteractiveFlag = true;
+    }
+  }
+
   const paths = resolveConfigPaths({ homeDir: options.homeDir });
   const draftRoot = options.draftRoot ?? paths.defaultDraftRoot;
   const evalsDir = paths.evalsDir;
   const prompter = options.feedbackPrompter ?? createReadlinePrompter();
 
   return runFeedbackCommand(
-    { subcommand },
+    { subcommand, targetDate },
     io,
-    { draftRoot, evalsDir, prompter }
+    {
+      draftRoot,
+      evalsDir,
+      prompter,
+      nonInteractive: hasNonInteractiveFlag
+        ? { fun, share, accuracy, safetyConcern, wouldPost, reasons, note, yes }
+        : undefined
+    }
   );
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -424,9 +424,9 @@ async function runFeedback(
   io: CliIo,
   options: CliOptions
 ): Promise<number> {
-  // Parse args: `feedback [latest] [--date YYYY-MM-DD] [--fun N] [--share N]
-  //   [--accuracy N] [--would-post] [--safety-concern] [--reasons a,b]
-  //   [--note "..."] [--yes]`
+  // Parse args: `feedback [latest|report] [--date YYYY-MM-DD] [--days N]
+  //   [--fun N] [--share N] [--accuracy N] [--would-post] [--safety-concern]
+  //   [--reasons a,b] [--note "..."] [--yes]`
   const [maybeSubcommand, ...rest] = args;
   const subcommand =
     maybeSubcommand && !maybeSubcommand.startsWith("-")
@@ -437,6 +437,7 @@ async function runFeedback(
     : rest;
 
   let targetDate: string | undefined;
+  let days: number | undefined;
   let fun: number | undefined;
   let share: number | undefined;
   let accuracy: number | undefined;
@@ -452,6 +453,8 @@ async function runFeedback(
 
     if (flag === "--date" && i + 1 < flagArgs.length) {
       targetDate = flagArgs[++i];
+    } else if (flag === "--days" && i + 1 < flagArgs.length) {
+      days = parseInt(flagArgs[++i], 10);
     } else if (flag === "--fun" && i + 1 < flagArgs.length) {
       fun = Number(flagArgs[++i]);
       hasNonInteractiveFlag = true;
@@ -485,7 +488,7 @@ async function runFeedback(
   const prompter = options.feedbackPrompter ?? createReadlinePrompter();
 
   return runFeedbackCommand(
-    { subcommand, targetDate },
+    { subcommand, targetDate, days },
     io,
     {
       draftRoot,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -454,7 +454,13 @@ async function runFeedback(
     if (flag === "--date" && i + 1 < flagArgs.length) {
       targetDate = flagArgs[++i];
     } else if (flag === "--days" && i + 1 < flagArgs.length) {
-      days = parseInt(flagArgs[++i], 10);
+      const rawDays = flagArgs[++i];
+      const parsedDays = parseInt(rawDays, 10);
+      if (!Number.isInteger(parsedDays) || parsedDays < 1) {
+        io.stderr(`--days must be a positive integer, got: ${rawDays}`);
+        return 1;
+      }
+      days = parsedDays;
     } else if (flag === "--fun" && i + 1 < flagArgs.length) {
       fun = Number(flagArgs[++i]);
       hasNonInteractiveFlag = true;
@@ -483,22 +489,33 @@ async function runFeedback(
   }
 
   const paths = resolveConfigPaths({ homeDir: options.homeDir });
-  const draftRoot = options.draftRoot ?? paths.defaultDraftRoot;
+  const draftRoot = options.draftRoot ?? await readPreviewDraftRoot(paths.configFile, options.homeDir);
   const evalsDir = paths.evalsDir;
-  const prompter = options.feedbackPrompter ?? createReadlinePrompter();
+  // Only create readline for 'latest'; 'report' never uses interactive prompts
+  const prompter = options.feedbackPrompter ?? (subcommand === "latest" ? createReadlinePrompter() : {
+    askScores: async (): Promise<never> => { throw new Error("prompter not available"); },
+    askBooleans: async (): Promise<never> => { throw new Error("prompter not available"); },
+    askReasons: async (): Promise<never> => { throw new Error("prompter not available"); },
+    askNote: async (): Promise<never> => { throw new Error("prompter not available"); },
+    confirmOverwrite: async (): Promise<never> => { throw new Error("prompter not available"); },
+  });
 
-  return runFeedbackCommand(
-    { subcommand, targetDate, days },
-    io,
-    {
-      draftRoot,
-      evalsDir,
-      prompter,
-      nonInteractive: hasNonInteractiveFlag
-        ? { fun, share, accuracy, safetyConcern, wouldPost, reasons, note, yes }
-        : undefined
-    }
-  );
+  try {
+    return await runFeedbackCommand(
+      { subcommand, targetDate, days },
+      io,
+      {
+        draftRoot,
+        evalsDir,
+        prompter,
+        nonInteractive: hasNonInteractiveFlag
+          ? { fun, share, accuracy, safetyConcern, wouldPost, reasons, note, yes }
+          : undefined
+      }
+    );
+  } finally {
+    prompter.close?.();
+  }
 }
 
 function isCliNodeError(error: unknown): error is NodeJS.ErrnoException {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -47,6 +47,11 @@ import {
 } from "./scheduler.js";
 import { runScheduleStatus } from "./schedule-status-command.js";
 import { runScheduleRemove } from "./schedule-remove-command.js";
+import {
+  createReadlinePrompter,
+  runFeedbackCommand,
+  type FeedbackPrompter
+} from "./feedback-command.js";
 import type { CarouselHtmlToPngRenderer } from "./carousel-renderer.js";
 import type { ImageAssetProvider } from "./visual-assets.js";
 
@@ -66,6 +71,8 @@ export type CliOptions = {
   schedulerExecutor?: LaunchctlExecutor;
   /** Injectable structured launchctl runner for status/remove (tests). */
   schedulerRunner?: LaunchctlRawRunner;
+  /** Injectable prompter for feedback command (tests). */
+  feedbackPrompter?: FeedbackPrompter;
 };
 
 const defaultIo: CliIo = {
@@ -166,6 +173,10 @@ export async function runCli(
 
   if (command === "schedule") {
     return await runSchedule(commandArgs, io, options);
+  }
+
+  if (command === "feedback") {
+    return await runFeedback(commandArgs, io, options);
   }
 
   io.stderr(`Command not implemented yet: ${command}`);
@@ -406,6 +417,24 @@ async function readPreviewDraftRoot(
     }
   }
   return resolveConfigPaths({ homeDir }).defaultDraftRoot;
+}
+
+async function runFeedback(
+  args: string[],
+  io: CliIo,
+  options: CliOptions
+): Promise<number> {
+  const [subcommand = "latest"] = args;
+  const paths = resolveConfigPaths({ homeDir: options.homeDir });
+  const draftRoot = options.draftRoot ?? paths.defaultDraftRoot;
+  const evalsDir = paths.evalsDir;
+  const prompter = options.feedbackPrompter ?? createReadlinePrompter();
+
+  return runFeedbackCommand(
+    { subcommand },
+    io,
+    { draftRoot, evalsDir, prompter }
+  );
 }
 
 function isCliNodeError(error: unknown): error is NodeJS.ErrnoException {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -13,7 +13,8 @@ export const commands: Command[] = [
   { name: "render", summary: "Render draft cards." },
   { name: "preview", summary: "Preview a draft." },
   { name: "export", summary: "Export draft assets." },
-  { name: "schedule", summary: "Manage the macOS schedule." }
+  { name: "schedule", summary: "Manage the macOS schedule." },
+  { name: "feedback", summary: "Record feedback on a draft." }
 ];
 
 export function isKnownCommand(name: string): boolean {

--- a/src/config-paths.ts
+++ b/src/config-paths.ts
@@ -16,6 +16,7 @@ export type ConfigPaths = {
   globalDraftsDir: string;
   logsDir: string;
   defaultDraftRoot: string;
+  evalsDir: string;
   requiredDirectories: string[];
 };
 
@@ -40,6 +41,8 @@ export function resolveConfigPaths(options: ConfigPathOptions = {}): ConfigPaths
     homeDir
   );
 
+  const evalsDir = resolvePath("~/Uncommitted/evals", homeDir);
+
   const paths = {
     configDir,
     configFile: join(configDir, "config.json"),
@@ -48,7 +51,8 @@ export function resolveConfigPaths(options: ConfigPathOptions = {}): ConfigPaths
     formatHistoryFile: join(historyDir, "formats.json"),
     globalDraftsDir: join(configDir, "drafts"),
     logsDir: join(configDir, "logs"),
-    defaultDraftRoot
+    defaultDraftRoot,
+    evalsDir
   };
 
   return {

--- a/src/feedback-command.ts
+++ b/src/feedback-command.ts
@@ -1,7 +1,13 @@
-import { readFile } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { createInterface } from "node:readline";
-import { FEEDBACK_REASONS, type FeedbackReason, type FeedbackRecord } from "./feedback-types.js";
+import {
+  FEEDBACK_REASONS,
+  isFeedbackReason,
+  isValidScore,
+  type FeedbackReason,
+  type FeedbackRecord
+} from "./feedback-types.js";
 import { saveFeedback } from "./feedback-storage.js";
 import { readLatestDraftPointer, DraftStorageError } from "./draft-storage.js";
 import type { CliIo } from "./cli.js";
@@ -121,6 +127,22 @@ export function createReadlinePrompter(): FeedbackPrompter {
 }
 
 // ---------------------------------------------------------------------------
+// Non-interactive input type (all flags from CLI)
+// ---------------------------------------------------------------------------
+
+export type NonInteractiveInput = {
+  fun?: number;
+  share?: number;
+  accuracy?: number;
+  safetyConcern?: boolean;
+  wouldPost?: boolean;
+  reasons?: string[];
+  note?: string;
+  /** When true, automatically confirm overwrite without prompting */
+  yes?: boolean;
+};
+
+// ---------------------------------------------------------------------------
 // runFeedbackCommand options
 // ---------------------------------------------------------------------------
 
@@ -134,6 +156,8 @@ export type FeedbackCommandOptions = {
   evalsDir: string;
   prompter: FeedbackPrompter;
   now?: () => string;
+  /** When provided, skip interactive prompts and use these values */
+  nonInteractive?: NonInteractiveInput;
 };
 
 // ---------------------------------------------------------------------------
@@ -146,7 +170,7 @@ export async function runFeedbackCommand(
   options: FeedbackCommandOptions
 ): Promise<number> {
   if (input.subcommand === "latest") {
-    return runFeedbackLatest(io, options);
+    return runFeedbackLatest(input, io, options);
   }
 
   io.stderr(
@@ -156,34 +180,63 @@ export async function runFeedbackCommand(
 }
 
 async function runFeedbackLatest(
+  input: FeedbackCommandInput,
   io: CliIo,
   options: FeedbackCommandOptions
 ): Promise<number> {
-  // 1. Resolve latest draft pointer
+  // 1. Validate non-interactive input early (before hitting the filesystem)
+  if (options.nonInteractive) {
+    const validationError = validateNonInteractiveInput(options.nonInteractive);
+    if (validationError) {
+      io.stderr(validationError);
+      return 1;
+    }
+  }
+
+  // 2. Resolve draft directory
   let targetDate: string;
   let revision: string;
   let outputDir: string;
 
-  try {
-    const pointer = await readLatestDraftPointer(options.draftRoot);
-    targetDate = pointer.targetDate;
-    revision = pointer.revision;
-    outputDir = pointer.path;
-  } catch (error) {
-    if (error instanceof DraftStorageError) {
+  if (input.targetDate) {
+    // Resolve the latest revision for the specific date
+    const result = await resolveLatestRevForDate(
+      options.draftRoot,
+      input.targetDate
+    );
+
+    if (!result) {
       io.stderr(
-        "No latest draft found. Run `uncommitted generate today` first."
+        `No draft found for ${input.targetDate}. Run \`uncommitted generate --date ${input.targetDate}\` first.`
       );
       return 1;
     }
 
-    throw error;
+    targetDate = input.targetDate;
+    revision = result.revision;
+    outputDir = result.outputDir;
+  } else {
+    try {
+      const pointer = await readLatestDraftPointer(options.draftRoot);
+      targetDate = pointer.targetDate;
+      revision = pointer.revision;
+      outputDir = pointer.path;
+    } catch (error) {
+      if (error instanceof DraftStorageError) {
+        io.stderr(
+          "No latest draft found. Run `uncommitted generate today` first."
+        );
+        return 1;
+      }
+
+      throw error;
+    }
   }
 
-  // 2. Read story.json for formatName / activityLevel
+  // 3. Read story.json for formatName / activityLevel
   const storyMeta = await readStoryMeta(outputDir);
 
-  // 3. Display draft metadata
+  // 4. Display draft metadata
   io.stdout(`Draft: ${targetDate} / ${revision}`);
 
   if (storyMeta.formatName) {
@@ -196,32 +249,52 @@ async function runFeedbackLatest(
 
   io.stdout("");
 
-  // 4. Collect feedback interactively
-  const scores = await options.prompter.askScores();
-  const booleans = await options.prompter.askBooleans();
-  const reasons = await options.prompter.askReasons();
-  const note = await options.prompter.askNote();
-
+  // 5. Collect feedback — either non-interactive or interactive
+  let record: FeedbackRecord;
   const createdAt = options.now ? options.now() : new Date().toISOString();
 
-  const record: FeedbackRecord = {
-    date: targetDate,
-    revision,
-    formatName: storyMeta.formatName ?? "",
-    fun: clampScore(scores.fun),
-    share: clampScore(scores.share),
-    accuracy: clampScore(scores.accuracy),
-    safetyConcern: booleans.safetyConcern,
-    wouldPost: booleans.wouldPost,
-    reasons: reasons.filter(isFeedbackReason),
-    note,
-    createdAt
-  };
+  if (options.nonInteractive) {
+    const ni = options.nonInteractive;
+    record = {
+      date: targetDate,
+      revision,
+      formatName: storyMeta.formatName ?? "",
+      fun: clampScore(ni.fun!),
+      share: clampScore(ni.share!),
+      accuracy: clampScore(ni.accuracy!),
+      safetyConcern: ni.safetyConcern ?? false,
+      wouldPost: ni.wouldPost ?? false,
+      reasons: (ni.reasons ?? []).filter(isFeedbackReason) as FeedbackReason[],
+      note: ni.note ?? "",
+      createdAt
+    };
 
-  // 5. Save
-  await saveFeedback(record, outputDir, options.evalsDir, {
-    confirmOverwrite: options.prompter.confirmOverwrite
-  });
+    const confirmOverwrite = ni.yes ? async () => true : options.prompter.confirmOverwrite;
+    await saveFeedback(record, outputDir, options.evalsDir, { confirmOverwrite });
+  } else {
+    const scores = await options.prompter.askScores();
+    const booleans = await options.prompter.askBooleans();
+    const reasons = await options.prompter.askReasons();
+    const note = await options.prompter.askNote();
+
+    record = {
+      date: targetDate,
+      revision,
+      formatName: storyMeta.formatName ?? "",
+      fun: clampScore(scores.fun),
+      share: clampScore(scores.share),
+      accuracy: clampScore(scores.accuracy),
+      safetyConcern: booleans.safetyConcern,
+      wouldPost: booleans.wouldPost,
+      reasons: reasons.filter(isFeedbackReason) as FeedbackReason[],
+      note,
+      createdAt
+    };
+
+    await saveFeedback(record, outputDir, options.evalsDir, {
+      confirmOverwrite: options.prompter.confirmOverwrite
+    });
+  }
 
   io.stdout(`\nFeedback saved for ${targetDate} / ${revision}.`);
   return 0;
@@ -230,6 +303,85 @@ async function runFeedbackLatest(
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Validate non-interactive input. Returns an error string if invalid, else null.
+ */
+function validateNonInteractiveInput(ni: NonInteractiveInput): string | null {
+  if (ni.fun === undefined || ni.fun === null) {
+    return "--fun is required in non-interactive mode. Pass --fun 1-5.";
+  }
+
+  if (!isValidScore(ni.fun)) {
+    return `--fun must be an integer between 1 and 5, got: ${String(ni.fun)}`;
+  }
+
+  if (ni.share === undefined || ni.share === null) {
+    return "--share is required in non-interactive mode. Pass --share 1-5.";
+  }
+
+  if (!isValidScore(ni.share)) {
+    return `--share must be an integer between 1 and 5, got: ${String(ni.share)}`;
+  }
+
+  if (ni.accuracy === undefined || ni.accuracy === null) {
+    return "--accuracy is required in non-interactive mode. Pass --accuracy 1-5.";
+  }
+
+  if (!isValidScore(ni.accuracy)) {
+    return `--accuracy must be an integer between 1 and 5, got: ${String(ni.accuracy)}`;
+  }
+
+  if (ni.reasons) {
+    for (const reason of ni.reasons) {
+      if (!isFeedbackReason(reason)) {
+        return `Invalid reason: "${reason}". Valid reasons: ${FEEDBACK_REASONS.join(", ")}`;
+      }
+    }
+  }
+
+  return null;
+}
+
+type RevisionResult = {
+  revision: string;
+  outputDir: string;
+};
+
+/**
+ * Find the highest revision under draftRoot/targetDate/.
+ * Returns null if no revisions exist.
+ */
+async function resolveLatestRevForDate(
+  draftRoot: string,
+  targetDate: string
+): Promise<RevisionResult | null> {
+  const dateDir = join(draftRoot, targetDate);
+
+  try {
+    const entries = await readdir(dateDir);
+    const revisions = entries
+      .filter((e) => /^rev-\d{3}$/.test(e))
+      .sort((a, b) => b.localeCompare(a)); // descending
+
+    if (revisions.length === 0) {
+      return null;
+    }
+
+    const revision = revisions[0];
+    return { revision, outputDir: join(dateDir, revision) };
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return null;
+    }
+
+    throw error;
+  }
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}
 
 type StoryMeta = {
   formatName?: string;
@@ -258,10 +410,6 @@ async function readStoryMeta(outputDir: string): Promise<StoryMeta> {
 function clampScore(value: number): 1 | 2 | 3 | 4 | 5 {
   const clamped = Math.max(1, Math.min(5, Math.round(value)));
   return clamped as 1 | 2 | 3 | 4 | 5;
-}
-
-function isFeedbackReason(value: string): value is FeedbackReason {
-  return (FEEDBACK_REASONS as readonly string[]).includes(value);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/feedback-command.ts
+++ b/src/feedback-command.ts
@@ -1,0 +1,269 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { createInterface } from "node:readline";
+import { FEEDBACK_REASONS, type FeedbackReason, type FeedbackRecord } from "./feedback-types.js";
+import { saveFeedback } from "./feedback-storage.js";
+import { readLatestDraftPointer, DraftStorageError } from "./draft-storage.js";
+import type { CliIo } from "./cli.js";
+
+// ---------------------------------------------------------------------------
+// FeedbackPrompter abstraction (injectable for tests)
+// ---------------------------------------------------------------------------
+
+export type FeedbackScoreAnswers = {
+  fun: number;
+  share: number;
+  accuracy: number;
+};
+
+export type FeedbackBooleanAnswers = {
+  safetyConcern: boolean;
+  wouldPost: boolean;
+};
+
+export type FeedbackPrompter = {
+  askScores: () => Promise<FeedbackScoreAnswers>;
+  askBooleans: () => Promise<FeedbackBooleanAnswers>;
+  askReasons: () => Promise<string[]>;
+  askNote: () => Promise<string>;
+  confirmOverwrite: () => Promise<boolean>;
+};
+
+// ---------------------------------------------------------------------------
+// Readline-backed default prompter
+// ---------------------------------------------------------------------------
+
+export function createReadlinePrompter(): FeedbackPrompter {
+  const rl = createInterface({
+    input: process.stdin,
+    output: process.stdout
+  });
+
+  function ask(question: string): Promise<string> {
+    return new Promise((resolve) => {
+      rl.question(question, (answer) => resolve(answer.trim()));
+    });
+  }
+
+  async function askScore(name: string): Promise<number> {
+    while (true) {
+      const raw = await ask(`${name} (1-5): `);
+      const value = parseInt(raw, 10);
+
+      if (Number.isInteger(value) && value >= 1 && value <= 5) {
+        return value;
+      }
+
+      process.stdout.write("Enter an integer between 1 and 5.\n");
+    }
+  }
+
+  async function askYesNo(question: string): Promise<boolean> {
+    while (true) {
+      const raw = await ask(`${question} (y/n): `);
+      const lower = raw.toLowerCase();
+
+      if (lower === "y" || lower === "yes") return true;
+      if (lower === "n" || lower === "no") return false;
+
+      process.stdout.write("Enter y or n.\n");
+    }
+  }
+
+  return {
+    async askScores(): Promise<FeedbackScoreAnswers> {
+      const fun = await askScore("Fun score");
+      const share = await askScore("Share score");
+      const accuracy = await askScore("Accuracy score");
+
+      rl.close();
+      return { fun, share, accuracy };
+    },
+
+    async askBooleans(): Promise<FeedbackBooleanAnswers> {
+      const safetyConcern = await askYesNo("Safety concern?");
+      const wouldPost = await askYesNo("Would post to Instagram?");
+
+      return { safetyConcern, wouldPost };
+    },
+
+    async askReasons(): Promise<string[]> {
+      process.stdout.write("\nWhat was wrong? (comma-separated numbers, or blank for none)\n");
+      FEEDBACK_REASONS.forEach((r, i) => {
+        process.stdout.write(`  ${String(i + 1).padStart(2)}. ${r}\n`);
+      });
+
+      const raw = await ask("Select: ");
+
+      if (!raw) return [];
+
+      const selected: FeedbackReason[] = [];
+
+      for (const part of raw.split(",")) {
+        const idx = parseInt(part.trim(), 10) - 1;
+
+        if (idx >= 0 && idx < FEEDBACK_REASONS.length) {
+          selected.push(FEEDBACK_REASONS[idx]);
+        }
+      }
+
+      return selected;
+    },
+
+    async askNote(): Promise<string> {
+      return ask("Note (optional): ");
+    },
+
+    async confirmOverwrite(): Promise<boolean> {
+      return askYesNo("Feedback already exists. Overwrite?");
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// runFeedbackCommand options
+// ---------------------------------------------------------------------------
+
+export type FeedbackCommandInput = {
+  subcommand: string;
+  targetDate?: string;
+};
+
+export type FeedbackCommandOptions = {
+  draftRoot: string;
+  evalsDir: string;
+  prompter: FeedbackPrompter;
+  now?: () => string;
+};
+
+// ---------------------------------------------------------------------------
+// Core command logic
+// ---------------------------------------------------------------------------
+
+export async function runFeedbackCommand(
+  input: FeedbackCommandInput,
+  io: CliIo,
+  options: FeedbackCommandOptions
+): Promise<number> {
+  if (input.subcommand === "latest") {
+    return runFeedbackLatest(io, options);
+  }
+
+  io.stderr(
+    `Usage: uncommitted feedback <latest|report> [options]`
+  );
+  return 1;
+}
+
+async function runFeedbackLatest(
+  io: CliIo,
+  options: FeedbackCommandOptions
+): Promise<number> {
+  // 1. Resolve latest draft pointer
+  let targetDate: string;
+  let revision: string;
+  let outputDir: string;
+
+  try {
+    const pointer = await readLatestDraftPointer(options.draftRoot);
+    targetDate = pointer.targetDate;
+    revision = pointer.revision;
+    outputDir = pointer.path;
+  } catch (error) {
+    if (error instanceof DraftStorageError) {
+      io.stderr(
+        "No latest draft found. Run `uncommitted generate today` first."
+      );
+      return 1;
+    }
+
+    throw error;
+  }
+
+  // 2. Read story.json for formatName / activityLevel
+  const storyMeta = await readStoryMeta(outputDir);
+
+  // 3. Display draft metadata
+  io.stdout(`Draft: ${targetDate} / ${revision}`);
+
+  if (storyMeta.formatName) {
+    io.stdout(`Format: ${storyMeta.formatName}`);
+  }
+
+  if (storyMeta.activityLevel) {
+    io.stdout(`Activity Level: ${storyMeta.activityLevel}`);
+  }
+
+  io.stdout("");
+
+  // 4. Collect feedback interactively
+  const scores = await options.prompter.askScores();
+  const booleans = await options.prompter.askBooleans();
+  const reasons = await options.prompter.askReasons();
+  const note = await options.prompter.askNote();
+
+  const createdAt = options.now ? options.now() : new Date().toISOString();
+
+  const record: FeedbackRecord = {
+    date: targetDate,
+    revision,
+    formatName: storyMeta.formatName ?? "",
+    fun: clampScore(scores.fun),
+    share: clampScore(scores.share),
+    accuracy: clampScore(scores.accuracy),
+    safetyConcern: booleans.safetyConcern,
+    wouldPost: booleans.wouldPost,
+    reasons: reasons.filter(isFeedbackReason),
+    note,
+    createdAt
+  };
+
+  // 5. Save
+  await saveFeedback(record, outputDir, options.evalsDir, {
+    confirmOverwrite: options.prompter.confirmOverwrite
+  });
+
+  io.stdout(`\nFeedback saved for ${targetDate} / ${revision}.`);
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type StoryMeta = {
+  formatName?: string;
+  activityLevel?: string;
+};
+
+async function readStoryMeta(outputDir: string): Promise<StoryMeta> {
+  try {
+    const raw = await readFile(join(outputDir, "story.json"), "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+
+    if (isRecord(parsed)) {
+      return {
+        formatName: typeof parsed.formatName === "string" ? parsed.formatName : undefined,
+        activityLevel:
+          typeof parsed.activityLevel === "string" ? parsed.activityLevel : undefined
+      };
+    }
+  } catch {
+    // story.json missing or unparseable — non-fatal, proceed without metadata
+  }
+
+  return {};
+}
+
+function clampScore(value: number): 1 | 2 | 3 | 4 | 5 {
+  const clamped = Math.max(1, Math.min(5, Math.round(value)));
+  return clamped as 1 | 2 | 3 | 4 | 5;
+}
+
+function isFeedbackReason(value: string): value is FeedbackReason {
+  return (FEEDBACK_REASONS as readonly string[]).includes(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/src/feedback-command.ts
+++ b/src/feedback-command.ts
@@ -34,6 +34,7 @@ export type FeedbackPrompter = {
   askReasons: () => Promise<string[]>;
   askNote: () => Promise<string>;
   confirmOverwrite: () => Promise<boolean>;
+  close?: () => void;
 };
 
 // ---------------------------------------------------------------------------
@@ -83,7 +84,6 @@ export function createReadlinePrompter(): FeedbackPrompter {
       const share = await askScore("Share score");
       const accuracy = await askScore("Accuracy score");
 
-      rl.close();
       return { fun, share, accuracy };
     },
 
@@ -123,6 +123,10 @@ export function createReadlinePrompter(): FeedbackPrompter {
 
     async confirmOverwrite(): Promise<boolean> {
       return askYesNo("Feedback already exists. Overwrite?");
+    },
+
+    close(): void {
+      rl.close();
     }
   };
 }
@@ -217,6 +221,11 @@ async function runFeedbackLatest(
   let outputDir: string;
 
   if (input.targetDate) {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(input.targetDate)) {
+      io.stderr(`--date must be in YYYY-MM-DD format, got: ${input.targetDate}`);
+      return 1;
+    }
+
     // Resolve the latest revision for the specific date
     const result = await resolveLatestRevForDate(
       options.draftRoot,

--- a/src/feedback-command.ts
+++ b/src/feedback-command.ts
@@ -10,6 +10,7 @@ import {
 } from "./feedback-types.js";
 import { saveFeedback } from "./feedback-storage.js";
 import { readLatestDraftPointer, DraftStorageError } from "./draft-storage.js";
+import { aggregateFeedback, formatFeedbackReport } from "./feedback-report.js";
 import type { CliIo } from "./cli.js";
 
 // ---------------------------------------------------------------------------
@@ -149,6 +150,8 @@ export type NonInteractiveInput = {
 export type FeedbackCommandInput = {
   subcommand: string;
   targetDate?: string;
+  /** For `report` subcommand: number of days to aggregate */
+  days?: number;
 };
 
 export type FeedbackCommandOptions = {
@@ -173,10 +176,25 @@ export async function runFeedbackCommand(
     return runFeedbackLatest(input, io, options);
   }
 
+  if (input.subcommand === "report") {
+    return runFeedbackReport(input, io, options);
+  }
+
   io.stderr(
     `Usage: uncommitted feedback <latest|report> [options]`
   );
   return 1;
+}
+
+async function runFeedbackReport(
+  input: FeedbackCommandInput,
+  io: CliIo,
+  options: FeedbackCommandOptions
+): Promise<number> {
+  const days = input.days ?? 7;
+  const agg = await aggregateFeedback(options.evalsDir, days);
+  io.stdout(formatFeedbackReport(agg));
+  return 0;
 }
 
 async function runFeedbackLatest(

--- a/src/feedback-report.ts
+++ b/src/feedback-report.ts
@@ -1,0 +1,341 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { FEEDBACK_REASONS, REASON_PROMPT_AREA_MAP, type FeedbackReason } from "./feedback-types.js";
+
+const JSONL_FILENAME = "daily-feedback.jsonl";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type ReasonCount = {
+  reason: FeedbackReason;
+  count: number;
+};
+
+export type FormatSummary = {
+  formatName: string;
+  averageFun: number;
+  averageShare: number;
+};
+
+export type FeedbackAggregate = {
+  days: number;
+  totalDrafts: number;
+  averageFun: number | null;
+  averageShare: number | null;
+  averageAccuracy: number | null;
+  wouldPostCount: number;
+  topReasons: ReasonCount[];
+  bestFormats: FormatSummary[];
+  recommendedWork: string[];
+};
+
+// ---------------------------------------------------------------------------
+// JSONL row shape (as stored by feedback-storage)
+// ---------------------------------------------------------------------------
+
+type JsonlRow = {
+  date: string;
+  revision: string;
+  formatName: string;
+  fun: number;
+  share: number;
+  accuracy: number;
+  wouldPost: boolean;
+  reasons: string[];
+  note: string;
+};
+
+// ---------------------------------------------------------------------------
+// aggregateFeedback
+// ---------------------------------------------------------------------------
+
+/**
+ * Read ~/Uncommitted/evals/daily-feedback.jsonl, filter to entries within
+ * the last `days` days (inclusive, from `referenceDate`), and aggregate.
+ *
+ * @param evalsDir   Directory containing daily-feedback.jsonl
+ * @param days       Number of days window (default 7)
+ * @param referenceDate ISO date string "YYYY-MM-DD" (defaults to today)
+ */
+export async function aggregateFeedback(
+  evalsDir: string,
+  days = 7,
+  referenceDate?: string
+): Promise<FeedbackAggregate> {
+  const cutoffDate = computeCutoffDate(referenceDate ?? todayIso(), days);
+  const rows = await readFilteredRows(evalsDir, cutoffDate, referenceDate ?? todayIso());
+
+  return computeAggregate(rows, days);
+}
+
+// ---------------------------------------------------------------------------
+// formatFeedbackReport
+// ---------------------------------------------------------------------------
+
+/**
+ * Format an aggregate as human-readable text matching the spec.
+ */
+export function formatFeedbackReport(agg: FeedbackAggregate): string {
+  const lines: string[] = [];
+
+  lines.push(`Feedback report: last ${agg.days} drafts`);
+  lines.push("");
+
+  if (agg.totalDrafts === 0) {
+    lines.push(`No feedback found in the last ${agg.days} days. Submit feedback with \`uncommitted feedback latest\`.`);
+    return lines.join("\n");
+  }
+
+  // Average scores
+  lines.push("Average scores:");
+  lines.push(`- Fun: ${fmt(agg.averageFun)} / 5`);
+  lines.push(`- Share: ${fmt(agg.averageShare)} / 5`);
+  lines.push(`- Accuracy: ${fmt(agg.averageAccuracy)} / 5`);
+  lines.push("");
+
+  // Would post
+  lines.push("Would post:");
+  lines.push(`- ${agg.wouldPostCount} / ${agg.totalDrafts} drafts`);
+  lines.push("");
+
+  // Top issues
+  if (agg.topReasons.length > 0) {
+    lines.push("Top issues:");
+    for (const { reason, count } of agg.topReasons) {
+      lines.push(`- ${reason}: ${count}`);
+    }
+    lines.push("");
+  }
+
+  // Best performing formats
+  if (agg.bestFormats.length > 0) {
+    lines.push("Best performing formats:");
+    for (const { formatName, averageFun, averageShare } of agg.bestFormats) {
+      lines.push(`- ${formatName}: fun ${fmt(averageFun)}, share ${fmt(averageShare)}`);
+    }
+    lines.push("");
+  }
+
+  // Recommended next prompt work
+  if (agg.recommendedWork.length > 0) {
+    lines.push("Recommended next prompt work:");
+    agg.recommendedWork.forEach((item, idx) => {
+      lines.push(`${idx + 1}. ${item}`);
+    });
+  }
+
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/**
+ * Compute the inclusive lower-bound date given a reference date and window.
+ * e.g. referenceDate=2026-05-19, days=7 → cutoff=2026-05-13
+ */
+function computeCutoffDate(referenceDate: string, days: number): string {
+  const ref = new Date(`${referenceDate}T00:00:00.000Z`);
+  ref.setUTCDate(ref.getUTCDate() - (days - 1));
+  return ref.toISOString().slice(0, 10);
+}
+
+async function readFilteredRows(
+  evalsDir: string,
+  cutoffDate: string,
+  referenceDate: string
+): Promise<JsonlRow[]> {
+  const jsonlPath = join(evalsDir, JSONL_FILENAME);
+
+  let text: string;
+
+  try {
+    text = await readFile(jsonlPath, "utf8");
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return [];
+    }
+
+    throw error;
+  }
+
+  const rows: JsonlRow[] = [];
+
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+
+    if (!trimmed) continue;
+
+    try {
+      const parsed = JSON.parse(trimmed) as unknown;
+
+      if (isJsonlRow(parsed)) {
+        if (parsed.date >= cutoffDate && parsed.date <= referenceDate) {
+          rows.push(parsed);
+        }
+      }
+    } catch {
+      // Skip malformed lines
+    }
+  }
+
+  return rows;
+}
+
+function computeAggregate(rows: JsonlRow[], days: number): FeedbackAggregate {
+  if (rows.length === 0) {
+    return {
+      days,
+      totalDrafts: 0,
+      averageFun: null,
+      averageShare: null,
+      averageAccuracy: null,
+      wouldPostCount: 0,
+      topReasons: [],
+      bestFormats: [],
+      recommendedWork: []
+    };
+  }
+
+  const totalDrafts = rows.length;
+
+  // Averages
+  const averageFun = avg(rows.map((r) => r.fun));
+  const averageShare = avg(rows.map((r) => r.share));
+  const averageAccuracy = avg(rows.map((r) => r.accuracy));
+
+  // Would post
+  const wouldPostCount = rows.filter((r) => r.wouldPost).length;
+
+  // Top reasons
+  const reasonCounts = new Map<FeedbackReason, number>();
+
+  for (const row of rows) {
+    for (const reason of row.reasons) {
+      if (isFeedbackReason(reason)) {
+        reasonCounts.set(reason, (reasonCounts.get(reason) ?? 0) + 1);
+      }
+    }
+  }
+
+  const topReasons: ReasonCount[] = Array.from(reasonCounts.entries())
+    .map(([reason, count]) => ({ reason, count }))
+    .sort((a, b) => b.count - a.count || a.reason.localeCompare(b.reason));
+
+  // Best formats — group by formatName, compute avg fun/share
+  const formatMap = new Map<string, { funSum: number; shareSum: number; count: number }>();
+
+  for (const row of rows) {
+    const name = row.formatName || "(unnamed)";
+    const existing = formatMap.get(name) ?? { funSum: 0, shareSum: 0, count: 0 };
+    formatMap.set(name, {
+      funSum: existing.funSum + row.fun,
+      shareSum: existing.shareSum + row.share,
+      count: existing.count + 1
+    });
+  }
+
+  const bestFormats: FormatSummary[] = Array.from(formatMap.entries())
+    .map(([formatName, { funSum, shareSum, count }]) => ({
+      formatName,
+      averageFun: round1(funSum / count),
+      averageShare: round1(shareSum / count)
+    }))
+    .sort((a, b) => b.averageFun - a.averageFun || b.averageShare - a.averageShare);
+
+  // Recommended work — deduplicate prompt areas from top reasons
+  const seenAreas = new Set<string>();
+  const recommendedWork: string[] = [];
+
+  for (const { reason } of topReasons) {
+    const area = REASON_PROMPT_AREA_MAP[reason];
+
+    if (area && !seenAreas.has(area)) {
+      seenAreas.add(area);
+      recommendedWork.push(buildRecommendation(reason, area));
+    }
+  }
+
+  return {
+    days,
+    totalDrafts,
+    averageFun: round1(averageFun),
+    averageShare: round1(averageShare),
+    averageAccuracy: round1(averageAccuracy),
+    wouldPostCount,
+    topReasons,
+    bestFormats,
+    recommendedWork
+  };
+}
+
+function buildRecommendation(reason: FeedbackReason, area: string): string {
+  const verbs: Partial<Record<FeedbackReason, string>> = {
+    "too-report-like": "avoid report-like phrasing",
+    "too-generic": "add specificity constraints",
+    "repetitive-format": "add format novelty constraints",
+    "weak-caption": "add stronger caption examples",
+    "inaccurate": "improve accuracy constraints",
+    "hallucinated-work": "tighten factual constraints",
+    "too-harsh": "soften roast policy",
+    "not-instagram-like": "align with Instagram tone",
+    "card-overflow": "enforce length limits",
+    "safety-concern": "review safety rules",
+    "too-boring": "increase variety",
+    "too-long": "enforce brevity",
+    "awkward-roast": "refine persona voice",
+    "other": "review general quality"
+  };
+
+  const verb = verbs[reason] ?? "improve output quality";
+  return `Improve ${area} to ${verb}.`;
+}
+
+function avg(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((sum, v) => sum + v, 0) / values.length;
+}
+
+function round1(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+function fmt(value: number | null): string {
+  if (value === null) return "—";
+  return value.toFixed(1);
+}
+
+function isFeedbackReason(value: string): value is FeedbackReason {
+  return (FEEDBACK_REASONS as readonly string[]).includes(value);
+}
+
+function isJsonlRow(value: unknown): value is JsonlRow {
+  if (!isRecord(value)) return false;
+
+  return (
+    typeof value.date === "string" &&
+    typeof value.revision === "string" &&
+    typeof value.formatName === "string" &&
+    typeof value.fun === "number" &&
+    typeof value.share === "number" &&
+    typeof value.accuracy === "number" &&
+    typeof value.wouldPost === "boolean" &&
+    Array.isArray(value.reasons) &&
+    typeof value.note === "string"
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}

--- a/src/feedback-storage.ts
+++ b/src/feedback-storage.ts
@@ -36,10 +36,11 @@ export async function saveFeedback(
   const feedbackPath = join(draftDir, FEEDBACK_FILENAME);
   const shouldWrite = await shouldWriteFeedbackJson(feedbackPath, options);
 
-  if (shouldWrite) {
-    await writeFeedbackJson(feedbackPath, record);
+  if (!shouldWrite) {
+    return;
   }
 
+  await writeFeedbackJson(feedbackPath, record);
   await appendToJsonl(evalsDir, record);
 }
 

--- a/src/feedback-storage.ts
+++ b/src/feedback-storage.ts
@@ -1,0 +1,150 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { isFeedbackRecord, type FeedbackRecord } from "./feedback-types.js";
+
+const FEEDBACK_FILENAME = "feedback.json";
+const JSONL_FILENAME = "daily-feedback.jsonl";
+
+export type SaveFeedbackOptions = {
+  /**
+   * Called when feedback.json already exists in draftDir.
+   * Return true to overwrite, false to skip.
+   * When not provided, existing feedback is silently overwritten.
+   */
+  confirmOverwrite?: () => Promise<boolean>;
+};
+
+/**
+ * Save a FeedbackRecord to two locations:
+ * 1. `draftDir/feedback.json` — full record (atomic write)
+ * 2. `evalsDir/daily-feedback.jsonl` — one compact JSON line appended
+ *
+ * If feedback.json already exists, calls `options.confirmOverwrite()` before
+ * overwriting. Returns without writing to feedback.json (but still appends
+ * to JSONL) if the user denies.
+ *
+ * Directories are auto-created if missing.
+ */
+export async function saveFeedback(
+  record: FeedbackRecord,
+  draftDir: string,
+  evalsDir: string,
+  options: SaveFeedbackOptions = {}
+): Promise<void> {
+  await mkdir(evalsDir, { recursive: true });
+
+  const feedbackPath = join(draftDir, FEEDBACK_FILENAME);
+  const shouldWrite = await shouldWriteFeedbackJson(feedbackPath, options);
+
+  if (shouldWrite) {
+    await writeFeedbackJson(feedbackPath, record);
+  }
+
+  await appendToJsonl(evalsDir, record);
+}
+
+/**
+ * Read a previously saved FeedbackRecord from draftDir/feedback.json.
+ * Returns null if the file does not exist.
+ */
+export async function readFeedback(
+  draftDir: string
+): Promise<FeedbackRecord | null> {
+  const feedbackPath = join(draftDir, FEEDBACK_FILENAME);
+
+  try {
+    const text = await readFile(feedbackPath, "utf8");
+    const parsed = JSON.parse(text) as unknown;
+
+    if (isFeedbackRecord(parsed)) {
+      return parsed;
+    }
+
+    return null;
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return null;
+    }
+
+    throw error;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+async function shouldWriteFeedbackJson(
+  feedbackPath: string,
+  options: SaveFeedbackOptions
+): Promise<boolean> {
+  const exists = await fileExists(feedbackPath);
+
+  if (!exists) {
+    return true;
+  }
+
+  if (options.confirmOverwrite) {
+    return options.confirmOverwrite();
+  }
+
+  // No confirm callback → overwrite silently
+  return true;
+}
+
+async function writeFeedbackJson(
+  feedbackPath: string,
+  record: FeedbackRecord
+): Promise<void> {
+  const content = `${JSON.stringify(record, null, 2)}\n`;
+  await writeFile(feedbackPath, content, "utf8");
+}
+
+async function appendToJsonl(
+  evalsDir: string,
+  record: FeedbackRecord
+): Promise<void> {
+  const jsonlPath = join(evalsDir, JSONL_FILENAME);
+  const line = buildJsonlLine(record);
+
+  // Use append flag — creates file if missing
+  await writeFile(jsonlPath, `${line}\n`, { flag: "a", encoding: "utf8" });
+}
+
+/**
+ * Build the compact JSONL representation per spec:
+ * {date, revision, formatName, fun, share, accuracy, wouldPost, reasons, note}
+ * Note: safetyConcern and createdAt are omitted from the JSONL row per spec example.
+ */
+function buildJsonlLine(record: FeedbackRecord): string {
+  const row = {
+    date: record.date,
+    revision: record.revision,
+    formatName: record.formatName,
+    fun: record.fun,
+    share: record.share,
+    accuracy: record.accuracy,
+    wouldPost: record.wouldPost,
+    reasons: record.reasons,
+    note: record.note
+  };
+
+  return JSON.stringify(row);
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await readFile(path);
+    return true;
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return false;
+    }
+
+    throw error;
+  }
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}

--- a/src/feedback-types.ts
+++ b/src/feedback-types.ts
@@ -1,0 +1,137 @@
+/**
+ * Feedback domain types, reason enum, prompt-area mapping, and score validation.
+ * All other feedback modules depend on this foundational module.
+ */
+
+// ---------------------------------------------------------------------------
+// FeedbackReason
+// ---------------------------------------------------------------------------
+
+export const FEEDBACK_REASONS = [
+  "too-boring",
+  "too-report-like",
+  "too-long",
+  "too-generic",
+  "repetitive-format",
+  "inaccurate",
+  "hallucinated-work",
+  "weak-caption",
+  "awkward-roast",
+  "too-harsh",
+  "not-instagram-like",
+  "card-overflow",
+  "safety-concern",
+  "other"
+] as const;
+
+export type FeedbackReason = (typeof FEEDBACK_REASONS)[number];
+
+export function isFeedbackReason(value: unknown): value is FeedbackReason {
+  return (
+    typeof value === "string" &&
+    (FEEDBACK_REASONS as readonly string[]).includes(value)
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Reason → Prompt Area mapping
+// Per spec table in UNC-98 / UNC-99 description
+// ---------------------------------------------------------------------------
+
+export const REASON_PROMPT_AREA_MAP: Record<FeedbackReason, string> = {
+  "too-boring": "Diary Writer prompt",
+  "too-report-like": "Diary Writer prompt",
+  "too-long": "Writer length constraint",
+  "too-generic": "Story Inventor + Writer prompt",
+  "repetitive-format": "Story Inventor prompt + format history",
+  "inaccurate": "Activity Summary prompt",
+  "hallucinated-work": "Activity Summary + Writer constraints",
+  "weak-caption": "Caption prompt",
+  "awkward-roast": "Persona / roast level prompt",
+  "too-harsh": "Roast policy + Safety Reviewer",
+  "not-instagram-like": "Caption + slide copy prompt",
+  "card-overflow": "Writer length constraint + Renderer",
+  "safety-concern": "Safety Reviewer",
+  "other": "General review"
+};
+
+// ---------------------------------------------------------------------------
+// FeedbackRecord
+// ---------------------------------------------------------------------------
+
+export type FeedbackScore = 1 | 2 | 3 | 4 | 5;
+
+export type FeedbackRecord = {
+  /** ISO date string: YYYY-MM-DD */
+  date: string;
+  /** Revision identifier, e.g. "rev-001" */
+  revision: string;
+  /** Human-readable format name from story.json */
+  formatName: string;
+  /** Fun score 1–5 */
+  fun: FeedbackScore;
+  /** Share score 1–5 */
+  share: FeedbackScore;
+  /** Accuracy score 1–5 */
+  accuracy: FeedbackScore;
+  /** Whether user flagged a safety concern */
+  safetyConcern: boolean;
+  /** Whether user would post to Instagram */
+  wouldPost: boolean;
+  /** Selected reasons for negative feedback */
+  reasons: FeedbackReason[];
+  /** Free-text note */
+  note: string;
+  /** ISO timestamp when feedback was created */
+  createdAt: string;
+};
+
+// ---------------------------------------------------------------------------
+// Score validation
+// ---------------------------------------------------------------------------
+
+export function isValidScore(value: unknown): value is FeedbackScore {
+  return (
+    typeof value === "number" &&
+    Number.isInteger(value) &&
+    value >= 1 &&
+    value <= 5
+  );
+}
+
+export function validateScore(value: unknown, fieldName: string): void {
+  if (!isValidScore(value)) {
+    throw new RangeError(
+      `${fieldName} must be an integer between 1 and 5, got: ${String(value)}`
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Type guard
+// ---------------------------------------------------------------------------
+
+export function isFeedbackRecord(value: unknown): value is FeedbackRecord {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return (
+    typeof value.date === "string" &&
+    typeof value.revision === "string" &&
+    typeof value.formatName === "string" &&
+    isValidScore(value.fun) &&
+    isValidScore(value.share) &&
+    isValidScore(value.accuracy) &&
+    typeof value.safetyConcern === "boolean" &&
+    typeof value.wouldPost === "boolean" &&
+    Array.isArray(value.reasons) &&
+    value.reasons.every(isFeedbackReason) &&
+    typeof value.note === "string" &&
+    typeof value.createdAt === "string"
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/tests/feedback-command-date.test.ts
+++ b/tests/feedback-command-date.test.ts
@@ -1,0 +1,323 @@
+import { mkdir } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  runFeedbackCommand,
+  type FeedbackPrompter
+} from "../src/feedback-command.js";
+import {
+  createDraftRevision,
+  writeLatestDraftPointer,
+  writeDraftArtifactJson
+} from "../src/draft-storage.js";
+import { readFeedback } from "../src/feedback-storage.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTmpDir(): string {
+  return join(tmpdir(), `unc-feedback-date-test-${randomUUID()}`);
+}
+
+function createIo() {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+
+  return {
+    io: {
+      stdout: (message: string) => stdout.push(message),
+      stderr: (message: string) => stderr.push(message)
+    },
+    stdout,
+    stderr
+  };
+}
+
+function makePrompter(): FeedbackPrompter {
+  return {
+    askScores: async () => ({ fun: 4, share: 3, accuracy: 5 }),
+    askBooleans: async () => ({ safetyConcern: false, wouldPost: false }),
+    askReasons: async () => ["weak-caption"],
+    askNote: async () => "test note",
+    confirmOverwrite: async () => true
+  };
+}
+
+async function setupDraftForDate(
+  draftRoot: string,
+  targetDate: string,
+  formatName = "테스트 포맷"
+): Promise<string> {
+  const revision = await createDraftRevision({ draftRoot, targetDate });
+  await writeDraftArtifactJson(revision, "story.json", {
+    schemaVersion: 1,
+    formatName,
+    activityLevel: "medium"
+  });
+  await writeLatestDraftPointer(revision, new Date().toISOString());
+  return revision.outputDir;
+}
+
+// ---------------------------------------------------------------------------
+// Tests: --date option
+// ---------------------------------------------------------------------------
+
+describe("runFeedbackCommand with targetDate", () => {
+  it("targets the specified date's draft when --date is passed", async () => {
+    const { io } = createIo();
+    const draftRoot = makeTmpDir();
+    const evalsDir = makeTmpDir();
+    await mkdir(draftRoot, { recursive: true });
+
+    // Create drafts for two dates
+    const outputDir1 = await setupDraftForDate(draftRoot, "2026-05-17", "Older Format");
+    await setupDraftForDate(draftRoot, "2026-05-19", "Latest Format");
+
+    // Target the older date explicitly
+    const exitCode = await runFeedbackCommand(
+      { subcommand: "latest", targetDate: "2026-05-17" },
+      io,
+      { draftRoot, evalsDir, prompter: makePrompter() }
+    );
+
+    expect(exitCode).toBe(0);
+
+    const saved = await readFeedback(outputDir1);
+    expect(saved).not.toBeNull();
+    expect(saved!.date).toBe("2026-05-17");
+    expect(saved!.formatName).toBe("Older Format");
+  });
+
+  it("returns exit code 1 when specified date has no draft", async () => {
+    const { io, stderr } = createIo();
+    const draftRoot = makeTmpDir();
+    const evalsDir = makeTmpDir();
+    await mkdir(draftRoot, { recursive: true });
+
+    await setupDraftForDate(draftRoot, "2026-05-19");
+
+    const exitCode = await runFeedbackCommand(
+      { subcommand: "latest", targetDate: "2026-05-01" },
+      io,
+      { draftRoot, evalsDir, prompter: makePrompter() }
+    );
+
+    expect(exitCode).toBe(1);
+    expect(stderr.join("\n")).toMatch(/no.*draft|not found|2026-05-01/i);
+  });
+
+  it("displays the targeted date in output header", async () => {
+    const { io, stdout } = createIo();
+    const draftRoot = makeTmpDir();
+    const evalsDir = makeTmpDir();
+    await mkdir(draftRoot, { recursive: true });
+
+    await setupDraftForDate(draftRoot, "2026-05-17", "Old Format");
+
+    await runFeedbackCommand(
+      { subcommand: "latest", targetDate: "2026-05-17" },
+      io,
+      { draftRoot, evalsDir, prompter: makePrompter() }
+    );
+
+    expect(stdout.join("\n")).toContain("2026-05-17");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: non-interactive flags
+// ---------------------------------------------------------------------------
+
+describe("runFeedbackCommand non-interactive mode", () => {
+  it("saves record from flags without calling prompter", async () => {
+    const { io } = createIo();
+    const draftRoot = makeTmpDir();
+    const evalsDir = makeTmpDir();
+    await mkdir(draftRoot, { recursive: true });
+    const outputDir = await setupDraftForDate(draftRoot, "2026-05-19", "AI의 퇴근일지");
+
+    const exitCode = await runFeedbackCommand(
+      { subcommand: "latest" },
+      io,
+      {
+        draftRoot,
+        evalsDir,
+        prompter: makePrompter(),
+        nonInteractive: {
+          fun: 5,
+          share: 4,
+          accuracy: 3,
+          safetyConcern: false,
+          wouldPost: true,
+          reasons: ["too-generic", "weak-caption"],
+          note: "auto note",
+          yes: true
+        }
+      }
+    );
+
+    expect(exitCode).toBe(0);
+
+    const saved = await readFeedback(outputDir);
+    expect(saved).not.toBeNull();
+    expect(saved!.fun).toBe(5);
+    expect(saved!.share).toBe(4);
+    expect(saved!.accuracy).toBe(3);
+    expect(saved!.safetyConcern).toBe(false);
+    expect(saved!.wouldPost).toBe(true);
+    expect(saved!.reasons).toEqual(["too-generic", "weak-caption"]);
+    expect(saved!.note).toBe("auto note");
+  });
+
+  it("returns exit code 1 when non-interactive flags have missing required fields", async () => {
+    const { io, stderr } = createIo();
+    const draftRoot = makeTmpDir();
+    const evalsDir = makeTmpDir();
+    await mkdir(draftRoot, { recursive: true });
+    await setupDraftForDate(draftRoot, "2026-05-19");
+
+    // Missing fun score
+    const exitCode = await runFeedbackCommand(
+      { subcommand: "latest" },
+      io,
+      {
+        draftRoot,
+        evalsDir,
+        prompter: makePrompter(),
+        nonInteractive: {
+          // fun is missing
+          share: 3,
+          accuracy: 5,
+          safetyConcern: false,
+          wouldPost: false,
+          reasons: [],
+          note: "",
+          yes: true
+        } as Parameters<typeof runFeedbackCommand>[2]["nonInteractive"]
+      }
+    );
+
+    expect(exitCode).toBe(1);
+    expect(stderr.join("\n")).toMatch(/fun|missing|required/i);
+  });
+
+  it("returns exit code 1 when non-interactive flags contain invalid score", async () => {
+    const { io, stderr } = createIo();
+    const draftRoot = makeTmpDir();
+    const evalsDir = makeTmpDir();
+    await mkdir(draftRoot, { recursive: true });
+    await setupDraftForDate(draftRoot, "2026-05-19");
+
+    const exitCode = await runFeedbackCommand(
+      { subcommand: "latest" },
+      io,
+      {
+        draftRoot,
+        evalsDir,
+        prompter: makePrompter(),
+        nonInteractive: {
+          fun: 9,  // out of range
+          share: 3,
+          accuracy: 5,
+          safetyConcern: false,
+          wouldPost: false,
+          reasons: [],
+          note: "",
+          yes: true
+        }
+      }
+    );
+
+    expect(exitCode).toBe(1);
+    expect(stderr.join("\n")).toMatch(/fun|score|1.5|valid|range/i);
+  });
+
+  it("returns exit code 1 when non-interactive reasons contain invalid enum value", async () => {
+    const { io, stderr } = createIo();
+    const draftRoot = makeTmpDir();
+    const evalsDir = makeTmpDir();
+    await mkdir(draftRoot, { recursive: true });
+    await setupDraftForDate(draftRoot, "2026-05-19");
+
+    const exitCode = await runFeedbackCommand(
+      { subcommand: "latest" },
+      io,
+      {
+        draftRoot,
+        evalsDir,
+        prompter: makePrompter(),
+        nonInteractive: {
+          fun: 4,
+          share: 3,
+          accuracy: 5,
+          safetyConcern: false,
+          wouldPost: false,
+          reasons: ["not-a-valid-reason"],
+          note: "",
+          yes: true
+        }
+      }
+    );
+
+    expect(exitCode).toBe(1);
+    expect(stderr.join("\n")).toMatch(/reason|invalid|not-a-valid-reason/i);
+  });
+
+  it("auto-confirms overwrite when yes flag is true", async () => {
+    const { io } = createIo();
+    const draftRoot = makeTmpDir();
+    const evalsDir = makeTmpDir();
+    await mkdir(draftRoot, { recursive: true });
+    const outputDir = await setupDraftForDate(draftRoot, "2026-05-19");
+
+    // First save
+    await runFeedbackCommand(
+      { subcommand: "latest" },
+      io,
+      {
+        draftRoot,
+        evalsDir,
+        prompter: makePrompter(),
+        nonInteractive: {
+          fun: 3,
+          share: 3,
+          accuracy: 3,
+          safetyConcern: false,
+          wouldPost: false,
+          reasons: [],
+          note: "first",
+          yes: true
+        }
+      }
+    );
+
+    // Second save should overwrite without prompt
+    const exitCode = await runFeedbackCommand(
+      { subcommand: "latest" },
+      io,
+      {
+        draftRoot,
+        evalsDir,
+        prompter: makePrompter(),
+        nonInteractive: {
+          fun: 5,
+          share: 5,
+          accuracy: 5,
+          safetyConcern: false,
+          wouldPost: true,
+          reasons: [],
+          note: "second",
+          yes: true
+        }
+      }
+    );
+
+    expect(exitCode).toBe(0);
+    const saved = await readFeedback(outputDir);
+    expect(saved!.fun).toBe(5);
+    expect(saved!.note).toBe("second");
+  });
+});

--- a/tests/feedback-command.test.ts
+++ b/tests/feedback-command.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/tests/feedback-command.test.ts
+++ b/tests/feedback-command.test.ts
@@ -1,0 +1,219 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  runFeedbackCommand,
+  type FeedbackPrompter
+} from "../src/feedback-command.js";
+import {
+  createDraftRevision,
+  writeLatestDraftPointer,
+  writeDraftArtifactJson
+} from "../src/draft-storage.js";
+import { readFeedback } from "../src/feedback-storage.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeTmpDir(): string {
+  return join(tmpdir(), `unc-feedback-cmd-test-${randomUUID()}`);
+}
+
+function createIo() {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+
+  return {
+    io: {
+      stdout: (message: string) => stdout.push(message),
+      stderr: (message: string) => stderr.push(message)
+    },
+    stdout,
+    stderr
+  };
+}
+
+const defaultPrompterAnswers = {
+  fun: 4,
+  share: 3,
+  accuracy: 5,
+  safetyConcern: false,
+  wouldPost: false,
+  reasons: ["weak-caption"] as string[],
+  note: "캡션이 너무 담백함"
+};
+
+function makePrompter(overrides: Partial<typeof defaultPrompterAnswers> = {}): FeedbackPrompter {
+  const answers = { ...defaultPrompterAnswers, ...overrides };
+
+  return {
+    askScores: async () => ({
+      fun: answers.fun,
+      share: answers.share,
+      accuracy: answers.accuracy
+    }),
+    askBooleans: async () => ({
+      safetyConcern: answers.safetyConcern,
+      wouldPost: answers.wouldPost
+    }),
+    askReasons: async () => answers.reasons,
+    askNote: async () => answers.note,
+    confirmOverwrite: async () => true
+  };
+}
+
+async function setupDraft(
+  draftRoot: string,
+  targetDate = "2026-05-19",
+  formatName = "AI의 퇴근일지",
+  activityLevel = "low"
+): Promise<string> {
+  const revision = await createDraftRevision({ draftRoot, targetDate });
+  await writeDraftArtifactJson(revision, "story.json", {
+    schemaVersion: 1,
+    formatName,
+    activityLevel
+  });
+  await writeLatestDraftPointer(revision, new Date().toISOString());
+  return revision.outputDir;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("runFeedbackCommand (feedback latest)", () => {
+  it("returns exit code 1 and actionable error when no latest draft exists", async () => {
+    const { io, stderr } = createIo();
+    const draftRoot = makeTmpDir();
+    const evalsDir = makeTmpDir();
+    await mkdir(draftRoot, { recursive: true });
+
+    const exitCode = await runFeedbackCommand(
+      { subcommand: "latest" },
+      io,
+      { draftRoot, evalsDir, prompter: makePrompter() }
+    );
+
+    expect(exitCode).toBe(1);
+    expect(stderr.join("\n")).toMatch(/no.*draft|run.*generate/i);
+  });
+
+  it("displays draft metadata before prompting", async () => {
+    const { io, stdout } = createIo();
+    const draftRoot = makeTmpDir();
+    const evalsDir = makeTmpDir();
+    await mkdir(draftRoot, { recursive: true });
+    await setupDraft(draftRoot, "2026-05-19", "AI의 퇴근일지", "low");
+
+    await runFeedbackCommand(
+      { subcommand: "latest" },
+      io,
+      { draftRoot, evalsDir, prompter: makePrompter() }
+    );
+
+    const output = stdout.join("\n");
+    expect(output).toContain("2026-05-19");
+    expect(output).toContain("rev-001");
+    expect(output).toContain("AI의 퇴근일지");
+    expect(output).toContain("low");
+  });
+
+  it("saves feedback.json and appends to JSONL on success", async () => {
+    const { io } = createIo();
+    const draftRoot = makeTmpDir();
+    const evalsDir = makeTmpDir();
+    await mkdir(draftRoot, { recursive: true });
+    const outputDir = await setupDraft(draftRoot, "2026-05-19", "AI의 퇴근일지", "low");
+
+    const exitCode = await runFeedbackCommand(
+      { subcommand: "latest" },
+      io,
+      { draftRoot, evalsDir, prompter: makePrompter() }
+    );
+
+    expect(exitCode).toBe(0);
+
+    const saved = await readFeedback(outputDir);
+    expect(saved).not.toBeNull();
+    expect(saved!.fun).toBe(4);
+    expect(saved!.share).toBe(3);
+    expect(saved!.accuracy).toBe(5);
+    expect(saved!.wouldPost).toBe(false);
+    expect(saved!.reasons).toEqual(["weak-caption"]);
+    expect(saved!.note).toBe("캡션이 너무 담백함");
+    expect(saved!.date).toBe("2026-05-19");
+    expect(saved!.revision).toBe("rev-001");
+    expect(saved!.formatName).toBe("AI의 퇴근일지");
+  });
+
+  it("returns exit code 0 on success and prints confirmation", async () => {
+    const { io, stdout } = createIo();
+    const draftRoot = makeTmpDir();
+    const evalsDir = makeTmpDir();
+    await mkdir(draftRoot, { recursive: true });
+    await setupDraft(draftRoot, "2026-05-19");
+
+    const exitCode = await runFeedbackCommand(
+      { subcommand: "latest" },
+      io,
+      { draftRoot, evalsDir, prompter: makePrompter() }
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout.join("\n")).toMatch(/saved|feedback/i);
+  });
+
+  it("passes confirmOverwrite from prompter to saveFeedback on re-run", async () => {
+    const { io } = createIo();
+    const draftRoot = makeTmpDir();
+    const evalsDir = makeTmpDir();
+    await mkdir(draftRoot, { recursive: true });
+    await setupDraft(draftRoot, "2026-05-19", "AI의 퇴근일지", "low");
+
+    const prompter = makePrompter();
+    // First run
+    await runFeedbackCommand(
+      { subcommand: "latest" },
+      io,
+      { draftRoot, evalsDir, prompter }
+    );
+
+    // Second run with updated scores — confirmOverwrite returns true
+    const updatedPrompter: FeedbackPrompter = {
+      ...makePrompter({ fun: 2 }),
+      confirmOverwrite: async () => true
+    };
+
+    const exitCode = await runFeedbackCommand(
+      { subcommand: "latest" },
+      io,
+      { draftRoot, evalsDir, prompter: updatedPrompter }
+    );
+
+    expect(exitCode).toBe(0);
+
+    // Re-read pointer to get dir again
+    const outputDir = join(draftRoot, "2026-05-19", "rev-001");
+    const saved = await readFeedback(outputDir);
+    expect(saved!.fun).toBe(2);
+  });
+
+  it("returns exit code 1 for unknown subcommand", async () => {
+    const { io, stderr } = createIo();
+    const draftRoot = makeTmpDir();
+    const evalsDir = makeTmpDir();
+
+    const exitCode = await runFeedbackCommand(
+      { subcommand: "unknown" },
+      io,
+      { draftRoot, evalsDir, prompter: makePrompter() }
+    );
+
+    expect(exitCode).toBe(1);
+    expect(stderr.join("\n")).toMatch(/usage/i);
+  });
+});

--- a/tests/feedback-report.test.ts
+++ b/tests/feedback-report.test.ts
@@ -1,0 +1,302 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  aggregateFeedback,
+  formatFeedbackReport,
+  type FeedbackAggregate
+} from "../src/feedback-report.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTmpDir(): string {
+  return join(tmpdir(), `unc-feedback-report-test-${randomUUID()}`);
+}
+
+// JSONL fixture lines matching the spec format used by feedback-storage
+const FIXTURE_LINES = [
+  JSON.stringify({
+    date: "2026-05-17",
+    revision: "rev-001",
+    formatName: "AI의 퇴근일지",
+    fun: 4,
+    share: 3,
+    accuracy: 5,
+    wouldPost: false,
+    reasons: ["weak-caption"],
+    note: "카드는 좋은데 caption이 너무 담백함"
+  }),
+  JSON.stringify({
+    date: "2026-05-18",
+    revision: "rev-001",
+    formatName: "TODO들의 야간 회의록",
+    fun: 5,
+    share: 4,
+    accuracy: 4,
+    wouldPost: true,
+    reasons: [],
+    note: "이건 진짜 올릴만함"
+  }),
+  JSON.stringify({
+    date: "2026-05-19",
+    revision: "rev-002",
+    formatName: "인간 관찰 보고서",
+    fun: 2,
+    share: 1,
+    accuracy: 5,
+    wouldPost: false,
+    reasons: ["too-generic", "too-report-like"],
+    note: "컨셉은 좋은데 문장이 평범함"
+  })
+];
+
+async function writeFixtureJsonl(evalsDir: string, lines: string[]): Promise<string> {
+  await mkdir(evalsDir, { recursive: true });
+  const jsonlPath = join(evalsDir, "daily-feedback.jsonl");
+  await writeFile(jsonlPath, lines.join("\n") + "\n", "utf8");
+  return jsonlPath;
+}
+
+// ---------------------------------------------------------------------------
+// aggregateFeedback tests
+// ---------------------------------------------------------------------------
+
+describe("aggregateFeedback", () => {
+  it("returns empty aggregate when JSONL file does not exist", async () => {
+    const evalsDir = makeTmpDir();
+    const result = await aggregateFeedback(evalsDir, 7, "2026-05-19");
+
+    expect(result.totalDrafts).toBe(0);
+    expect(result.averageFun).toBeNull();
+    expect(result.averageShare).toBeNull();
+    expect(result.averageAccuracy).toBeNull();
+    expect(result.wouldPostCount).toBe(0);
+    expect(result.topReasons).toEqual([]);
+    expect(result.bestFormats).toEqual([]);
+    expect(result.recommendedWork).toEqual([]);
+  });
+
+  it("computes correct averages from 3 fixture entries", async () => {
+    const evalsDir = makeTmpDir();
+    await writeFixtureJsonl(evalsDir, FIXTURE_LINES);
+
+    const result = await aggregateFeedback(evalsDir, 7, "2026-05-19");
+
+    expect(result.totalDrafts).toBe(3);
+    // fun: (4+5+2)/3 = 3.67, rounded to 1 decimal
+    expect(result.averageFun).toBeCloseTo(3.7, 1);
+    // share: (3+4+1)/3 = 2.67
+    expect(result.averageShare).toBeCloseTo(2.7, 1);
+    // accuracy: (5+4+5)/3 = 4.67
+    expect(result.averageAccuracy).toBeCloseTo(4.7, 1);
+  });
+
+  it("counts wouldPost correctly", async () => {
+    const evalsDir = makeTmpDir();
+    await writeFixtureJsonl(evalsDir, FIXTURE_LINES);
+
+    const result = await aggregateFeedback(evalsDir, 7, "2026-05-19");
+
+    expect(result.wouldPostCount).toBe(1);
+  });
+
+  it("returns top reasons sorted by count descending", async () => {
+    const evalsDir = makeTmpDir();
+    await writeFixtureJsonl(evalsDir, FIXTURE_LINES);
+
+    const result = await aggregateFeedback(evalsDir, 7, "2026-05-19");
+
+    // weak-caption: 1, too-generic: 1, too-report-like: 1
+    expect(result.topReasons.length).toBeGreaterThan(0);
+    // All have count 1, so any order is valid — just verify keys exist
+    const reasonNames = result.topReasons.map((r) => r.reason);
+    expect(reasonNames).toContain("weak-caption");
+    expect(reasonNames).toContain("too-generic");
+    expect(reasonNames).toContain("too-report-like");
+    // Each has count 1
+    for (const r of result.topReasons) {
+      expect(r.count).toBe(1);
+    }
+  });
+
+  it("filters entries outside the --days N window", async () => {
+    const evalsDir = makeTmpDir();
+    await writeFixtureJsonl(evalsDir, FIXTURE_LINES);
+
+    // Only look at the last 1 day from 2026-05-19 → only 2026-05-19 entry
+    const result = await aggregateFeedback(evalsDir, 1, "2026-05-19");
+
+    expect(result.totalDrafts).toBe(1);
+    expect(result.averageFun).toBeCloseTo(2, 0);
+  });
+
+  it("returns best format with highest average fun", async () => {
+    const evalsDir = makeTmpDir();
+    await writeFixtureJsonl(evalsDir, FIXTURE_LINES);
+
+    const result = await aggregateFeedback(evalsDir, 7, "2026-05-19");
+
+    // TODO들의 야간 회의록: fun 5, share 4 — should be top
+    expect(result.bestFormats.length).toBeGreaterThan(0);
+    expect(result.bestFormats[0].formatName).toBe("TODO들의 야간 회의록");
+  });
+
+  it("recommended work maps top reasons to prompt areas via REASON_PROMPT_AREA_MAP", async () => {
+    const evalsDir = makeTmpDir();
+    await writeFixtureJsonl(evalsDir, FIXTURE_LINES);
+
+    const result = await aggregateFeedback(evalsDir, 7, "2026-05-19");
+
+    expect(result.recommendedWork.length).toBeGreaterThan(0);
+    // Every item should be a non-empty string
+    for (const work of result.recommendedWork) {
+      expect(typeof work).toBe("string");
+      expect(work.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("handles duplicate formatName entries by averaging", async () => {
+    const lines = [
+      JSON.stringify({
+        date: "2026-05-18",
+        revision: "rev-001",
+        formatName: "Same Format",
+        fun: 4,
+        share: 4,
+        accuracy: 4,
+        wouldPost: true,
+        reasons: [],
+        note: ""
+      }),
+      JSON.stringify({
+        date: "2026-05-19",
+        revision: "rev-001",
+        formatName: "Same Format",
+        fun: 2,
+        share: 2,
+        accuracy: 2,
+        wouldPost: false,
+        reasons: [],
+        note: ""
+      })
+    ];
+
+    const evalsDir = makeTmpDir();
+    await writeFixtureJsonl(evalsDir, lines);
+
+    const result = await aggregateFeedback(evalsDir, 7, "2026-05-19");
+
+    expect(result.bestFormats).toHaveLength(1);
+    expect(result.bestFormats[0].formatName).toBe("Same Format");
+    expect(result.bestFormats[0].averageFun).toBeCloseTo(3.0, 1);
+  });
+
+  it("skips malformed JSONL lines without throwing", async () => {
+    const evalsDir = makeTmpDir();
+    const lines = [
+      "{not valid json",
+      ...FIXTURE_LINES.slice(0, 2)
+    ];
+    await writeFixtureJsonl(evalsDir, lines);
+
+    const result = await aggregateFeedback(evalsDir, 7, "2026-05-19");
+
+    expect(result.totalDrafts).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatFeedbackReport tests
+// ---------------------------------------------------------------------------
+
+describe("formatFeedbackReport", () => {
+  const sampleAggregate: FeedbackAggregate = {
+    totalDrafts: 7,
+    averageFun: 3.7,
+    averageShare: 2.4,
+    averageAccuracy: 4.6,
+    wouldPostCount: 2,
+    topReasons: [
+      { reason: "too-report-like", count: 4 },
+      { reason: "weak-caption", count: 3 },
+      { reason: "repetitive-format", count: 2 }
+    ],
+    bestFormats: [
+      { formatName: "TODO들의 야간 회의록", averageFun: 5, averageShare: 4 },
+      { formatName: "버그의 진술서", averageFun: 4, averageShare: 3 }
+    ],
+    recommendedWork: [
+      "Improve Diary Writer prompt to avoid report-like phrasing.",
+      "Add stronger caption examples.",
+      "Add format novelty constraints to Story Inventor."
+    ],
+    days: 7
+  };
+
+  it("includes all required sections", () => {
+    const text = formatFeedbackReport(sampleAggregate);
+
+    expect(text).toContain("Feedback report");
+    expect(text).toContain("Average scores");
+    expect(text).toContain("Fun");
+    expect(text).toContain("Share");
+    expect(text).toContain("Accuracy");
+    expect(text).toContain("Would post");
+    expect(text).toContain("Top issues");
+    expect(text).toContain("Best performing formats");
+    expect(text).toContain("Recommended next prompt work");
+  });
+
+  it("shows correct numeric values", () => {
+    const text = formatFeedbackReport(sampleAggregate);
+
+    expect(text).toContain("3.7");
+    expect(text).toContain("2.4");
+    expect(text).toContain("4.6");
+    expect(text).toContain("2 / 7");
+  });
+
+  it("shows top reasons", () => {
+    const text = formatFeedbackReport(sampleAggregate);
+
+    expect(text).toContain("too-report-like");
+    expect(text).toContain("weak-caption");
+    expect(text).toContain("repetitive-format");
+  });
+
+  it("shows best formats", () => {
+    const text = formatFeedbackReport(sampleAggregate);
+
+    expect(text).toContain("TODO들의 야간 회의록");
+    expect(text).toContain("버그의 진술서");
+  });
+
+  it("shows recommended work items", () => {
+    const text = formatFeedbackReport(sampleAggregate);
+
+    expect(text).toContain("Diary Writer");
+    expect(text).toContain("caption");
+    expect(text).toContain("Story Inventor");
+  });
+
+  it("shows no-data message when totalDrafts is 0", () => {
+    const empty: FeedbackAggregate = {
+      totalDrafts: 0,
+      averageFun: null,
+      averageShare: null,
+      averageAccuracy: null,
+      wouldPostCount: 0,
+      topReasons: [],
+      bestFormats: [],
+      recommendedWork: [],
+      days: 7
+    };
+    const text = formatFeedbackReport(empty);
+
+    expect(text).toMatch(/no feedback|0 draft/i);
+  });
+});

--- a/tests/feedback-storage.test.ts
+++ b/tests/feedback-storage.test.ts
@@ -1,0 +1,201 @@
+import { mkdir, readFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+  saveFeedback,
+  readFeedback,
+  type SaveFeedbackOptions
+} from "../src/feedback-storage.js";
+import type { FeedbackRecord } from "../src/feedback-types.js";
+
+function makeTmpDir(): string {
+  return join(tmpdir(), `unc-feedback-test-${randomUUID()}`);
+}
+
+const baseRecord: FeedbackRecord = {
+  date: "2026-05-19",
+  revision: "rev-001",
+  formatName: "AI의 퇴근일지",
+  fun: 4,
+  share: 3,
+  accuracy: 5,
+  safetyConcern: false,
+  wouldPost: false,
+  reasons: ["weak-caption"],
+  note: "캡션이 너무 담백함",
+  createdAt: "2026-05-19T23:30:00.000Z"
+};
+
+describe("saveFeedback", () => {
+  it("writes feedback.json to the draft directory", async () => {
+    const draftDir = join(makeTmpDir(), "2026-05-19", "rev-001");
+    const evalsDir = makeTmpDir();
+    await mkdir(draftDir, { recursive: true });
+
+    await saveFeedback(baseRecord, draftDir, evalsDir);
+
+    const content = JSON.parse(
+      await readFile(join(draftDir, "feedback.json"), "utf8")
+    ) as unknown;
+    expect(content).toEqual(baseRecord);
+  });
+
+  it("appends one JSON line to daily-feedback.jsonl", async () => {
+    const draftDir = join(makeTmpDir(), "2026-05-19", "rev-001");
+    const evalsDir = makeTmpDir();
+    await mkdir(draftDir, { recursive: true });
+
+    await saveFeedback(baseRecord, draftDir, evalsDir);
+
+    const jsonlPath = join(evalsDir, "daily-feedback.jsonl");
+    const lines = (await readFile(jsonlPath, "utf8"))
+      .trim()
+      .split("\n")
+      .filter(Boolean);
+    expect(lines).toHaveLength(1);
+
+    const parsed = JSON.parse(lines[0]) as Record<string, unknown>;
+    expect(parsed.date).toBe("2026-05-19");
+    expect(parsed.revision).toBe("rev-001");
+    expect(parsed.formatName).toBe("AI의 퇴근일지");
+    expect(parsed.fun).toBe(4);
+    expect(parsed.share).toBe(3);
+    expect(parsed.accuracy).toBe(5);
+    expect(parsed.wouldPost).toBe(false);
+    expect(parsed.reasons).toEqual(["weak-caption"]);
+    expect(parsed.note).toBe("캡션이 너무 담백함");
+  });
+
+  it("appends multiple records as separate JSONL lines", async () => {
+    const draftDir1 = join(makeTmpDir(), "2026-05-19", "rev-001");
+    const draftDir2 = join(makeTmpDir(), "2026-05-20", "rev-001");
+    const evalsDir = makeTmpDir();
+    await mkdir(draftDir1, { recursive: true });
+    await mkdir(draftDir2, { recursive: true });
+
+    const record2: FeedbackRecord = {
+      ...baseRecord,
+      date: "2026-05-20",
+      formatName: "TODO들의 야간 회의록",
+      fun: 5,
+      wouldPost: true,
+      reasons: [],
+      note: ""
+    };
+
+    await saveFeedback(baseRecord, draftDir1, evalsDir);
+    await saveFeedback(record2, draftDir2, evalsDir);
+
+    const jsonlPath = join(evalsDir, "daily-feedback.jsonl");
+    const lines = (await readFile(jsonlPath, "utf8"))
+      .trim()
+      .split("\n")
+      .filter(Boolean);
+    expect(lines).toHaveLength(2);
+
+    const first = JSON.parse(lines[0]) as Record<string, unknown>;
+    const second = JSON.parse(lines[1]) as Record<string, unknown>;
+    expect(first.date).toBe("2026-05-19");
+    expect(second.date).toBe("2026-05-20");
+  });
+
+  it("auto-creates the evals directory if it does not exist", async () => {
+    const draftDir = join(makeTmpDir(), "2026-05-19", "rev-001");
+    const evalsDir = join(makeTmpDir(), "nested", "evals");
+    await mkdir(draftDir, { recursive: true });
+
+    await expect(saveFeedback(baseRecord, draftDir, evalsDir)).resolves.not.toThrow();
+
+    const jsonlPath = join(evalsDir, "daily-feedback.jsonl");
+    const text = await readFile(jsonlPath, "utf8");
+    expect(text.trim().length).toBeGreaterThan(0);
+  });
+
+  it("calls confirm callback and overwrites when confirmed", async () => {
+    const draftDir = join(makeTmpDir(), "2026-05-19", "rev-001");
+    const evalsDir = makeTmpDir();
+    await mkdir(draftDir, { recursive: true });
+
+    // First save
+    await saveFeedback(baseRecord, draftDir, evalsDir);
+
+    // Second save with overwrite confirmed
+    const updatedRecord: FeedbackRecord = { ...baseRecord, fun: 1, note: "updated" };
+    const confirmFn = vi.fn().mockResolvedValue(true);
+
+    const opts: SaveFeedbackOptions = { confirmOverwrite: confirmFn };
+    await saveFeedback(updatedRecord, draftDir, evalsDir, opts);
+
+    expect(confirmFn).toHaveBeenCalledOnce();
+
+    const content = JSON.parse(
+      await readFile(join(draftDir, "feedback.json"), "utf8")
+    ) as FeedbackRecord;
+    expect(content.fun).toBe(1);
+    expect(content.note).toBe("updated");
+  });
+
+  it("calls confirm callback and skips overwrite when denied", async () => {
+    const draftDir = join(makeTmpDir(), "2026-05-19", "rev-001");
+    const evalsDir = makeTmpDir();
+    await mkdir(draftDir, { recursive: true });
+
+    // First save
+    await saveFeedback(baseRecord, draftDir, evalsDir);
+
+    // Second save with overwrite denied
+    const updatedRecord: FeedbackRecord = { ...baseRecord, fun: 1, note: "denied" };
+    const confirmFn = vi.fn().mockResolvedValue(false);
+
+    const opts: SaveFeedbackOptions = { confirmOverwrite: confirmFn };
+    await saveFeedback(updatedRecord, draftDir, evalsDir, opts);
+
+    expect(confirmFn).toHaveBeenCalledOnce();
+
+    // Original should remain unchanged
+    const content = JSON.parse(
+      await readFile(join(draftDir, "feedback.json"), "utf8")
+    ) as FeedbackRecord;
+    expect(content.fun).toBe(4);
+    expect(content.note).toBe("캡션이 너무 담백함");
+  });
+
+  it("overwrites without confirm when no confirmOverwrite is provided", async () => {
+    const draftDir = join(makeTmpDir(), "2026-05-19", "rev-001");
+    const evalsDir = makeTmpDir();
+    await mkdir(draftDir, { recursive: true });
+
+    await saveFeedback(baseRecord, draftDir, evalsDir);
+
+    const updatedRecord: FeedbackRecord = { ...baseRecord, fun: 2, note: "no confirm" };
+    await saveFeedback(updatedRecord, draftDir, evalsDir);
+
+    const content = JSON.parse(
+      await readFile(join(draftDir, "feedback.json"), "utf8")
+    ) as FeedbackRecord;
+    expect(content.fun).toBe(2);
+  });
+});
+
+describe("readFeedback", () => {
+  it("returns the stored FeedbackRecord after saving", async () => {
+    const draftDir = join(makeTmpDir(), "2026-05-19", "rev-001");
+    const evalsDir = makeTmpDir();
+    await mkdir(draftDir, { recursive: true });
+
+    await saveFeedback(baseRecord, draftDir, evalsDir);
+    const result = await readFeedback(draftDir);
+
+    expect(result).toEqual(baseRecord);
+  });
+
+  it("returns null when feedback.json does not exist", async () => {
+    const draftDir = join(makeTmpDir(), "2026-05-19", "rev-001");
+    await mkdir(draftDir, { recursive: true });
+
+    const result = await readFeedback(draftDir);
+    expect(result).toBeNull();
+  });
+});

--- a/tests/feedback-types.test.ts
+++ b/tests/feedback-types.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+import {
+  FEEDBACK_REASONS,
+  REASON_PROMPT_AREA_MAP,
+  isFeedbackReason,
+  isFeedbackRecord,
+  isValidScore,
+  validateScore
+} from "../src/feedback-types.js";
+import type { FeedbackReason, FeedbackRecord } from "../src/feedback-types.js";
+
+describe("FeedbackReason", () => {
+  it("contains all 14 expected reason values", () => {
+    const expected: FeedbackReason[] = [
+      "too-boring",
+      "too-report-like",
+      "too-long",
+      "too-generic",
+      "repetitive-format",
+      "inaccurate",
+      "hallucinated-work",
+      "weak-caption",
+      "awkward-roast",
+      "too-harsh",
+      "not-instagram-like",
+      "card-overflow",
+      "safety-concern",
+      "other"
+    ];
+
+    expect(FEEDBACK_REASONS).toHaveLength(14);
+    for (const reason of expected) {
+      expect(FEEDBACK_REASONS).toContain(reason);
+    }
+  });
+
+  it("isFeedbackReason returns true for valid reasons", () => {
+    expect(isFeedbackReason("too-boring")).toBe(true);
+    expect(isFeedbackReason("too-report-like")).toBe(true);
+    expect(isFeedbackReason("too-long")).toBe(true);
+    expect(isFeedbackReason("too-generic")).toBe(true);
+    expect(isFeedbackReason("repetitive-format")).toBe(true);
+    expect(isFeedbackReason("inaccurate")).toBe(true);
+    expect(isFeedbackReason("hallucinated-work")).toBe(true);
+    expect(isFeedbackReason("weak-caption")).toBe(true);
+    expect(isFeedbackReason("awkward-roast")).toBe(true);
+    expect(isFeedbackReason("too-harsh")).toBe(true);
+    expect(isFeedbackReason("not-instagram-like")).toBe(true);
+    expect(isFeedbackReason("card-overflow")).toBe(true);
+    expect(isFeedbackReason("safety-concern")).toBe(true);
+    expect(isFeedbackReason("other")).toBe(true);
+  });
+
+  it("isFeedbackReason returns false for invalid values", () => {
+    expect(isFeedbackReason("unknown")).toBe(false);
+    expect(isFeedbackReason("")).toBe(false);
+    expect(isFeedbackReason(null)).toBe(false);
+    expect(isFeedbackReason(42)).toBe(false);
+    expect(isFeedbackReason(undefined)).toBe(false);
+  });
+});
+
+describe("REASON_PROMPT_AREA_MAP", () => {
+  it("every FeedbackReason has a mapping entry", () => {
+    for (const reason of FEEDBACK_REASONS) {
+      expect(
+        REASON_PROMPT_AREA_MAP[reason],
+        `Missing mapping for reason: ${reason}`
+      ).toBeDefined();
+      expect(typeof REASON_PROMPT_AREA_MAP[reason]).toBe("string");
+      expect(REASON_PROMPT_AREA_MAP[reason].length).toBeGreaterThan(0);
+    }
+  });
+
+  it("maps each reason to the expected prompt area per spec", () => {
+    expect(REASON_PROMPT_AREA_MAP["too-report-like"]).toContain(
+      "Diary Writer"
+    );
+    expect(REASON_PROMPT_AREA_MAP["too-generic"]).toContain("Story Inventor");
+    expect(REASON_PROMPT_AREA_MAP["repetitive-format"]).toContain(
+      "Story Inventor"
+    );
+    expect(REASON_PROMPT_AREA_MAP["weak-caption"]).toContain("Caption");
+    expect(REASON_PROMPT_AREA_MAP["inaccurate"]).toContain("Activity Summary");
+    expect(REASON_PROMPT_AREA_MAP["hallucinated-work"]).toContain(
+      "Activity Summary"
+    );
+    expect(REASON_PROMPT_AREA_MAP["too-harsh"]).toContain("Safety");
+    expect(REASON_PROMPT_AREA_MAP["not-instagram-like"]).toContain("Caption");
+    expect(REASON_PROMPT_AREA_MAP["card-overflow"]).toContain("Renderer");
+    expect(REASON_PROMPT_AREA_MAP["safety-concern"]).toContain("Safety");
+  });
+
+  it("has no extra keys beyond FEEDBACK_REASONS", () => {
+    const mappingKeys = Object.keys(REASON_PROMPT_AREA_MAP);
+    expect(mappingKeys).toHaveLength(FEEDBACK_REASONS.length);
+    for (const key of mappingKeys) {
+      expect(FEEDBACK_REASONS).toContain(key);
+    }
+  });
+});
+
+describe("score validation", () => {
+  it("isValidScore returns true for integers 1-5", () => {
+    expect(isValidScore(1)).toBe(true);
+    expect(isValidScore(2)).toBe(true);
+    expect(isValidScore(3)).toBe(true);
+    expect(isValidScore(4)).toBe(true);
+    expect(isValidScore(5)).toBe(true);
+  });
+
+  it("isValidScore returns false for values outside 1-5", () => {
+    expect(isValidScore(0)).toBe(false);
+    expect(isValidScore(6)).toBe(false);
+    expect(isValidScore(-1)).toBe(false);
+    expect(isValidScore(100)).toBe(false);
+  });
+
+  it("isValidScore returns false for non-integers", () => {
+    expect(isValidScore(1.5)).toBe(false);
+    expect(isValidScore(3.9)).toBe(false);
+    expect(isValidScore(NaN)).toBe(false);
+  });
+
+  it("isValidScore returns false for non-numbers", () => {
+    expect(isValidScore("3")).toBe(false);
+    expect(isValidScore(null)).toBe(false);
+    expect(isValidScore(undefined)).toBe(false);
+  });
+
+  it("validateScore throws for invalid values", () => {
+    expect(() => validateScore(0, "fun")).toThrow("fun");
+    expect(() => validateScore(6, "share")).toThrow("share");
+    expect(() => validateScore(1.5, "accuracy")).toThrow("accuracy");
+  });
+
+  it("validateScore does not throw for valid values", () => {
+    expect(() => validateScore(1, "fun")).not.toThrow();
+    expect(() => validateScore(5, "share")).not.toThrow();
+    expect(() => validateScore(3, "accuracy")).not.toThrow();
+  });
+});
+
+describe("isFeedbackRecord", () => {
+  const validRecord: FeedbackRecord = {
+    date: "2026-05-19",
+    revision: "rev-001",
+    formatName: "AI의 퇴근일지",
+    fun: 4,
+    share: 3,
+    accuracy: 5,
+    safetyConcern: false,
+    wouldPost: false,
+    reasons: ["weak-caption"],
+    note: "캡션이 너무 담백함",
+    createdAt: "2026-05-19T23:30:00.000Z"
+  };
+
+  it("returns true for a valid FeedbackRecord", () => {
+    expect(isFeedbackRecord(validRecord)).toBe(true);
+  });
+
+  it("returns true with empty reasons and empty note", () => {
+    expect(
+      isFeedbackRecord({ ...validRecord, reasons: [], note: "" })
+    ).toBe(true);
+  });
+
+  it("returns false when required fields are missing", () => {
+    const { date: _date, ...noDate } = validRecord;
+    expect(isFeedbackRecord(noDate)).toBe(false);
+
+    const { revision: _rev, ...noRevision } = validRecord;
+    expect(isFeedbackRecord(noRevision)).toBe(false);
+  });
+
+  it("returns false when scores are out of range", () => {
+    expect(isFeedbackRecord({ ...validRecord, fun: 0 })).toBe(false);
+    expect(isFeedbackRecord({ ...validRecord, share: 6 })).toBe(false);
+    expect(isFeedbackRecord({ ...validRecord, accuracy: 1.5 })).toBe(false);
+  });
+
+  it("returns false when reasons contain invalid values", () => {
+    expect(
+      isFeedbackRecord({ ...validRecord, reasons: ["unknown-reason"] })
+    ).toBe(false);
+  });
+
+  it("returns false for null/non-object values", () => {
+    expect(isFeedbackRecord(null)).toBe(false);
+    expect(isFeedbackRecord(undefined)).toBe(false);
+    expect(isFeedbackRecord("string")).toBe(false);
+    expect(isFeedbackRecord(42)).toBe(false);
+  });
+});

--- a/tests/feedback-types.test.ts
+++ b/tests/feedback-types.test.ts
@@ -168,9 +168,11 @@ describe("isFeedbackRecord", () => {
 
   it("returns false when required fields are missing", () => {
     const { date: _date, ...noDate } = validRecord;
+    void _date;
     expect(isFeedbackRecord(noDate)).toBe(false);
 
     const { revision: _rev, ...noRevision } = validRecord;
+    void _rev;
     expect(isFeedbackRecord(noRevision)).toBe(false);
   });
 


### PR DESCRIPTION
🤖 **Auto-generated by Uncommitted Builder (Routine B)**

## Parent issue
[UNC-98: Feedback Command 추가](https://linear.app/sangchu/issue/UNC-98/feature-feedback-command-추가)

## Sub-issues progress

- [x] UNC-99: Feedback 도메인 타입/스키마 (✅ done)
- [x] UNC-100: Feedback 저장 (✅ done)
- [x] UNC-101: feedback latest 인터랙티브 폼 (✅ done)
- [x] UNC-102: --date + non-interactive (✅ done)
- [x] UNC-103: feedback report --days N (✅ done)

## Status

- Branch: `claude/UNC-98-feedback-command`
- Tests: ✅ passing (vitest — 322 tests)
- Build: ✅ pnpm build clean
- Lockfile: ✅ no drift

## TDD trail

| Sub | Attempts | Tests |
|-----|----------|-------|
| UNC-99 | 1 | 18 GREEN |
| UNC-100 | 1 | 9 GREEN |
| UNC-101 | 1 | 6 GREEN |
| UNC-102 | 1 | 8 GREEN |
| UNC-103 | 1 | 15 GREEN |

## New files added

- `src/feedback-types.ts` — FeedbackRecord, FeedbackReason enum, REASON_PROMPT_AREA_MAP, isValidScore
- `src/feedback-storage.ts` — saveFeedback, readFeedback
- `src/feedback-command.ts` — runFeedbackCommand, FeedbackPrompter, NonInteractiveInput, createReadlinePrompter
- `src/feedback-report.ts` — aggregateFeedback, formatFeedbackReport

## Modified files

- `src/commands.ts` — added `feedback` to command list
- `src/cli.ts` — feedback routing + CLI flag parsing + feedbackPrompter injectable
- `src/config-paths.ts` — added `evalsDir` (~/Uncommitted/evals)

## Notes

- `FeedbackPrompter` is injectable — all tests mock it, real terminal uses readline
- `evalsDir` resolves to `~/Uncommitted/evals` (not in requiredDirectories — auto-created on first write)
- Non-interactive mode via `--fun/--share/--accuracy/--would-post/--safety-concern/--reasons/--note/--yes`
- `--date YYYY-MM-DD` targets a specific date's latest revision
- `feedback report --days N` defaults to 7 days

## Review checklist

- [ ] Review each sub-issue's commits separately
- [ ] Verify TDD test coverage
- [ ] Confirm no lockfile changes
- [ ] Run `pnpm install && pnpm test && pnpm build` locally
- [ ] Confirm no auto-publish code introduced
- [ ] Test `uncommitted feedback latest` interactively

---
이 PR은 자동 생성되었습니다. 머지 전 사람의 리뷰가 반드시 필요합니다.

Closes #(none — Linear tracked)
