### PR TITLE
🤖 fix(scheduler): include EnvironmentVariables in launchd plist (UNC-113) — single-issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ dist/
 GEMINI.md
 .agents/
 .codex/
+.claude/
 docs/plans
+docs/superpowers/
 .codex-workflows-manifest.json
 .linear-prism-manifest.json

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,6 +41,7 @@ import { loadLatestDraftPreview } from "./preview-loader.js";
 import { formatPreview } from "./preview-formatter.js";
 import {
   buildLaunchAgentPlist,
+  captureProviderEnv,
   installScheduler,
   type LaunchctlExecutor,
   type LaunchctlRawRunner
@@ -215,7 +216,8 @@ async function runSchedule(
       const plist = buildLaunchAgentPlist({
         homeDir: options.homeDir,
         scheduleTime,
-        executablePath
+        executablePath,
+        environmentVariables: captureProviderEnv()
       });
 
       await installScheduler(plist, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,7 +140,9 @@ export type {
 } from "./safety-report.js";
 export {
   buildLaunchAgentPlist,
+  captureProviderEnv,
   getLaunchdLabel,
+  KNOWN_PROVIDER_ENV_KEYS,
   parseScheduleTime,
   resolveLaunchAgentPlistPath,
   resolveSchedulerLogPaths

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -96,6 +96,7 @@ export type SchedulerLogPaths = {
 export type LaunchAgentPlistOptions = SchedulerPathOptions & {
   scheduleTime: string;
   executablePath?: string;
+  environmentVariables?: Record<string, string>;
 };
 
 export type LaunchAgentPlist = {
@@ -119,6 +120,32 @@ export type InstallSchedulerOptions = SchedulerPathOptions & {
 const launchdLabel = "com.uncommitted.schedule";
 const defaultExecutableName = "uncommitted";
 const scheduleCommand = ["schedule", "run-now"] as const;
+
+export const KNOWN_PROVIDER_ENV_KEYS = [
+  "OPENAI_API_KEY",
+  "OPENROUTER_API_KEY",
+  "UNCOMMITTED_AI_TIMEOUT_MS"
+] as const;
+
+/**
+ * Reads only the known provider env keys from `source`, omits keys whose
+ * value is undefined or empty string, and returns the remaining as a
+ * Record<string, string>.
+ */
+export function captureProviderEnv(
+  source: NodeJS.ProcessEnv = process.env
+): Record<string, string> {
+  const result: Record<string, string> = {};
+
+  for (const key of KNOWN_PROVIDER_ENV_KEYS) {
+    const value = source[key];
+    if (value !== undefined && value.trim() !== "") {
+      result[key] = value;
+    }
+  }
+
+  return result;
+}
 
 export function getLaunchdLabel(): string {
   return launchdLabel;
@@ -175,7 +202,8 @@ export function buildLaunchAgentPlist(
     hour,
     minute,
     stdoutLogPath: logs.stdout,
-    stderrLogPath: logs.stderr
+    stderrLogPath: logs.stderr,
+    environmentVariables: options.environmentVariables
   });
 
   return {
@@ -231,10 +259,29 @@ function renderLaunchAgentPlistXml(options: {
   minute: number;
   stdoutLogPath: string;
   stderrLogPath: string;
+  environmentVariables?: Record<string, string>;
 }): string {
   const programArgumentXml = options.programArguments
     .map((argument) => `    <string>${escapePlistString(argument)}</string>`)
     .join("\n");
+
+  const envVars = options.environmentVariables;
+  const hasEnvVars = envVars !== undefined && Object.keys(envVars).length > 0;
+  const environmentVariablesXml = hasEnvVars
+    ? [
+        "  <key>EnvironmentVariables</key>",
+        "  <dict>",
+        ...Object.keys(envVars)
+          .sort()
+          .map(
+            (key) =>
+              `    <key>${escapePlistString(key)}</key>\n    <string>${escapePlistString(envVars[key])}</string>`
+          ),
+        "  </dict>"
+      ].join("\n") + "\n"
+    : "";
+
+  const afterInterval = hasEnvVars ? `\n${environmentVariablesXml}` : "";
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -252,7 +299,7 @@ ${programArgumentXml}
     <integer>${options.hour}</integer>
     <key>Minute</key>
     <integer>${options.minute}</integer>
-  </dict>
+  </dict>${afterInterval}
   <key>StandardOutPath</key>
   <string>${escapePlistString(options.stdoutLogPath)}</string>
   <key>StandardErrorPath</key>

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -231,7 +231,7 @@ export async function installScheduler(
   await mkdir(dirname(logs.stdout), { recursive: true });
 
   await mkdir(dirname(plist.plistPath), { recursive: true });
-  await writeFile(plist.plistPath, plist.xml, "utf8");
+  await writeFile(plist.plistPath, plist.xml, { encoding: "utf8", mode: 0o600 });
 
   // We use bootout/bootstrap for modern macOS launchctl (10.11+)
   // bootout might fail if not already loaded, so we ignore that error.

--- a/tests/scheduler-install.test.ts
+++ b/tests/scheduler-install.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
@@ -34,6 +34,30 @@ describe("scheduler install", () => {
       ["bootout", "gui/501", plist.plistPath],
       ["bootstrap", "gui/501", plist.plistPath]
     ]);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("writes plist with owner-only (0600) permissions", async () => {
+    vi.stubGlobal("process", {
+      ...process,
+      platform: "darwin",
+      getuid: () => 501
+    });
+
+    const homeDir = await mkdtemp(join(tmpdir(), "uncommitted-install-perms-"));
+    const plist = buildLaunchAgentPlist({
+      homeDir,
+      scheduleTime: "23:30"
+    });
+
+    await installScheduler(plist, {
+      homeDir,
+      executor: async () => ({ stdout: "", stderr: "" })
+    });
+
+    const { mode } = await stat(plist.plistPath);
+    expect(mode & 0o777).toBe(0o600);
 
     vi.unstubAllGlobals();
   });

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   buildLaunchAgentPlist,
+  captureProviderEnv,
   getLaunchdLabel,
   parseScheduleTime,
   resolveLaunchAgentPlistPath,
@@ -135,5 +136,193 @@ describe("macOS scheduler plist helpers", () => {
         "Schedule time must use 24-hour HH:mm format."
       );
     }
+  });
+
+  it("includes EnvironmentVariables dict when env vars are provided", () => {
+    const homeDir = "/tmp/uncommitted-scheduler-home";
+
+    const plist = buildLaunchAgentPlist({
+      homeDir,
+      scheduleTime: "23:30",
+      environmentVariables: { OPENAI_API_KEY: "sk-test" }
+    });
+
+    expect(plist.xml).toContain("<key>EnvironmentVariables</key>");
+    expect(plist.xml).toContain("<key>OPENAI_API_KEY</key>");
+    expect(plist.xml).toContain("<string>sk-test</string>");
+  });
+
+  it("omits EnvironmentVariables key when no env vars are provided", () => {
+    const homeDir = "/tmp/uncommitted-scheduler-home";
+
+    const plist = buildLaunchAgentPlist({
+      homeDir,
+      scheduleTime: "23:30"
+    });
+
+    expect(plist.xml).not.toContain("EnvironmentVariables");
+  });
+
+  it("omits EnvironmentVariables key when empty object is provided", () => {
+    const homeDir = "/tmp/uncommitted-scheduler-home";
+
+    const plist = buildLaunchAgentPlist({
+      homeDir,
+      scheduleTime: "23:30",
+      environmentVariables: {}
+    });
+
+    expect(plist.xml).not.toContain("EnvironmentVariables");
+  });
+
+  it("XML-escapes env var values containing special characters", () => {
+    const homeDir = "/tmp/uncommitted-scheduler-home";
+
+    const plist = buildLaunchAgentPlist({
+      homeDir,
+      scheduleTime: "23:30",
+      environmentVariables: { SPECIAL_VAR: "val&<>\"'" }
+    });
+
+    expect(plist.xml).toContain("<key>SPECIAL_VAR</key>");
+    expect(plist.xml).toContain("<string>val&amp;&lt;&gt;&quot;&apos;</string>");
+    expect(plist.xml).not.toContain("<string>val&<>\"'</string>");
+  });
+
+  it("emits multiple env vars in alphabetical key order for determinism", () => {
+    const homeDir = "/tmp/uncommitted-scheduler-home";
+
+    const plist = buildLaunchAgentPlist({
+      homeDir,
+      scheduleTime: "23:30",
+      environmentVariables: {
+        OPENROUTER_API_KEY: "sk-or-test",
+        OPENAI_API_KEY: "sk-test",
+        UNCOMMITTED_AI_TIMEOUT_MS: "5000"
+      }
+    });
+
+    const openaiPos = plist.xml.indexOf("<key>OPENAI_API_KEY</key>");
+    const openrouterPos = plist.xml.indexOf("<key>OPENROUTER_API_KEY</key>");
+    const timeoutPos = plist.xml.indexOf("<key>UNCOMMITTED_AI_TIMEOUT_MS</key>");
+
+    // Alphabetical: OPENAI < OPENROUTER < UNCOMMITTED
+    expect(openaiPos).toBeLessThan(openrouterPos);
+    expect(openrouterPos).toBeLessThan(timeoutPos);
+  });
+
+  it("produces exact byte-for-byte XML when env vars are provided", () => {
+    const homeDir = "/tmp/uncommitted-scheduler-home";
+
+    const plist = buildLaunchAgentPlist({
+      homeDir,
+      scheduleTime: "08:00",
+      executablePath: "uncommitted",
+      environmentVariables: {
+        OPENROUTER_API_KEY: "or-xyz",
+        OPENAI_API_KEY: "sk-abc"
+      }
+    });
+
+    const expectedXml = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.uncommitted.schedule</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>uncommitted</string>
+    <string>schedule</string>
+    <string>run-now</string>
+  </array>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key>
+    <integer>8</integer>
+    <key>Minute</key>
+    <integer>0</integer>
+  </dict>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>OPENAI_API_KEY</key>
+    <string>sk-abc</string>
+    <key>OPENROUTER_API_KEY</key>
+    <string>or-xyz</string>
+  </dict>
+
+  <key>StandardOutPath</key>
+  <string>/tmp/uncommitted-scheduler-home/.uncommitted/logs/schedule.stdout.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/uncommitted-scheduler-home/.uncommitted/logs/schedule.stderr.log</string>
+</dict>
+</plist>
+`;
+
+    expect(plist.xml).toBe(expectedXml);
+  });
+});
+
+describe("captureProviderEnv", () => {
+  it("captures only known provider env keys", () => {
+    const result = captureProviderEnv({
+      OPENAI_API_KEY: "sk-test",
+      OPENROUTER_API_KEY: "sk-or-test",
+      UNCOMMITTED_AI_TIMEOUT_MS: "5000",
+      HOME: "/home/user",
+      SOME_OTHER_VAR: "value"
+    });
+
+    expect(result).toEqual({
+      OPENAI_API_KEY: "sk-test",
+      OPENROUTER_API_KEY: "sk-or-test",
+      UNCOMMITTED_AI_TIMEOUT_MS: "5000"
+    });
+    expect(result).not.toHaveProperty("HOME");
+    expect(result).not.toHaveProperty("SOME_OTHER_VAR");
+  });
+
+  it("omits keys with undefined values", () => {
+    const result = captureProviderEnv({
+      OPENAI_API_KEY: undefined,
+      OPENROUTER_API_KEY: "sk-or-test"
+    });
+
+    expect(result).not.toHaveProperty("OPENAI_API_KEY");
+    expect(result).toEqual({ OPENROUTER_API_KEY: "sk-or-test" });
+  });
+
+  it("omits keys with empty string values", () => {
+    const result = captureProviderEnv({
+      OPENAI_API_KEY: "",
+      OPENROUTER_API_KEY: "sk-or-test"
+    });
+
+    expect(result).not.toHaveProperty("OPENAI_API_KEY");
+    expect(result).toEqual({ OPENROUTER_API_KEY: "sk-or-test" });
+  });
+
+  it("omits keys whose value is whitespace-only", () => {
+    const result = captureProviderEnv({
+      OPENAI_API_KEY: "   ",
+      OPENROUTER_API_KEY: "\t",
+      UNCOMMITTED_AI_TIMEOUT_MS: "5000"
+    });
+
+    expect(result).not.toHaveProperty("OPENAI_API_KEY");
+    expect(result).not.toHaveProperty("OPENROUTER_API_KEY");
+    expect(result).toEqual({ UNCOMMITTED_AI_TIMEOUT_MS: "5000" });
+  });
+
+  it("returns empty object when no known keys are present", () => {
+    const result = captureProviderEnv({ HOME: "/home/user", PATH: "/usr/bin" });
+
+    expect(result).toEqual({});
+  });
+
+  it("defaults to process.env when no source is provided", () => {
+    // Just verify it doesn't throw and returns a record
+    const result = captureProviderEnv();
+    expect(typeof result).toBe("object");
   });
 });


### PR DESCRIPTION
🤖 **Auto-generated by Uncommitted Builder (Routine B v2 — single-issue path)**

## Issue

[UNC-113: [Bug] launchd scheduler omits EnvironmentVariables — OPENAI_API_KEY missing at runtime causes generate to fail silently](https://linear.app/sangchu/issue/UNC-113/bug-launchd-scheduler-omits-environmentvariables-openai-api-key)

Routine A가 분해 불필요(`single-issue`)로 판정하여 sub-issue 없이 이 이슈를 그대로 단일 작업으로 처리했습니다.

Closes UNC-113

## Root cause

`scheduler.ts:renderLaunchAgentPlistXml` 는 plist XML에 `EnvironmentVariables` 섹션을 포함하지 않았다. launchd는 사용자 셸 환경을 상속하지 않으므로 `~/.zshrc`에 설정된 `OPENAI_API_KEY` 등 프로바이더 키가 스케줄 실행 시점에 누락된다. `uncommitted generate today`는 `activity-summary.json`만 쓰고 AI 호출 직전 `AiGenerationError: OPENAI_API_KEY is not set.`로 중단되고, `latest.json`은 갱신되지 않은 채 직전 성공 draft를 계속 가리키게 된다.

## Fix

- `KNOWN_PROVIDER_ENV_KEYS` 상수와 `captureProviderEnv(source = process.env)` 헬퍼 신설 — `OPENAI_API_KEY`, `OPENROUTER_API_KEY`, `UNCOMMITTED_AI_TIMEOUT_MS` 중 정의되어 있고 공백이 아닌 값만 추출.
- `LaunchAgentPlistOptions.environmentVariables?: Record<string, string>` 추가, `buildLaunchAgentPlist → renderLaunchAgentPlistXml` 까지 전달.
- 비어 있지 않으면 plist XML에 알파벳 정렬된 `<key>EnvironmentVariables</key><dict>...</dict>` 블록을 emit (XML escape 포함). 비어 있으면 블록 자체를 생략하여 기존 결정론적 plist XML 테스트가 byte-identical 하게 통과한다.
- `cli.ts`의 `schedule install` 호출 부에서 `captureProviderEnv()` 결과를 plist 빌더에 주입.
- `src/index.ts` 배럴에 두 새 심볼 재수출.

## Status

- Branch: `claude/UNC-113-launchd-env-vars`
- Tests: ✅ 377/378 passed (1 skipped, vitest)
- Build: ✅ `pnpm build`
- Type check: ✅ `pnpm typecheck`
- Lint: ✅ `pnpm lint`

## TDD trail

- Attempt 1 (implementer): ✅ success — RED tests written first, GREEN with minimal change, all checks pass.
- Reviewer pass 1: `minor_issues` (missing barrel re-exports, no whitespace-only filter, no byte-for-byte XML test).
- Attempt 2 (implementer fix-up): ✅ all 3 review findings fixed, tests pass clean.

## Notes

- No lockfile changes.
- No new dependencies.
- No `.env*` / `AGENTS.md` modifications.
- No auto-publish / SNS code introduced.
- `~/Library/LaunchAgents/*.plist` lives in the user's private home; storing API keys there matches the existing security model (`.zshrc`).

## Verification (manual, post-merge)

```bash
# Re-install to propagate keys
export OPENAI_API_KEY=sk-...
uncommitted schedule install --time 23:30

# Confirm EnvironmentVariables block in the generated plist
grep -A 4 EnvironmentVariables ~/Library/LaunchAgents/com.uncommitted.schedule.plist

# Trigger immediate run; latest.json should advance to today
uncommitted schedule run-now
cat ~/Uncommitted/drafts/latest.json
```

## Review checklist

- [x] Verify TDD test coverage (5 new env-vars XML tests + 6 `captureProviderEnv` tests + byte-for-byte XML pin)
- [x] Confirm no lockfile changes
- [x] Run `pnpm install && pnpm test && pnpm build` locally
- [x] Confirm no auto-publish code introduced
- [x] **single-issue 판정이 적절했는지 확인** — 만약 사후에 분해가 필요했다고 판단되면 PR 닫고 이슈에서 `single-issue` 라벨 제거 후 Decomposer 재실행 권장

---

이 PR은 자동 생성되었습니다. 머지 전 사람의 리뷰가 반드시 필요합니다.
