### PR TITLE
🤖 feat: add Anthropic AI provider adapter (UNC-41) — single-issue

### DIFF
--- a/src/ai-provider.ts
+++ b/src/ai-provider.ts
@@ -702,6 +702,7 @@ function createAnthropicMessagesBody(
       {
         name: toolName,
         description: "Return the structured output for this task.",
+        strict: true,
         input_schema: schema
       }
     ],

--- a/src/ai-provider.ts
+++ b/src/ai-provider.ts
@@ -277,6 +277,24 @@ export function createAiProvider(
     });
   }
 
+  if (config.provider === "anthropic") {
+    const apiKey = resolveEnvValue(options, "ANTHROPIC_API_KEY");
+
+    if (!apiKey) {
+      throw new AiGenerationError(
+        "ANTHROPIC_API_KEY is not set.",
+        "provider-unavailable"
+      );
+    }
+
+    return new AnthropicProvider({
+      apiKey,
+      model: "claude-sonnet-4-6",
+      timeoutMs: resolveProviderTimeoutMs(options),
+      transport: options.transport ?? defaultFetchTransport
+    });
+  }
+
   throw new AiGenerationError(
     `AI provider is not implemented yet: ${config.provider}.`,
     "provider-unavailable"
@@ -410,6 +428,68 @@ class OpenAiCompatibleProvider implements AiProvider {
       }
 
       return { responseJson: extractChatCompletionContent(await readResponseJson(response)) };
+    } catch (error) {
+      if (error instanceof AiGenerationError) {
+        throw error;
+      }
+
+      if (isAbortError(error)) {
+        throw new AiGenerationError(
+          "AI provider timed out. Try again later.",
+          "provider-failed"
+        );
+      }
+
+      throw new AiGenerationError(
+        "AI provider failed. Check provider configuration.",
+        "provider-failed"
+      );
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+class AnthropicProvider implements AiProvider {
+  public readonly name = "anthropic" as const;
+  public readonly model: string;
+
+  constructor(
+    private readonly options: {
+      apiKey: string;
+      model: string;
+      timeoutMs: number;
+      transport: AiProviderHttpTransport;
+    }
+  ) {
+    this.model = options.model;
+  }
+
+  async generateStructured(
+    request: AiStructuredGenerationRequest
+  ): Promise<AiProviderRawResponse> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.options.timeoutMs);
+
+    try {
+      const response = await this.options.transport("https://api.anthropic.com/v1/messages", {
+        method: "POST",
+        headers: {
+          "x-api-key": this.options.apiKey,
+          "anthropic-version": "2023-06-01",
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify(createAnthropicMessagesBody(request, this.options.model)),
+        signal: controller.signal
+      });
+
+      if (!response.ok) {
+        throwProviderHttpError(response.status);
+      }
+
+      return {
+        responseJson: extractAnthropicToolUseContent(await readResponseJson(response))
+      };
     } catch (error) {
       if (error instanceof AiGenerationError) {
         throw error;
@@ -595,6 +675,70 @@ function extractChatCompletionContent(value: unknown): string {
   }
 
   return content;
+}
+
+function createAnthropicMessagesBody(
+  request: AiStructuredGenerationRequest,
+  model: string
+): JsonObject {
+  const { toolName, schema } = createAnthropicToolDefinition(request.task);
+
+  return {
+    model,
+    max_tokens: 4096,
+    system: [
+      request.instructions,
+      "The response_format JSON schema is authoritative.",
+      "Return only one valid JSON object.",
+      "Do not wrap the JSON in Markdown or prose."
+    ].join("\n"),
+    messages: [
+      {
+        role: "user",
+        content: JSON.stringify({ task: request.task, input: request.input })
+      }
+    ],
+    tools: [
+      {
+        name: toolName,
+        description: "Return the structured output for this task.",
+        input_schema: schema
+      }
+    ],
+    tool_choice: { type: "tool", name: toolName }
+  };
+}
+
+function createAnthropicToolDefinition(task: AiGenerationTask): {
+  toolName: string;
+  schema: JsonObject;
+} {
+  if (task === "story-plan") {
+    return { toolName: "uncommitted_story_format_plan", schema: createStoryFormatPlanSchema() };
+  }
+
+  if (task === "caption") {
+    return { toolName: "uncommitted_caption", schema: createCaptionSchema() };
+  }
+
+  return { toolName: "uncommitted_diary_draft", schema: createDiaryDraftSchema() };
+}
+
+function extractAnthropicToolUseContent(value: unknown): string {
+  if (!isRecord(value) || !Array.isArray(value.content) || value.content.length === 0) {
+    throwInvalidProviderJson();
+  }
+
+  const toolUseBlock = (value.content as unknown[]).find(
+    (block): block is Record<string, unknown> =>
+      isRecord(block) && block.type === "tool_use"
+  );
+
+  if (!toolUseBlock || !isRecord(toolUseBlock.input)) {
+    throwInvalidProviderJson();
+  }
+
+  return JSON.stringify(toolUseBlock.input);
 }
 
 async function readResponseJson(

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -124,6 +124,7 @@ const scheduleCommand = ["schedule", "run-now"] as const;
 export const KNOWN_PROVIDER_ENV_KEYS = [
   "OPENAI_API_KEY",
   "OPENROUTER_API_KEY",
+  "ANTHROPIC_API_KEY",
   "UNCOMMITTED_AI_TIMEOUT_MS"
 ] as const;
 

--- a/tests/ai-provider.test.ts
+++ b/tests/ai-provider.test.ts
@@ -307,7 +307,12 @@ describe("AI provider abstraction", () => {
       max_tokens?: number;
       system?: string;
       messages?: Array<{ role: string; content: string }>;
-      tools?: Array<{ name: string; description: string; input_schema: unknown }>;
+      tools?: Array<{
+        name: string;
+        description: string;
+        strict?: boolean;
+        input_schema: unknown;
+      }>;
       tool_choice?: { type: string; name: string };
     };
 
@@ -320,6 +325,7 @@ describe("AI provider abstraction", () => {
     expect(typeof body.messages?.[0]?.content).toBe("string");
     expect(body.tools).toHaveLength(1);
     expect(body.tools?.[0]?.name).toBe("uncommitted_story_format_plan");
+    expect(body.tools?.[0]?.strict).toBe(true);
     expect(typeof body.tools?.[0]?.input_schema).toBe("object");
     expect(body.tool_choice).toEqual({ type: "tool", name: "uncommitted_story_format_plan" });
     expect(JSON.stringify(body)).not.toContain("sk-ant-test-secret");

--- a/tests/ai-provider.test.ts
+++ b/tests/ai-provider.test.ts
@@ -249,7 +249,7 @@ describe("AI provider abstraction", () => {
   it("fails clearly for configured providers that do not have adapters yet", () => {
     expect(() =>
       createAiProvider({
-        provider: "anthropic",
+        provider: "google",
         persona: "dry reviewer",
         roastLevel: 3
       })
@@ -257,9 +257,298 @@ describe("AI provider abstraction", () => {
       expect.objectContaining({
         code: "provider-unavailable",
         exitCode: 4,
-        message: "AI provider is not implemented yet: anthropic."
+        message: "AI provider is not implemented yet: google."
       })
     );
+  });
+
+  it("creates an Anthropic provider with environment credentials and safe JSON requests", async () => {
+    const calls: Array<{ url: string; request: AiProviderHttpRequest }> = [];
+    const provider = createAiProvider(
+      {
+        provider: "anthropic",
+        persona: "dry reviewer",
+        roastLevel: 3
+      },
+      {
+        env: { ANTHROPIC_API_KEY: "sk-ant-test-secret" },
+        transport: createTransport(calls, {
+          content: [
+            {
+              type: "tool_use",
+              name: "uncommitted_story_format_plan",
+              input: { title: "Anthropic provider day", beats: ["Configured", "Generated"] }
+            }
+          ],
+          stop_reason: "tool_use"
+        })
+      }
+    );
+    const request = createAiGenerationRequest({
+      task: "story-plan",
+      instructions: "Return a compact JSON object.",
+      summary: createQuietSummary()
+    });
+
+    await expect(generateStructured(provider, request)).resolves.toEqual({
+      schemaVersion: 1,
+      provider: "anthropic",
+      data: { title: "Anthropic provider day", beats: ["Configured", "Generated"] }
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe("https://api.anthropic.com/v1/messages");
+    expect(calls[0]?.request.headers["x-api-key"]).toBe("sk-ant-test-secret");
+    expect(calls[0]?.request.headers["anthropic-version"]).toBe("2023-06-01");
+    expect(calls[0]?.request.headers["Content-Type"]).toBe("application/json");
+
+    const body = JSON.parse(calls[0]?.request.body ?? "{}") as {
+      model?: string;
+      max_tokens?: number;
+      system?: string;
+      messages?: Array<{ role: string; content: string }>;
+      tools?: Array<{ name: string; description: string; input_schema: unknown }>;
+      tool_choice?: { type: string; name: string };
+    };
+
+    expect(body.model).toBe("claude-sonnet-4-6");
+    expect(typeof body.max_tokens).toBe("number");
+    expect(body.max_tokens).toBeGreaterThan(0);
+    expect(typeof body.system).toBe("string");
+    expect(body.messages).toHaveLength(1);
+    expect(body.messages?.[0]?.role).toBe("user");
+    expect(typeof body.messages?.[0]?.content).toBe("string");
+    expect(body.tools).toHaveLength(1);
+    expect(body.tools?.[0]?.name).toBe("uncommitted_story_format_plan");
+    expect(typeof body.tools?.[0]?.input_schema).toBe("object");
+    expect(body.tool_choice).toEqual({ type: "tool", name: "uncommitted_story_format_plan" });
+    expect(JSON.stringify(body)).not.toContain("sk-ant-test-secret");
+  });
+
+  it("creates an Anthropic provider that uses the diary draft schema for the draft task", async () => {
+    const calls: Array<{ url: string; request: AiProviderHttpRequest }> = [];
+    const provider = createAiProvider(
+      {
+        provider: "anthropic",
+        persona: "dry reviewer",
+        roastLevel: 3
+      },
+      {
+        env: { ANTHROPIC_API_KEY: "sk-ant-test-secret" },
+        transport: createTransport(calls, {
+          content: [
+            {
+              type: "tool_use",
+              name: "uncommitted_diary_draft",
+              input: { title: "Draft day", slides: [], altText: "A quiet day." }
+            }
+          ],
+          stop_reason: "tool_use"
+        })
+      }
+    );
+
+    await generateStructured(
+      provider,
+      createAiGenerationRequest({
+        task: "draft",
+        instructions: "Return JSON.",
+        summary: createQuietSummary()
+      })
+    );
+
+    const body = JSON.parse(calls[0]?.request.body ?? "{}") as {
+      tools?: Array<{ name: string }>;
+      tool_choice?: { type: string; name: string };
+    };
+
+    expect(body.tools?.[0]?.name).toBe("uncommitted_diary_draft");
+    expect(body.tool_choice?.name).toBe("uncommitted_diary_draft");
+  });
+
+  it("fails clearly when ANTHROPIC_API_KEY is missing", () => {
+    expect(() =>
+      createAiProvider(
+        {
+          provider: "anthropic",
+          persona: "dry reviewer",
+          roastLevel: 3
+        },
+        { env: {} }
+      )
+    ).toThrow(
+      expect.objectContaining({
+        code: "provider-unavailable",
+        exitCode: 4,
+        message: "ANTHROPIC_API_KEY is not set."
+      })
+    );
+  });
+
+  it("normalizes Anthropic HTTP failures without leaking response bodies", async () => {
+    const provider = createAiProvider(
+      {
+        provider: "anthropic",
+        persona: "dry reviewer",
+        roastLevel: 3
+      },
+      {
+        env: { ANTHROPIC_API_KEY: "sk-ant-test-secret" },
+        transport: createTransport(
+          [],
+          { error: { type: "authentication_error", message: "invalid x-api-key sk-ant-test-secret" } },
+          401
+        )
+      }
+    );
+
+    await expect(
+      generateStructured(
+        provider,
+        createAiGenerationRequest({
+          task: "draft",
+          instructions: "Return JSON.",
+          summary: createQuietSummary()
+        })
+      )
+    ).rejects.toMatchObject({
+      code: "provider-failed",
+      exitCode: 4,
+      message: "AI provider authentication failed. Check API key."
+    });
+  });
+
+  it("normalizes Anthropic rate-limit failures", async () => {
+    const provider = createAiProvider(
+      {
+        provider: "anthropic",
+        persona: "dry reviewer",
+        roastLevel: 3
+      },
+      {
+        env: { ANTHROPIC_API_KEY: "sk-ant-test-secret" },
+        transport: createTransport([], { error: "rate limit exceeded" }, 429)
+      }
+    );
+
+    await expect(
+      generateStructured(
+        provider,
+        createAiGenerationRequest({
+          task: "draft",
+          instructions: "Return JSON.",
+          summary: createQuietSummary()
+        })
+      )
+    ).rejects.toMatchObject({
+      code: "provider-failed",
+      exitCode: 4,
+      message: "AI provider rate limit exceeded. Try again later."
+    });
+  });
+
+  it("normalizes Anthropic timeout via env override", async () => {
+    const provider = createAiProvider(
+      {
+        provider: "anthropic",
+        persona: "dry reviewer",
+        roastLevel: 3
+      },
+      {
+        env: {
+          ANTHROPIC_API_KEY: "sk-ant-test-secret",
+          UNCOMMITTED_AI_TIMEOUT_MS: "1"
+        },
+        transport: async (_url, request) => {
+          return await new Promise<AiProviderHttpResponse>((_resolve, reject) => {
+            request.signal?.addEventListener("abort", () => {
+              const error = new Error("aborted");
+              error.name = "AbortError";
+              reject(error);
+            });
+          });
+        }
+      }
+    );
+
+    await expect(
+      generateStructured(
+        provider,
+        createAiGenerationRequest({
+          task: "draft",
+          instructions: "Return JSON.",
+          summary: createQuietSummary()
+        })
+      )
+    ).rejects.toMatchObject({
+      code: "provider-failed",
+      exitCode: 4,
+      message: "AI provider timed out. Try again later."
+    });
+  });
+
+  it("fails before downstream generation when Anthropic response has no tool_use block", async () => {
+    const provider = createAiProvider(
+      {
+        provider: "anthropic",
+        persona: "dry reviewer",
+        roastLevel: 3
+      },
+      {
+        env: { ANTHROPIC_API_KEY: "sk-ant-test-secret" },
+        transport: createTransport([], {
+          content: [{ type: "text", text: "no tool used" }],
+          stop_reason: "end_turn"
+        })
+      }
+    );
+
+    await expect(
+      generateStructured(
+        provider,
+        createAiGenerationRequest({
+          task: "story-plan",
+          instructions: "Return JSON.",
+          summary: createQuietSummary()
+        })
+      )
+    ).rejects.toMatchObject({
+      code: "malformed-response",
+      exitCode: 4,
+      message: "AI provider returned invalid JSON."
+    });
+  });
+
+  it("fails when Anthropic tool_use input is not valid JSON-serializable structure", async () => {
+    const provider = createAiProvider(
+      {
+        provider: "anthropic",
+        persona: "dry reviewer",
+        roastLevel: 3
+      },
+      {
+        env: { ANTHROPIC_API_KEY: "sk-ant-test-secret" },
+        transport: createTransport([], {
+          content: [{ type: "tool_use", name: "x", input: "not an object" }],
+          stop_reason: "tool_use"
+        })
+      }
+    );
+
+    await expect(
+      generateStructured(
+        provider,
+        createAiGenerationRequest({
+          task: "story-plan",
+          instructions: "Return JSON.",
+          summary: createQuietSummary()
+        })
+      )
+    ).rejects.toMatchObject({
+      code: "malformed-response",
+      exitCode: 4,
+      message: "AI provider returned invalid JSON."
+    });
   });
 
   it("normalizes OpenAI-compatible HTTP failures without leaking response bodies", async () => {

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -268,6 +268,7 @@ describe("captureProviderEnv", () => {
     const result = captureProviderEnv({
       OPENAI_API_KEY: "sk-test",
       OPENROUTER_API_KEY: "sk-or-test",
+      ANTHROPIC_API_KEY: "sk-ant-test",
       UNCOMMITTED_AI_TIMEOUT_MS: "5000",
       HOME: "/home/user",
       SOME_OTHER_VAR: "value"
@@ -276,6 +277,7 @@ describe("captureProviderEnv", () => {
     expect(result).toEqual({
       OPENAI_API_KEY: "sk-test",
       OPENROUTER_API_KEY: "sk-or-test",
+      ANTHROPIC_API_KEY: "sk-ant-test",
       UNCOMMITTED_AI_TIMEOUT_MS: "5000"
     });
     expect(result).not.toHaveProperty("HOME");


### PR DESCRIPTION
🤖 **Auto-generated by Uncommitted Builder (Routine B v2 — single-issue path)**

Routine A가 분해 불필요(single-issue)로 판정하여 sub-issue 없이 이 이슈를 그대로 단일 작업으로 처리했습니다.
머지 전 사람의 리뷰가 반드시 필요합니다.

---

# Goal

Add an Anthropic provider adapter behind the existing `AiProvider` interface so users who configure `aiProvider: "anthropic"` can generate diary drafts with Anthropic's hosted API.

## Related Issue

Closes #41
Linear: [UNC-41](https://linear.app/sangchu/issue/UNC-41/feat-add-anthropic-ai-provider-adapter)

## Acceptance Criteria

- [x] `aiProvider: "anthropic"` creates an Anthropic-backed provider
- [x] Missing `ANTHROPIC_API_KEY` fails with a short actionable generation error suitable for exit code `4`
- [x] Anthropic request payloads include only safe summarized generation inputs
- [x] Anthropic responses are parsed as structured JSON before downstream use
- [x] Auth, network, rate-limit, timeout, provider, and malformed-response failures do not leak secrets or raw provider traces
- [x] Mock provider behavior remains deterministic
- [x] Unit tests cover provider selection, credential handling, successful mocked response, provider failure, and malformed response behavior

## Implementation Notes

- New `AnthropicProvider` class lives inline in `src/ai-provider.ts` alongside `OpenAiCompatibleProvider`. It targets `https://api.anthropic.com/v1/messages` with `x-api-key` + `anthropic-version: 2023-06-01` + `Content-Type: application/json` headers. Default model: `claude-sonnet-4-6`.
- Structured JSON is forced via Anthropic's native tool-use mechanism (`tools` + `tool_choice: { type: "tool", name: "<schema name>" }`) rather than OpenAI's `response_format.json_schema`. The existing `createStoryFormatPlanSchema` / `createCaptionSchema` / `createDiaryDraftSchema` factories are reused so schema edits stay in one place.
- Response extraction finds the first `content` entry with `type === "tool_use"` and serializes its `input` through the existing `parseStructuredResponse`. Missing tool_use block or non-object input → `malformed-response`.
- HTTP/abort/error mapping reuses `throwProviderHttpError`, `throwInvalidProviderJson`, `resolveProviderTimeoutMs`, `resolveEnvValue`, `defaultFetchTransport`, `readResponseJson`, and `isAbortError` — no duplication of the OpenAI-compatible plumbing.
- The pre-existing "fails clearly for configured providers that do not have adapters yet" test was repointed from `anthropic` to `google` (rather than deleted) so the not-implemented path stays covered for the providers that still lack adapters.
- No new npm dependencies. No `package.json` or `pnpm-lock.yaml` changes. No `.env*` / `AGENTS.md` / `CLAUDE.md` touches.

## Validation

- `pnpm test` ✅ 386 passed, 1 skipped (pre-existing), 0 failed
- `pnpm build` ✅
- `pnpm lint` ✅
- `pnpm typecheck` ✅ (`tsc --noEmit -p tsconfig.json`)
- `git diff --check` ✅ no whitespace issues

## Remaining Risk

- No live integration test against the real Anthropic API was run — the issue explicitly excludes that. The success-path test mocks the transport. First production use will be the first real round-trip; recommend a manual smoke after merge with a throwaway `ANTHROPIC_API_KEY` against one quiet day's summary.
- Default model is hardcoded to `claude-sonnet-4-6`. If the model is later retired or renamed, this becomes a config touchpoint — same shape as the existing OpenAI / OpenRouter hardcoded defaults.
- **single-issue path**: Routine A judged this issue small enough to skip decomposition. If on review you feel it should have been split (e.g. you'd prefer the new tests in their own PR), close this PR, remove the `single-issue` label, move UNC-41 back to Todo, and the next Decomposer run will re-evaluate.

---

## Builder run trail

- Branch: `claude/UNC-41-anthropic-provider`
- Commit: `b866c18`
- Dispatch: Implementer (Sonnet 4.6) — succeeded on attempt 1. Reviewer (Sonnet 4.6) — verdict `pass`, 1 low-severity comment-readability nit (non-blocking, can be addressed in review if desired).
- TDD trail: RED tests authored first, then GREEN implementation, then REFACTOR pass for helper reuse. 8 new mock-transport test cases added.

## Review checklist

- [ ] Confirm endpoint, headers, default model, and env var name are what you want long-term
- [ ] Verify TDD test coverage matches your bar for new provider adapters
- [ ] Confirm no lockfile changes (or, if any, justified) — none expected here
- [ ] Run `pnpm install && pnpm test && pnpm build` locally to reproduce
- [ ] Confirm no auto-publish code introduced
- [ ] **Confirm single-issue judgment was appropriate** — if you'd have preferred decomposition, see Remaining Risk above for the rollback path