### PR TITLE
🤖 Fix launchd node interpreter in schedule install (UNC-104)

### DIFF
--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -162,9 +162,16 @@ export function buildLaunchAgentPlist(
   const plistPath = resolveLaunchAgentPlistPath(options);
   const logs = resolveSchedulerLogPaths(options);
   const executablePath = options.executablePath ?? defaultExecutableName;
+  // When the executable is a .js script, launchd cannot resolve the shebang
+  // interpreter because it uses a minimal PATH. Prepend the absolute node binary
+  // path (process.execPath) so launchd invokes: [node, script.js, ...args].
+  // Binary executable paths (no .js extension) are left unchanged.
+  const programArguments = executablePath.endsWith(".js")
+    ? [process.execPath, executablePath, ...scheduleCommand]
+    : [executablePath, ...scheduleCommand];
   const xml = renderLaunchAgentPlistXml({
     label: launchdLabel,
-    programArguments: [executablePath, ...scheduleCommand],
+    programArguments,
     hour,
     minute,
     stdoutLogPath: logs.stdout,

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -102,7 +102,28 @@ describe("macOS scheduler plist helpers", () => {
       executablePath
     });
 
+    // Binary executable path: must appear as ProgramArguments[0], no interpreter prepended
     expect(plist.xml).toContain(`<string>${executablePath}</string>`);
+    expect(plist.xml).not.toContain(`<string>${process.execPath}</string>`);
+  });
+
+  it("prepends process.execPath as interpreter when executablePath is a .js file", () => {
+    const homeDir = "/tmp/uncommitted-scheduler-home";
+    const executablePath = "/Users/user/.nvm/versions/node/v22.0.0/lib/node_modules/uncommitted/dist/cli.js";
+
+    const plist = buildLaunchAgentPlist({
+      homeDir,
+      scheduleTime: "23:30",
+      executablePath
+    });
+
+    // node interpreter must be ProgramArguments[0], script path must be ProgramArguments[1]
+    const nodeLine = `<string>${process.execPath}</string>`;
+    const scriptLine = `<string>${executablePath}</string>`;
+    expect(plist.xml).toContain(nodeLine);
+    expect(plist.xml).toContain(scriptLine);
+    // node must appear before the script path in the XML
+    expect(plist.xml.indexOf(nodeLine)).toBeLessThan(plist.xml.indexOf(scriptLine));
   });
 
   it("rejects invalid schedule times with a short actionable error", () => {


### PR DESCRIPTION
# Goal

Fix `uncommitted schedule install` so the generated launchd plist actually runs on schedule. launchd uses a minimal PATH and cannot resolve `node` via the shebang; the plist must explicitly list the node binary as the interpreter.

## Related Issue

Closes #UNC-104

## Acceptance Criteria

- [x] Root cause explained in the PR.
- [x] `uncommitted schedule install` generates a plist with `process.execPath` as `ProgramArguments[0]` and the `.js` script path as `ProgramArguments[1]` when the executable is a `.js` file.
- [x] Binary executable paths (no `.js` extension) are unaffected — no interpreter prepended.
- [x] Existing scheduler tests updated; new test confirms node interpreter is included for a `.js` executable path.
- [x] No breaking of related scheduler behavior.
- [x] Verification steps included in this PR.

## Implementation Notes

**Root cause:** `cli.ts` line 214 sets `executablePath = realpathSync.native(process.argv[1])`, which resolves to the `.js` script path (e.g. `dist/cli.js`) when running from source or from a globally installed package. `buildLaunchAgentPlist` in `scheduler.ts` line 167 placed this as the sole first `ProgramArguments` entry with no interpreter. launchd's minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) cannot find `node` via the `#!/usr/bin/env node` shebang, so the job registers but silently never executes.

**Fix (in `src/scheduler.ts`):** Inside `buildLaunchAgentPlist`, detect whether `executablePath` ends with `.js`. If so, prepend `process.execPath` (the absolute path of the current node binary) as the first `ProgramArguments` entry, with the script path as the second. Binary paths (no `.js` extension, e.g. `/usr/local/bin/uncommitted`) are passed through unchanged.

```ts
const programArguments = executablePath.endsWith(".js")
  ? [process.execPath, executablePath, ...scheduleCommand]
  : [executablePath, ...scheduleCommand];
```

This is purely conditional and backwards-compatible: the existing test for `/usr/local/bin/uncommitted` (binary path) continues to pass unchanged.

**Changed files:**
- `src/scheduler.ts` — 8 lines added (conditional interpreter logic + comment)
- `tests/scheduler.test.ts` — 21 lines added (new `.js` test + strengthened binary test)

## Validation

- `pnpm test` — **351 passed**, 2 skipped, 0 failed (36 test files)
- `pnpm build` — **pass** (tsc -p tsconfig.build.json, no errors)
- `pnpm typecheck` — **pass** (tsc --noEmit, no errors)
- `pnpm lint` — **pass** (ESLint, no errors)
- `git diff --check` — **pass** (no whitespace errors)

**TDD:** 1 attempt. RED (new test failed, 350 passed), then GREEN (all 351 passed after fix).

## Verification Steps

1. Check out this branch and build: `pnpm install && pnpm build`
2. Inspect the generated plist manually:
   ```sh
   node dist/cli.js schedule install --time 23:30
   cat ~/Library/LaunchAgents/com.uncommitted.schedule.plist
   ```
   Verify `ProgramArguments` begins with the absolute node path followed by the `.js` script path.
3. For a globally installed binary (`uncommitted schedule install`), the binary path (no `.js`) should appear as `ProgramArguments[0]` with no interpreter prepended.
4. Run `pnpm test -- tests/scheduler.test.ts` and confirm all 7 scheduler plist tests pass.

## Remaining Risk

- If a user installs via a package manager that compiles to a native binary (no `.js` extension), behavior is correct (binary path, no interpreter prepended).
- The `process.execPath` used in the plist is the node binary that ran `schedule install`. If users later upgrade Node, they may need to reinstall the schedule. This is standard launchd behavior and is out of scope for this fix.
