### PR TITLE
✨ feat(ci): add MVP release artifact workflow (UNC-72)

### DIFF
--- a/.github/workflows/release-artifact.yml
+++ b/.github/workflows/release-artifact.yml
@@ -15,6 +15,8 @@ jobs:
   build-and-package:
     name: Build, validate, and package CLI
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout

--- a/.github/workflows/release-artifact.yml
+++ b/.github/workflows/release-artifact.yml
@@ -1,0 +1,62 @@
+# .github/workflows/release-artifact.yml
+name: Release Artifact
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: release-artifact-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-package:
+    name: Build, validate, and package CLI
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.10.0
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Build
+        run: pnpm build
+
+      - name: Test
+        run: pnpm test
+
+      - name: Pack
+        run: pnpm pack
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: uncommitted-cli-${{ github.ref_name }}
+          path: '*.tgz'
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/release-artifact.yml
+++ b/.github/workflows/release-artifact.yml
@@ -55,10 +55,14 @@ jobs:
       - name: Pack
         run: pnpm pack
 
+      - name: Sanitize ref name for artifact
+        id: sanitize
+        run: echo "ref=$(echo '${{ github.ref_name }}' | tr '/' '-')" >> $GITHUB_OUTPUT
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: uncommitted-cli-${{ github.ref_name }}
+          name: uncommitted-cli-${{ steps.sanitize.outputs.ref }}
           path: '*.tgz'
           if-no-files-found: error
           retention-days: 30

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ uncommitted --help
 uncommitted init
 ```
 
-See [`docs/release/MVP-CHECKLIST.md`](docs/release/MVP-CHECKLIST.md) for the full pre-tag release checklist.
+See [`docs/release/MVP-CHECKLIST.md`](docs/release/MVP-CHECKLIST.md) for the full pre-tag release checklist and [`docs/release/CI-WORKFLOW.md`](docs/release/CI-WORKFLOW.md) for the GitHub Actions release artifact workflow.
 
 ## MVP Direction
 

--- a/docs/release/CI-WORKFLOW.md
+++ b/docs/release/CI-WORKFLOW.md
@@ -25,7 +25,7 @@ The CI workflow is **not** a substitute for the local pre-flight checks — run 
 ### Manual dispatch (recommended)
 
 1. Go to the repo on GitHub → **Actions** → **Release Artifact**
-2. Click **Run workflow** → select branch or tag → **Run workflow**
+2. Click **Run workflow**, choose the branch or tag from the dropdown, then click **Run workflow**
 
 ### Tag push (automatic)
 
@@ -43,7 +43,7 @@ The workflow starts automatically for any tag matching the `v*` pattern.
 The workflow (`.github/workflows/release-artifact.yml`) runs these steps in order:
 
 1. Checkout the repo
-2. Install pnpm 10.10.0 and Node.js 22 (mirrors `ci.yml` setup)
+2. Install pnpm 10.10.0 and Node.js 22
 3. `pnpm install --frozen-lockfile`
 4. Install Playwright Chromium (required for renderer tests)
 5. `pnpm lint`

--- a/docs/release/CI-WORKFLOW.md
+++ b/docs/release/CI-WORKFLOW.md
@@ -1,0 +1,76 @@
+# CI Release Artifact Workflow
+
+> **Automated packaging via GitHub Actions.** Use this when you need a reproducible,
+> machine-built artifact produced from a clean GitHub environment — not your local machine.
+>
+> **Workflow file:** `.github/workflows/release-artifact.yml`
+> **Does NOT publish to npm. Does NOT deploy any hosted service.**
+
+---
+
+## When to use the CI workflow vs. the local flow
+
+| Situation | Use |
+|-----------|-----|
+| Need a verifiable artifact built from a clean GitHub environment | **CI workflow** (this doc) |
+| Pre-flight smoke check before tagging on your local machine | **Local flow** — see [`MVP-CHECKLIST.md`](MVP-CHECKLIST.md) |
+| Debugging a packaging or install issue locally | **Local flow** |
+
+The CI workflow is **not** a substitute for the local pre-flight checks — run both before a real release.
+
+---
+
+## Triggers
+
+### Manual dispatch (recommended)
+
+1. Go to the repo on GitHub → **Actions** → **Release Artifact**
+2. Click **Run workflow** → select branch or tag → **Run workflow**
+
+### Tag push (automatic)
+
+```bash
+git tag -a v0.1.1 -m "MVP v0.1.1"
+git push origin v0.1.1
+```
+
+The workflow starts automatically for any tag matching the `v*` pattern.
+
+---
+
+## What the workflow does
+
+The workflow (`.github/workflows/release-artifact.yml`) runs these steps in order:
+
+1. Checkout the repo
+2. Install pnpm 10.10.0 and Node.js 22 (mirrors `ci.yml` setup)
+3. `pnpm install --frozen-lockfile`
+4. Install Playwright Chromium (required for renderer tests)
+5. `pnpm lint`
+6. `pnpm typecheck`
+7. `pnpm build`
+8. `pnpm test`
+9. `pnpm pack` — produces `uncommitted-x.y.z.tgz`
+10. Upload the `.tgz` via `actions/upload-artifact`
+
+Packaging only runs if all validation steps pass.
+
+---
+
+## Downloading the artifact
+
+1. Open the workflow run from the **Actions** tab
+2. Scroll to **Artifacts** at the bottom of the run summary
+3. Click the artifact name (e.g., `uncommitted-cli-v0.1.1`) to download the `.tgz`
+
+Artifacts are retained for **30 days**.
+
+---
+
+## What this workflow does NOT do
+
+- Does **not** publish to npm (no `npm publish`, no `NPM_TOKEN` required)
+- Does **not** deploy any hosted service or web dashboard
+- Does **not** post to Instagram or any external platform
+- Does **not** replace the local smoke test (`pnpm release:smoke`)
+- Does **not** automatically close the MVP milestone or update project board fields

--- a/docs/release/MVP-CHECKLIST.md
+++ b/docs/release/MVP-CHECKLIST.md
@@ -1,3 +1,5 @@
+> **CI packaging:** For the GitHub Actions release artifact workflow, see [`CI-WORKFLOW.md`](CI-WORKFLOW.md).
+
 # Uncommitted MVP Release Checklist
 
 > **Not published to public npm.** This is a manual local release flow for the MVP tag.

--- a/tests/release-artifact-workflow.test.ts
+++ b/tests/release-artifact-workflow.test.ts
@@ -87,4 +87,14 @@ describe("release-artifact.yml", () => {
     const content = readFileSync(workflowPath, "utf8");
     expect(content).toContain("cancel-in-progress: true");
   });
+
+  it("sanitizes ref name before using it as artifact name", () => {
+    const content = readFileSync(workflowPath, "utf8");
+    // Raw github.ref_name must not appear directly in the artifact name field —
+    // slashes in branch names (e.g. feature/foo) cause upload-artifact to fail.
+    expect(content).not.toContain("name: uncommitted-cli-${{ github.ref_name }}");
+    // Sanitized value must be used instead
+    expect(content).toContain("GITHUB_OUTPUT");
+    expect(content).toContain("tr '/' '-'");
+  });
 });

--- a/tests/release-artifact-workflow.test.ts
+++ b/tests/release-artifact-workflow.test.ts
@@ -1,0 +1,75 @@
+// tests/release-artifact-workflow.test.ts
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(fileURLToPath(import.meta.url), "../../");
+const workflowPath = resolve(
+  repoRoot,
+  ".github/workflows/release-artifact.yml"
+);
+
+describe("release-artifact.yml", () => {
+  it("exists at .github/workflows/release-artifact.yml", () => {
+    expect(existsSync(workflowPath)).toBe(true);
+  });
+
+  it("supports workflow_dispatch trigger", () => {
+    const content = readFileSync(workflowPath, "utf8");
+    expect(content).toContain("workflow_dispatch");
+  });
+
+  it("supports v* tag push trigger", () => {
+    const content = readFileSync(workflowPath, "utf8");
+    expect(content).toContain("tags:");
+    expect(content).toContain("- 'v*'");
+  });
+
+  it("pins pnpm to 10.10.0", () => {
+    const content = readFileSync(workflowPath, "utf8");
+    expect(content).toContain("version: 10.10.0");
+  });
+
+  it("uses Node.js 22", () => {
+    const content = readFileSync(workflowPath, "utf8");
+    expect(content).toContain("node-version: 22");
+  });
+
+  it("runs all validation steps before packaging", () => {
+    const content = readFileSync(workflowPath, "utf8");
+    const lintPos = content.indexOf("pnpm lint");
+    const typecheckPos = content.indexOf("pnpm typecheck");
+    const buildPos = content.indexOf("pnpm build");
+    const testPos = content.indexOf("pnpm test");
+    const packPos = content.indexOf("pnpm pack");
+    expect(lintPos, "lint step missing").toBeGreaterThan(-1);
+    expect(typecheckPos, "typecheck step missing").toBeGreaterThan(-1);
+    expect(buildPos, "build step missing").toBeGreaterThan(-1);
+    expect(testPos, "test step missing").toBeGreaterThan(-1);
+    expect(packPos, "pack step missing").toBeGreaterThan(-1);
+    // pnpm pack must come AFTER all four validation steps
+    expect(packPos, "pack must be after lint").toBeGreaterThan(lintPos);
+    expect(packPos, "pack must be after typecheck").toBeGreaterThan(typecheckPos);
+    expect(packPos, "pack must be after build").toBeGreaterThan(buildPos);
+    expect(packPos, "pack must be after test").toBeGreaterThan(testPos);
+  });
+
+  it("uploads artifact via actions/upload-artifact with *.tgz glob", () => {
+    const content = readFileSync(workflowPath, "utf8");
+    expect(content).toContain("actions/upload-artifact");
+    expect(content).toContain("*.tgz");
+  });
+
+  it("does not reference npm publish credentials", () => {
+    const content = readFileSync(workflowPath, "utf8");
+    expect(content).not.toContain("NPM_TOKEN");
+    expect(content).not.toContain("npm publish");
+    expect(content).not.toContain("NODE_AUTH_TOKEN");
+  });
+
+  it("has concurrency control", () => {
+    const content = readFileSync(workflowPath, "utf8");
+    expect(content).toContain("concurrency:");
+  });
+});

--- a/tests/release-artifact-workflow.test.ts
+++ b/tests/release-artifact-workflow.test.ts
@@ -72,4 +72,19 @@ describe("release-artifact.yml", () => {
     const content = readFileSync(workflowPath, "utf8");
     expect(content).toContain("concurrency:");
   });
+
+  it("sets if-no-files-found to error on artifact upload", () => {
+    const content = readFileSync(workflowPath, "utf8");
+    expect(content).toContain("if-no-files-found: error");
+  });
+
+  it("sets retention-days to 30 on artifact upload", () => {
+    const content = readFileSync(workflowPath, "utf8");
+    expect(content).toContain("retention-days: 30");
+  });
+
+  it("sets cancel-in-progress on concurrency", () => {
+    const content = readFileSync(workflowPath, "utf8");
+    expect(content).toContain("cancel-in-progress: true");
+  });
 });


### PR DESCRIPTION
# Goal

Add a minimal GitHub Actions release artifact workflow so MVP release candidates can be built and packaged consistently from GitHub, without requiring a developer's local machine as the only packaging path.

## Related Issue

Closes #72

Sub-issues: UNC-110 (workflow scaffold), UNC-111 (docs)

## Acceptance Criteria

- [x] `.github/workflows/release-artifact.yml` exists and can be dispatched manually from the GitHub Actions UI
- [x] Workflow uses pnpm 10.10.0 and Node.js 22 (aligned with existing CI)
- [x] Workflow runs `pnpm lint`, `pnpm typecheck`, `pnpm build`, and `pnpm test` before producing artifacts
- [x] Workflow produces a downloadable `.tgz` artifact via `actions/upload-artifact`
- [x] Workflow does not reference or require any npm publish credentials
- [x] README and `docs/release/CI-WORKFLOW.md` explain when to use this workflow vs. the local package validation flow

## Implementation Notes

- Workflow triggers: `workflow_dispatch` (manual) and `v*` tag push
- Concurrency control: `cancel-in-progress: true` on same ref
- `permissions: contents: read` scoped at job level (least-privilege hardening)
- `pnpm pack` used for packaging (equivalent to `npm pack`; consistent with pnpm toolchain in CI)
- Documentation lives in new `docs/release/CI-WORKFLOW.md`; `MVP-CHECKLIST.md` and `README.md` each received a pointer

## Validation

- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm build` ✅
- `pnpm test` — 363 passed, 1 pre-existing failure (`carousel-renderer-smoke` requires `playwright install chromium` locally, unrelated to this change)
- 12 new tests in `tests/release-artifact-workflow.test.ts` — all pass

## Remaining Risk

- `carousel-renderer-smoke` test failure is pre-existing (Playwright Chromium not installed locally); CI installs it via `playwright install --with-deps chromium` so this will pass in GitHub Actions
- `workflow_dispatch` artifact name resolves to branch name (e.g. `uncommitted-cli-main`) when triggered manually without a tag — expected behavior, not a bug