### PR TITLE
🤖 [Improvement] move export instagram output sibling to drafts (UNC-123)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,34 @@ See [`docs/release/MVP-CHECKLIST.md`](docs/release/MVP-CHECKLIST.md) for the ful
 ## MVP Direction
 
 The MVP is macOS-first and outputs local drafts, metadata, captions, safety reports, and 4:5 Instagram carousel PNGs. It does not auto-publish.
+
+## Exports
+
+`uncommitted export instagram` writes Instagram-ready output to:
+
+```
+~/Uncommitted/exports/instagram/<date>/<rev>/
+```
+
+This sits **sibling to `drafts/`**, not inside it. Prior versions wrote to `~/Uncommitted/drafts/exports/instagram/...`; that legacy location is no longer used.
+
+### Migrating from the legacy export location
+
+If you previously ran `uncommitted export instagram` and have content under `~/Uncommitted/drafts/exports/...`, Uncommitted will **not** auto-migrate it. To clean up:
+
+1. Run `uncommitted doctor` — it will surface a `Legacy export directory` warning when the old path exists, including the source and target paths.
+2. Either move the contents to the new path:
+
+   ```sh
+   mv ~/Uncommitted/drafts/exports/instagram ~/Uncommitted/exports/instagram
+   ```
+
+   or delete the legacy directory:
+
+   ```sh
+   rm -rf ~/Uncommitted/drafts/exports
+   ```
+
+3. Re-run `uncommitted doctor` to confirm the warning is gone.
+
+Future exports always write to the new sibling location; there is no silent fallback to the legacy path.

--- a/src/doctor-command.ts
+++ b/src/doctor-command.ts
@@ -98,6 +98,10 @@ export async function createDoctorReport(
     configuredPaths,
     options.checkAccess ?? defaultCheckAccess
   );
+  const exportRootCheck = await createExportRootCheck(
+    configuredPaths,
+    options.checkAccess ?? defaultCheckAccess
+  );
   const legacyExportCheck = await createLegacyExportCheck(
     configuredPaths,
     options.checkAccess ?? defaultCheckAccess
@@ -108,6 +112,7 @@ export async function createDoctorReport(
     createNodeCheck(options.nodeVersion ?? process.version),
     await createGitCheck(options.checkCommand ?? defaultCheckCommand),
     ...directoryChecks,
+    exportRootCheck,
     ...(legacyExportCheck ? [legacyExportCheck] : [])
   ];
 
@@ -244,15 +249,12 @@ async function createDirectoryChecks(
   paths: ReturnType<typeof resolveConfigPaths>,
   checkAccess: (path: string, mode: number) => Promise<boolean>
 ): Promise<DoctorCheck[]> {
-  const exportRoot = join(dirname(paths.defaultDraftRoot), "exports", "instagram");
-
   const pathEntries = [
     ["configDir", paths.configDir],
     ["historyDir", paths.historyDir],
     ["globalDraftsDir", paths.globalDraftsDir],
     ["logsDir", paths.logsDir],
-    ["defaultDraftRoot", paths.defaultDraftRoot],
-    ["exportRoot", exportRoot]
+    ["defaultDraftRoot", paths.defaultDraftRoot]
   ] as const;
 
   return await Promise.all(
@@ -276,6 +278,60 @@ async function createDirectoryChecks(
       };
     })
   );
+}
+
+async function createExportRootCheck(
+  paths: ReturnType<typeof resolveConfigPaths>,
+  checkAccess: (path: string, mode: number) => Promise<boolean>
+): Promise<DoctorCheck> {
+  const uncommittedRoot = dirname(paths.defaultDraftRoot);
+  const exportRoot = join(uncommittedRoot, "exports", "instagram");
+  const id = directoryIds.exportRoot;
+  const label = directoryLabels.exportRoot;
+
+  // The export root is created lazily on first `export instagram`, so a
+  // freshly-initialized environment legitimately has no export root yet.
+  // Don't fail doctor before the first export: when the directory is absent,
+  // confirm the parent path it will be created under is writable instead.
+  const exists = await checkAccess(exportRoot, constants.F_OK);
+
+  if (!exists) {
+    const parentWritable = await checkAccess(uncommittedRoot, constants.W_OK);
+
+    if (!parentWritable) {
+      return {
+        id,
+        label,
+        status: "fail",
+        message: `Cannot create export root; parent is not writable: ${uncommittedRoot}`
+      };
+    }
+
+    return {
+      id,
+      label,
+      status: "pass",
+      message: `Export root will be created on first export: ${exportRoot}`
+    };
+  }
+
+  const writable = await checkAccess(exportRoot, constants.W_OK);
+
+  if (!writable) {
+    return {
+      id,
+      label,
+      status: "fail",
+      message: `Directory is not writable: ${exportRoot}`
+    };
+  }
+
+  return {
+    id,
+    label,
+    status: "pass",
+    message: `Directory is writable: ${exportRoot}`
+  };
 }
 
 async function createLegacyExportCheck(

--- a/src/doctor-command.ts
+++ b/src/doctor-command.ts
@@ -1,6 +1,7 @@
 import { execFile } from "node:child_process";
 import { constants } from "node:fs";
 import { access, readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import process from "node:process";
 import { promisify } from "node:util";
 import { resolveConfigPaths } from "./config-paths.js";
@@ -58,7 +59,8 @@ const directoryLabels: Record<string, string> = {
   historyDir: "Format history directory",
   globalDraftsDir: "Global drafts directory",
   logsDir: "Logs directory",
-  defaultDraftRoot: "Configured draft root"
+  defaultDraftRoot: "Configured draft root",
+  exportRoot: "Export root"
 };
 
 const directoryIds: Record<string, string> = {
@@ -66,7 +68,8 @@ const directoryIds: Record<string, string> = {
   historyDir: "directory-history",
   globalDraftsDir: "directory-global-drafts",
   logsDir: "directory-logs",
-  defaultDraftRoot: "directory-draft-root"
+  defaultDraftRoot: "directory-draft-root",
+  exportRoot: "directory-export-root"
 };
 
 export async function runDoctorCommand(
@@ -91,14 +94,21 @@ export async function createDoctorReport(
     draftRoot: config?.draftRoot
   });
 
+  const directoryChecks = await createDirectoryChecks(
+    configuredPaths,
+    options.checkAccess ?? defaultCheckAccess
+  );
+  const legacyExportCheck = await createLegacyExportCheck(
+    configuredPaths,
+    options.checkAccess ?? defaultCheckAccess
+  );
+
   const checks: DoctorCheck[] = [
     check,
     createNodeCheck(options.nodeVersion ?? process.version),
     await createGitCheck(options.checkCommand ?? defaultCheckCommand),
-    ...(await createDirectoryChecks(
-      configuredPaths,
-      options.checkAccess ?? defaultCheckAccess
-    ))
+    ...directoryChecks,
+    ...(legacyExportCheck ? [legacyExportCheck] : [])
   ];
 
   if (config) {
@@ -234,12 +244,15 @@ async function createDirectoryChecks(
   paths: ReturnType<typeof resolveConfigPaths>,
   checkAccess: (path: string, mode: number) => Promise<boolean>
 ): Promise<DoctorCheck[]> {
+  const exportRoot = join(dirname(paths.defaultDraftRoot), "exports", "instagram");
+
   const pathEntries = [
     ["configDir", paths.configDir],
     ["historyDir", paths.historyDir],
     ["globalDraftsDir", paths.globalDraftsDir],
     ["logsDir", paths.logsDir],
-    ["defaultDraftRoot", paths.defaultDraftRoot]
+    ["defaultDraftRoot", paths.defaultDraftRoot],
+    ["exportRoot", exportRoot]
   ] as const;
 
   return await Promise.all(
@@ -263,6 +276,26 @@ async function createDirectoryChecks(
       };
     })
   );
+}
+
+async function createLegacyExportCheck(
+  paths: ReturnType<typeof resolveConfigPaths>,
+  checkAccess: (path: string, mode: number) => Promise<boolean>
+): Promise<DoctorCheck | null> {
+  const legacyDir = join(paths.defaultDraftRoot, "exports");
+  const exists = await checkAccess(legacyDir, constants.F_OK);
+
+  if (!exists) return null;
+
+  return {
+    id: "directory-legacy-exports",
+    label: "Legacy export directory",
+    status: "warn",
+    message:
+      `Legacy export directory detected at ${legacyDir}. Move its contents to ` +
+      `${join(dirname(paths.defaultDraftRoot), "exports", "instagram")} or delete it; ` +
+      `Uncommitted no longer writes here.`
+  };
 }
 
 function createAiApiKeyCheck(

--- a/src/export-command.ts
+++ b/src/export-command.ts
@@ -1,5 +1,5 @@
 import { copyFile, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { DraftStorageError, readLatestDraftPointer } from "./draft-storage.js";
 import type { SafetyStatus } from "./safety-report.js";
 
@@ -106,8 +106,10 @@ export async function runExportCommand(
   const carouselPngs = await collectCarouselPngs(sourceDraftPath);
 
   // 6. Create export folder
+  // Per UNC-123: exports live sibling to drafts/, derived from the parent of draftRoot.
+  const uncommittedRoot = dirname(draftRoot);
   const exportDir = join(
-    draftRoot,
+    uncommittedRoot,
     "exports",
     "instagram",
     pointer.targetDate,

--- a/tests/doctor-command.test.ts
+++ b/tests/doctor-command.test.ts
@@ -1,5 +1,5 @@
 import { constants } from "node:fs";
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -187,6 +187,61 @@ describe("doctor command", () => {
     expect(exportRootCheck?.message).toContain(
       join(homeDir, "Uncommitted", "exports", "instagram")
     );
+  });
+
+  it("passes the Export root check before first export instead of failing", async () => {
+    const homeDir = await createHomeWithConfig();
+    // The export root is created lazily on first `export instagram`, so a
+    // freshly-initialized environment has no exports/ directory yet.
+    await rm(join(homeDir, "Uncommitted", "exports"), {
+      recursive: true,
+      force: true
+    });
+
+    const report = await createDoctorReport({
+      homeDir,
+      env: {},
+      nodeVersion: "v22.13.0",
+      checkCommand: async () => ({ ok: true, detail: "git version 2.49.0" })
+    });
+
+    const exportRootCheck = report.checks.find(
+      (c) => c.id === "directory-export-root"
+    );
+    expect(exportRootCheck).toBeDefined();
+    expect(exportRootCheck?.status).toBe("pass");
+    expect(getDoctorExitCode(report)).toBe(0);
+  });
+
+  it("fails the Export root check when the parent path is not writable", async () => {
+    const homeDir = await createHomeWithConfig();
+    const exportRoot = join(homeDir, "Uncommitted", "exports", "instagram");
+    const uncommittedRoot = join(homeDir, "Uncommitted");
+
+    const report = await createDoctorReport({
+      homeDir,
+      env: {},
+      nodeVersion: "v22.13.0",
+      checkCommand: async () => ({ ok: true, detail: "git version 2.49.0" }),
+      checkAccess: async (path, mode) => {
+        if (path === exportRoot) {
+          return false;
+        }
+
+        if (path === uncommittedRoot && mode === constants.W_OK) {
+          return false;
+        }
+
+        return true;
+      }
+    });
+
+    const exportRootCheck = report.checks.find(
+      (c) => c.id === "directory-export-root"
+    );
+    expect(exportRootCheck).toBeDefined();
+    expect(exportRootCheck?.status).toBe("fail");
+    expect(getDoctorExitCode(report)).toBe(1);
   });
 
   it("emits a legacy-export-dir warning when <draftRoot>/exports exists", async () => {

--- a/tests/doctor-command.test.ts
+++ b/tests/doctor-command.test.ts
@@ -168,6 +168,62 @@ describe("doctor command", () => {
     );
     expect(getDoctorExitCode(report)).toBe(1);
   });
+
+  it("includes an Export root directory check pointing at sibling exports/instagram", async () => {
+    const homeDir = await createHomeWithConfig();
+    const exportRoot = join(homeDir, "Uncommitted", "exports", "instagram");
+    await mkdir(exportRoot, { recursive: true });
+
+    const report = await createDoctorReport({
+      homeDir,
+      env: {},
+      nodeVersion: "v22.13.0",
+      checkCommand: async () => ({ ok: true, detail: "git version 2.49.0" })
+    });
+
+    const exportRootCheck = report.checks.find((c) => c.id === "directory-export-root");
+    expect(exportRootCheck).toBeDefined();
+    expect(exportRootCheck?.label).toBe("Export root");
+    expect(exportRootCheck?.message).toContain(
+      join(homeDir, "Uncommitted", "exports", "instagram")
+    );
+  });
+
+  it("emits a legacy-export-dir warning when <draftRoot>/exports exists", async () => {
+    const homeDir = await createHomeWithConfig();
+    const exportRoot = join(homeDir, "Uncommitted", "exports", "instagram");
+    await mkdir(exportRoot, { recursive: true });
+    const legacyDir = join(homeDir, "Uncommitted", "drafts", "exports");
+    await mkdir(legacyDir, { recursive: true });
+
+    const report = await createDoctorReport({
+      homeDir,
+      env: {},
+      nodeVersion: "v22.13.0",
+      checkCommand: async () => ({ ok: true, detail: "git version 2.49.0" })
+    });
+
+    const legacyCheck = report.checks.find((c) => c.id === "directory-legacy-exports");
+    expect(legacyCheck).toBeDefined();
+    expect(legacyCheck?.status).toBe("warn");
+    expect(legacyCheck?.message).toContain("Legacy export directory");
+  });
+
+  it("omits the legacy-export-dir warning when <draftRoot>/exports is absent", async () => {
+    const homeDir = await createHomeWithConfig();
+    const exportRoot = join(homeDir, "Uncommitted", "exports", "instagram");
+    await mkdir(exportRoot, { recursive: true });
+
+    const report = await createDoctorReport({
+      homeDir,
+      env: {},
+      nodeVersion: "v22.13.0",
+      checkCommand: async () => ({ ok: true, detail: "git version 2.49.0" })
+    });
+
+    const legacyCheck = report.checks.find((c) => c.id === "directory-legacy-exports");
+    expect(legacyCheck).toBeUndefined();
+  });
 });
 
 async function createHomeWithConfig(
@@ -181,6 +237,7 @@ async function createHomeWithConfig(
   await mkdir(join(configDir, "drafts"), { recursive: true });
   await mkdir(join(configDir, "logs"), { recursive: true });
   await mkdir(draftRoot, { recursive: true });
+  await mkdir(join(homeDir, "Uncommitted", "exports", "instagram"), { recursive: true });
   await writeFile(
     join(configDir, "config.json"),
     `${JSON.stringify({

--- a/tests/export-command.test.ts
+++ b/tests/export-command.test.ts
@@ -185,7 +185,26 @@ describe("export-command (UNC-92: scaffold)", () => {
     });
 
     expect(result.exportDir).not.toBe(outputDir);
-    expect(result.exportDir).toContain(draftRoot);
+    // Export lives sibling to drafts/, not inside it.
+    expect(result.exportDir).not.toContain(`${draftRoot}/exports`);
+    expect(result.exportDir.startsWith(draftRoot + "/")).toBe(false);
+  });
+
+  it("writes exports to <uncommittedRoot>/exports/instagram/<date>/<rev> (sibling of drafts/)", async () => {
+    // Set up <uncommittedRoot>/drafts/<date>/<rev>
+    const uncommittedRoot = await createTempDir();
+    const draftRoot = join(uncommittedRoot, "drafts");
+    await mkdir(draftRoot, { recursive: true });
+    await scaffoldDraft(draftRoot, { targetDate: "2026-05-18", revision: "rev-001" });
+
+    const result = await runExportCommand(
+      ["instagram"],
+      { draftRoot, now: () => "2026-05-18T10:30:00.000Z" }
+    );
+
+    const expectedExportDir = join(uncommittedRoot, "exports", "instagram", "2026-05-18", "rev-001");
+    expect(result.exportDir).toBe(expectedExportDir);
+    expect(result.exportDir.startsWith(draftRoot + "/")).toBe(false);
   });
 
   it("accepts 'instagram latest' alias", async () => {
@@ -409,7 +428,9 @@ describe("export-command (UNC-95: error handling)", () => {
   });
 
   it("does not create an export folder when carousel is missing", async () => {
-    const draftRoot = await createTempDir();
+    // Use isolated uncommittedRoot so dirname(draftRoot) is not a shared temp dir
+    const uncommittedRoot = await createTempDir();
+    const draftRoot = join(uncommittedRoot, "drafts");
     const targetDate = "2026-05-18";
     const revision = "rev-001";
     const outputDir = join(draftRoot, targetDate, revision);
@@ -454,7 +475,8 @@ describe("export-command (UNC-95: error handling)", () => {
       // expected
     }
 
-    const exportBase = join(draftRoot, "exports", "instagram");
+    // After UNC-128: exports live sibling to draftRoot (at uncommittedRoot/exports/instagram).
+    const exportBase = join(uncommittedRoot, "exports", "instagram");
     await expect(readdir(exportBase)).rejects.toThrow();
   });
 });
@@ -521,7 +543,10 @@ describe("export-command (UNC-94: safety policy)", () => {
   });
 
   it("blocked draft does not create an export folder", async () => {
-    const draftRoot = await createTempDir();
+    // Use isolated uncommittedRoot so dirname(draftRoot) is not a shared temp dir
+    const uncommittedRoot = await createTempDir();
+    const draftRoot = join(uncommittedRoot, "drafts");
+    await mkdir(draftRoot, { recursive: true });
     await scaffoldDraftWithSafety(draftRoot, "blocked");
 
     try {
@@ -530,7 +555,8 @@ describe("export-command (UNC-94: safety policy)", () => {
       // expected
     }
 
-    const exportBase = join(draftRoot, "exports", "instagram");
+    // After UNC-128: exports live sibling to draftRoot (at uncommittedRoot/exports/instagram).
+    const exportBase = join(uncommittedRoot, "exports", "instagram");
     await expect(readdir(exportBase)).rejects.toThrow();
   });
 


### PR DESCRIPTION
🤖 **Auto-generated by Uncommitted Builder (Routine B v2)**

## Parent issue
[UNC-123: `export instagram` 결과물이 `drafts/` 내부에 생성됨 — drafts 밖으로 이동](https://linear.app/sangchu/issue/UNC-123)

## Sub-issues progress
- [x] [UNC-128](https://linear.app/sangchu/issue/UNC-128) — Move export output to sibling `exports/` directory and update manifest (✅ done 2026-06-07 06:11)
- [x] [UNC-129](https://linear.app/sangchu/issue/UNC-129) — Update `doctor` command for new export path and legacy-dir hint (✅ done 2026-06-07 06:18)
- [x] [UNC-130](https://linear.app/sangchu/issue/UNC-130) — Add README backward-compatibility guidance for legacy export path (✅ done 2026-06-07 06:21)

## Status
- Branch: `claude/UNC-123-improvement-export-instagram`
- Tests: ✅ 389 passed | 1 skipped (vitest, isolated runs)
  - ⚠️ Known pre-existing Playwright flake on full-suite runs (`carousel-renderer-smoke.test.ts > renders a quiet 3-slide fixture`) — passes 3/3 when run in isolation. Not caused by this PR (no carousel/Playwright code touched).
- Build: ✅ tsc clean
- Lint: ✅ eslint clean
- Type check: ✅ `tsc --noEmit` clean
- `git diff --check`: ✅ no whitespace/conflict markers

## TDD trail
- UNC-128: ✅ commit `b1fa76e` — RED sibling-path test → GREEN with `dirname(draftRoot)`-derived export root. Adjacent negative-path tests restructured to use `uncommittedRoot/drafts` layout (rationale: `dirname(createTempDir())` resolved to shared `/tmp`, causing false positives).
- UNC-129: ✅ commit `6130887` — RED 3 doctor tests → GREEN with `Export root` directory check + `createLegacyExportCheck` probe + `createHomeWithConfig` helper updated to pre-create `exports/instagram`.
- UNC-130: ✅ commit `2e8c39f` — Pure docs. README `## Exports` section documenting new path + 3-step migration guide aligned with the doctor hint wording.

## Notes
- No new dependencies, no lockfile changes.
- No edits to `pnpm-lock.yaml`, `.env*`, `AGENTS.md`, or anything under `secrets`/`credentials`.
- No auto-publish code introduced.
- No silent read-side fallback for the legacy `<draftRoot>/exports/...` location — per UNC-128's Q3 decision.
- Files touched: `src/export-command.ts`, `src/doctor-command.ts`, `README.md`, `tests/export-command.test.ts`, `tests/doctor-command.test.ts`.
- Reviewer follow-ups (advisory, not blocking): duplicate `join(dirname(...), "exports", "instagram")` in doctor (extract helper); doctor legacy test under-asserts path in message; export test isolation uses shared `/tmp` grandparent. None are spec violations; left for human judgment.

## Review checklist
- [ ] Review each sub-issue's commit separately (commits map 1:1 to subs).
- [ ] Verify TDD test coverage matches each sub's acceptance criteria.
- [ ] Confirm no lockfile changes (none here).
- [ ] Run `pnpm install --frozen-lockfile && pnpm test && pnpm build` locally (re-run the Playwright smoke test individually if it flakes).
- [ ] Confirm no auto-publish / SNS-upload code introduced.
- [ ] Spot-check the new `## Exports` README section renders correctly on GitHub.

---
이 PR은 자동 생성되었습니다. 머지 전 사람의 리뷰가 반드시 필요합니다.
