### PR TITLE
🤖 uncommitted preview에 날짜/리비전 지정 지원 (UNC-122)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -411,7 +411,10 @@ async function runPreview(
     const arg = args[i];
     if (arg === "--date") {
       const value = args[i + 1];
-      if (value === undefined) {
+      // Reject a missing value or an adjacent flag (e.g. `--date --rev`),
+      // which would otherwise be consumed as the value and fail later with a
+      // confusing format error. No valid date starts with "--".
+      if (value === undefined || value.startsWith("--")) {
         io.stderr(`--date requires a value (YYYY-MM-DD). ${PREVIEW_USAGE}`);
         return 1;
       }
@@ -421,7 +424,8 @@ async function runPreview(
     }
     if (arg === "--rev") {
       const value = args[i + 1];
-      if (value === undefined) {
+      // Same guard as --date: a following flag is not a valid rev-NNN value.
+      if (value === undefined || value.startsWith("--")) {
         io.stderr(`--rev requires a value (rev-NNN). ${PREVIEW_USAGE}`);
         return 1;
       }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,8 +37,16 @@ import {
   RenderCommandError,
   runRenderCommand
 } from "./render-command.js";
-import { loadLatestDraftPreview } from "./preview-loader.js";
+import {
+  loadDraftPreviewForRevision,
+  loadLatestDraftPreview
+} from "./preview-loader.js";
 import { formatPreview } from "./preview-formatter.js";
+import {
+  RevisionFormatError,
+  resolveLatestRevForDate,
+  resolveSpecificRev
+} from "./draft-revision-resolver.js";
 import {
   buildLaunchAgentPlist,
   captureProviderEnv,
@@ -371,21 +379,104 @@ async function runRender(
   }
 }
 
+const PREVIEW_USAGE =
+  "Usage: uncommitted preview latest | uncommitted preview --date YYYY-MM-DD [--rev rev-NNN]";
+
 async function runPreview(
   args: string[],
   io: CliIo,
   options: CliOptions
 ): Promise<number> {
-  const [subcommand] = args;
+  // Backward-compat path: `preview latest` (no flags).
+  if (args.length === 1 && args[0] === "latest") {
+    const paths = resolveConfigPaths({ homeDir: options.homeDir });
+    const draftRoot = await readPreviewDraftRoot(paths.configFile, options.homeDir);
+    const result = await loadLatestDraftPreview(draftRoot);
 
-  if (subcommand !== "latest" || args.length !== 1) {
-    io.stderr("Usage: uncommitted preview latest");
+    if (result.outcome === "success") {
+      io.stdout(formatPreview(result));
+      return 0;
+    }
+
+    io.stderr(formatPreview(result));
+    return 1;
+  }
+
+  // New path: `preview --date YYYY-MM-DD [--rev rev-NNN]`.
+  // Parse flags + reject any other positional (including "latest" mixed with flags).
+  let targetDate: string | undefined;
+  let revision: string | undefined;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--date") {
+      const value = args[i + 1];
+      if (value === undefined) {
+        io.stderr(`--date requires a value (YYYY-MM-DD). ${PREVIEW_USAGE}`);
+        return 1;
+      }
+      targetDate = value;
+      i++;
+      continue;
+    }
+    if (arg === "--rev") {
+      const value = args[i + 1];
+      if (value === undefined) {
+        io.stderr(`--rev requires a value (rev-NNN). ${PREVIEW_USAGE}`);
+        return 1;
+      }
+      revision = value;
+      i++;
+      continue;
+    }
+    // Any other token (including "latest" combined with flags, or unknown positionals).
+    io.stderr(PREVIEW_USAGE);
+    return 1;
+  }
+
+  if (targetDate === undefined) {
+    io.stderr(`--date is required when not using \`preview latest\`. ${PREVIEW_USAGE}`);
+    return 1;
+  }
+
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(targetDate)) {
+    io.stderr(`--date must be in YYYY-MM-DD format, got: ${targetDate}`);
     return 1;
   }
 
   const paths = resolveConfigPaths({ homeDir: options.homeDir });
   const draftRoot = await readPreviewDraftRoot(paths.configFile, options.homeDir);
-  const result = await loadLatestDraftPreview(draftRoot);
+
+  let resolved: { revision: string; outputDir: string } | null;
+  try {
+    if (revision === undefined) {
+      resolved = await resolveLatestRevForDate(draftRoot, targetDate);
+    } else {
+      resolved = await resolveSpecificRev(draftRoot, targetDate, revision);
+    }
+  } catch (error) {
+    if (error instanceof RevisionFormatError) {
+      io.stderr(`${error.message} ${PREVIEW_USAGE}`);
+      return 1;
+    }
+    throw error;
+  }
+
+  if (resolved === null) {
+    if (revision === undefined) {
+      io.stderr(`No draft found for ${targetDate}.`);
+    } else {
+      io.stderr(`No draft ${revision} found for ${targetDate}.`);
+    }
+    return 1;
+  }
+
+  const result = await loadDraftPreviewForRevision(
+    draftRoot,
+    resolved.outputDir,
+    targetDate,
+    resolved.revision
+  );
 
   if (result.outcome === "success") {
     io.stdout(formatPreview(result));

--- a/src/draft-revision-resolver.ts
+++ b/src/draft-revision-resolver.ts
@@ -1,0 +1,94 @@
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
+
+/**
+ * Resolved draft revision location under a draft root.
+ */
+export type RevisionResult = {
+  revision: string;
+  outputDir: string;
+};
+
+/**
+ * Thrown by {@link resolveSpecificRev} when the caller passes a revision
+ * string that doesn't match the canonical `rev-NNN` (three-digit) format.
+ *
+ * CLI callers should catch this and surface a friendly usage message.
+ */
+export class RevisionFormatError extends Error {
+  constructor(public readonly revision: string) {
+    super(
+      `Invalid revision format: "${revision}". Expected "rev-NNN" (e.g. rev-001).`
+    );
+    this.name = "RevisionFormatError";
+  }
+}
+
+const REVISION_PATTERN = /^rev-\d{3}$/;
+
+/**
+ * Find the highest revision under `draftRoot/targetDate/`.
+ * Returns `null` when the date directory is missing or contains no
+ * `rev-NNN` entries.
+ */
+export async function resolveLatestRevForDate(
+  draftRoot: string,
+  targetDate: string
+): Promise<RevisionResult | null> {
+  const dateDir = join(draftRoot, targetDate);
+
+  try {
+    const entries = await readdir(dateDir);
+    const revisions = entries
+      .filter((e) => REVISION_PATTERN.test(e))
+      .sort((a, b) => b.localeCompare(a)); // descending
+
+    if (revisions.length === 0) {
+      return null;
+    }
+
+    const revision = revisions[0];
+    return { revision, outputDir: join(dateDir, revision) };
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Resolve a specific revision under `draftRoot/targetDate/<revision>`.
+ *
+ * Throws {@link RevisionFormatError} when `revision` does not match
+ * the canonical `rev-NNN` format. Returns `null` when the revision
+ * directory is missing.
+ */
+export async function resolveSpecificRev(
+  draftRoot: string,
+  targetDate: string,
+  revision: string
+): Promise<RevisionResult | null> {
+  if (!REVISION_PATTERN.test(revision)) {
+    throw new RevisionFormatError(revision);
+  }
+
+  const dateDir = join(draftRoot, targetDate);
+
+  try {
+    const entries = await readdir(dateDir);
+    if (!entries.includes(revision)) {
+      return null;
+    }
+    return { revision, outputDir: join(dateDir, revision) };
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}

--- a/src/draft-revision-resolver.ts
+++ b/src/draft-revision-resolver.ts
@@ -1,4 +1,4 @@
-import { readdir } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 
 /**
@@ -27,7 +27,15 @@ export class RevisionFormatError extends Error {
 const REVISION_PATTERN = /^rev-\d{3}$/;
 
 /**
- * Find the highest revision under `draftRoot/targetDate/`.
+ * Resolve the latest revision under `draftRoot/targetDate/`.
+ *
+ * Prefers the per-date latest pointer (`<targetDate>/latest.json`), which the
+ * storage layer writes only after a generation finishes writing all artifacts,
+ * so it records the last *complete* draft. This guards against a crashed
+ * generation that leaves a higher `rev-NNN` directory behind: a plain directory
+ * scan would wrongly select that incomplete revision. Falls back to the highest
+ * `rev-NNN` on disk when the pointer is absent or malformed.
+ *
  * Returns `null` when the date directory is missing or contains no
  * `rev-NNN` entries.
  */
@@ -36,6 +44,11 @@ export async function resolveLatestRevForDate(
   targetDate: string
 ): Promise<RevisionResult | null> {
   const dateDir = join(draftRoot, targetDate);
+
+  const pointed = await readDatePointerRevision(dateDir);
+  if (pointed !== null) {
+    return { revision: pointed, outputDir: join(dateDir, pointed) };
+  }
 
   try {
     const entries = await readdir(dateDir);
@@ -55,6 +68,40 @@ export async function resolveLatestRevForDate(
     }
     throw error;
   }
+}
+
+/**
+ * Read the revision recorded by `<dateDir>/latest.json`, the per-date latest
+ * pointer. Returns `null` when the pointer is absent or malformed so callers
+ * fall back to a directory scan.
+ */
+async function readDatePointerRevision(
+  dateDir: string
+): Promise<string | null> {
+  let raw: string;
+  try {
+    raw = await readFile(join(dateDir, "latest.json"), "utf8");
+  } catch {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      typeof (parsed as Record<string, unknown>).revision === "string"
+    ) {
+      const revision = (parsed as Record<string, unknown>).revision as string;
+      if (REVISION_PATTERN.test(revision)) {
+        return revision;
+      }
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
 }
 
 /**

--- a/src/feedback-command.ts
+++ b/src/feedback-command.ts
@@ -1,4 +1,4 @@
-import { readdir, readFile } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { createInterface } from "node:readline";
 import {
@@ -11,6 +11,7 @@ import {
 import { saveFeedback } from "./feedback-storage.js";
 import { readLatestDraftPointer, DraftStorageError } from "./draft-storage.js";
 import { aggregateFeedback, formatFeedbackReport } from "./feedback-report.js";
+import { resolveLatestRevForDate } from "./draft-revision-resolver.js";
 import type { CliIo } from "./cli.js";
 
 // ---------------------------------------------------------------------------
@@ -374,46 +375,6 @@ function validateNonInteractiveInput(ni: NonInteractiveInput): string | null {
   }
 
   return null;
-}
-
-type RevisionResult = {
-  revision: string;
-  outputDir: string;
-};
-
-/**
- * Find the highest revision under draftRoot/targetDate/.
- * Returns null if no revisions exist.
- */
-async function resolveLatestRevForDate(
-  draftRoot: string,
-  targetDate: string
-): Promise<RevisionResult | null> {
-  const dateDir = join(draftRoot, targetDate);
-
-  try {
-    const entries = await readdir(dateDir);
-    const revisions = entries
-      .filter((e) => /^rev-\d{3}$/.test(e))
-      .sort((a, b) => b.localeCompare(a)); // descending
-
-    if (revisions.length === 0) {
-      return null;
-    }
-
-    const revision = revisions[0];
-    return { revision, outputDir: join(dateDir, revision) };
-  } catch (error) {
-    if (isNodeError(error) && error.code === "ENOENT") {
-      return null;
-    }
-
-    throw error;
-  }
-}
-
-function isNodeError(error: unknown): error is NodeJS.ErrnoException {
-  return error instanceof Error && "code" in error;
 }
 
 type StoryMeta = {

--- a/src/preview-loader.ts
+++ b/src/preview-loader.ts
@@ -69,10 +69,49 @@ export async function loadLatestDraftPreview(
     );
   }
 
-  // 2. Read caption.txt (optional — null if missing)
+  return loadDraftArtifacts(outputDir, targetDate, revision);
+}
+
+/**
+ * Load preview artifacts for a specific revision directory.
+ *
+ * Mirrors {@link loadLatestDraftPreview} starting from the caption/JSON
+ * artifact reads, but takes the resolved `outputDir`, `targetDate`, and
+ * `revision` directly (callers resolve these via `draft-revision-resolver`).
+ *
+ * Guards that `outputDir` resolves inside `draftRoot`; otherwise returns
+ * a `malformed` outcome citing the offending path.
+ */
+export async function loadDraftPreviewForRevision(
+  draftRoot: string,
+  outputDir: string,
+  targetDate: string,
+  revision: string
+): Promise<PreviewLoaderResult> {
+  if (!isPathInside(draftRoot, outputDir)) {
+    return malformed(
+      outputDir,
+      "Draft revision path is outside the draft root."
+    );
+  }
+
+  return loadDraftArtifacts(outputDir, targetDate, revision);
+}
+
+/**
+ * Shared core: read caption.txt + the three required JSON artifacts +
+ * scan the carousel directory. Used by both the latest-pointer entry
+ * point and the explicit revision entry point.
+ */
+async function loadDraftArtifacts(
+  outputDir: string,
+  targetDate: string,
+  revision: string
+): Promise<PreviewLoaderResult> {
+  // 1. Read caption.txt (optional — null if missing)
   const caption = await readCaptionOptional(outputDir);
 
-  // 3. Parse required JSON artifacts
+  // 2. Parse required JSON artifacts
   const storyResult = await readRequiredJson(outputDir, "story.json");
   if (storyResult.outcome === "malformed") return storyResult;
   if (!isRecord(storyResult.value)) {
@@ -94,7 +133,7 @@ export async function loadLatestDraftPreview(
     );
   }
 
-  // 4. Scan carousel directory for *.png files
+  // 3. Scan carousel directory for *.png files
   const carouselPngs = await readCarouselPngs(outputDir);
 
   return {

--- a/src/preview-loader.ts
+++ b/src/preview-loader.ts
@@ -88,6 +88,9 @@ export async function loadDraftPreviewForRevision(
   targetDate: string,
   revision: string
 ): Promise<PreviewLoaderResult> {
+  // Defense-in-depth: CLI callers pass a resolver-built path that is inside
+  // `draftRoot` by construction, so this never trips for them. The guard
+  // protects any non-resolver caller that might pass an arbitrary outputDir.
   if (!isPathInside(draftRoot, outputDir)) {
     return malformed(
       outputDir,

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1478,6 +1478,36 @@ describe("cli", () => {
       expect(stdout).toEqual([]);
       expect(stderr.join("\n")).toMatch(/--date/);
     });
+
+    it("(f5) --date immediately followed by another flag reports a missing value", async () => {
+      const { io, stdout, stderr } = createIo();
+      const { homeDir } = await setupTwoRevisions();
+
+      const exitCode = await runCli(
+        ["preview", "--date", "--rev", "rev-001"],
+        io,
+        { homeDir }
+      );
+
+      expect(exitCode).toBe(1);
+      expect(stdout).toEqual([]);
+      expect(stderr.join("\n")).toContain("--date requires a value");
+    });
+
+    it("(f6) --rev immediately followed by another flag reports a missing value", async () => {
+      const { io, stdout, stderr } = createIo();
+      const { homeDir } = await setupTwoRevisions();
+
+      const exitCode = await runCli(
+        ["preview", "--rev", "--date", "2026-06-01"],
+        io,
+        { homeDir }
+      );
+
+      expect(exitCode).toBe(1);
+      expect(stdout).toEqual([]);
+      expect(stderr.join("\n")).toContain("--rev requires a value");
+    });
   });
 });
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1254,6 +1254,231 @@ describe("cli", () => {
       expect(stderr.join("\n")).toContain("Usage: uncommitted preview latest");
     });
   });
+
+  describe("preview --date / --rev", () => {
+    const defaultStory = { schemaVersion: 1, title: "Test draft", slides: [] };
+    const defaultSafetyReport = {
+      schemaVersion: 1,
+      status: "safe",
+      risks: [],
+      redactionsApplied: [],
+      exportAllowed: true,
+      message: "Safety check passed."
+    };
+
+    function makeMetadata(targetDate: string): Record<string, unknown> {
+      return {
+        schemaVersion: 1,
+        targetDate,
+        generatedAt: `${targetDate}T00:00:00.000Z`,
+        activityLevel: "moderate",
+        formatName: "daily-summary",
+        storyFormatVoice: "casual",
+        storyFormatTone: "warm",
+        projectIds: ["proj-a"],
+        entryMode: "daily_global",
+        slideCount: 3
+      };
+    }
+
+    async function writeRevisionArtifacts(
+      outputDir: string,
+      targetDate: string,
+      caption: string
+    ): Promise<void> {
+      await mkdir(outputDir, { recursive: true });
+      await writeFile(
+        join(outputDir, "story.json"),
+        JSON.stringify(defaultStory, null, 2),
+        "utf8"
+      );
+      await writeFile(
+        join(outputDir, "metadata.json"),
+        JSON.stringify(makeMetadata(targetDate), null, 2),
+        "utf8"
+      );
+      await writeFile(
+        join(outputDir, "safety-report.json"),
+        JSON.stringify(defaultSafetyReport, null, 2),
+        "utf8"
+      );
+      await writeFile(join(outputDir, "caption.txt"), caption, "utf8");
+    }
+
+    async function setupTwoRevisions(): Promise<{
+      homeDir: string;
+      draftRoot: string;
+      rev001Dir: string;
+      rev002Dir: string;
+    }> {
+      const homeDir = await mkdtemp(
+        join(tmpdir(), "uncommitted-preview-date-rev-")
+      );
+      const draftRoot = join(homeDir, "Uncommitted", "drafts");
+      const rev001Dir = join(draftRoot, "2026-06-01", "rev-001");
+      const rev002Dir = join(draftRoot, "2026-06-01", "rev-002");
+      await writeRevisionArtifacts(rev001Dir, "2026-06-01", "Rev one caption\n");
+      await writeRevisionArtifacts(rev002Dir, "2026-06-01", "Rev two caption\n");
+      return { homeDir, draftRoot, rev001Dir, rev002Dir };
+    }
+
+    it("(a) --date <existing> selects the latest rev for that date", async () => {
+      const { io, stdout, stderr } = createIo();
+      const { homeDir } = await setupTwoRevisions();
+
+      const exitCode = await runCli(
+        ["preview", "--date", "2026-06-01"],
+        io,
+        { homeDir }
+      );
+
+      expect(exitCode).toBe(0);
+      expect(stderr).toEqual([]);
+      const out = stdout.join("\n");
+      expect(out).toContain("2026-06-01");
+      expect(out).toContain("rev-002");
+      expect(out).toContain("Rev two caption");
+    });
+
+    it("(b) --date <existing> --rev rev-001 hits the specific rev", async () => {
+      const { io, stdout, stderr } = createIo();
+      const { homeDir } = await setupTwoRevisions();
+
+      const exitCode = await runCli(
+        ["preview", "--date", "2026-06-01", "--rev", "rev-001"],
+        io,
+        { homeDir }
+      );
+
+      expect(exitCode).toBe(0);
+      expect(stderr).toEqual([]);
+      const out = stdout.join("\n");
+      expect(out).toContain("rev-001");
+      expect(out).toContain("Rev one caption");
+      expect(out).not.toContain("Rev two caption");
+    });
+
+    it("(c) --date <missing> exits 1 with literal 'No draft found for <date>'", async () => {
+      const { io, stdout, stderr } = createIo();
+      const { homeDir } = await setupTwoRevisions();
+
+      const exitCode = await runCli(
+        ["preview", "--date", "2026-05-01"],
+        io,
+        { homeDir }
+      );
+
+      expect(exitCode).toBe(1);
+      expect(stdout).toEqual([]);
+      expect(stderr.join("\n")).toContain("No draft found for 2026-05-01");
+    });
+
+    it("(d) --date <existing> --rev rev-999 exits 1 with literal 'No draft rev-999 found for <date>'", async () => {
+      const { io, stdout, stderr } = createIo();
+      const { homeDir } = await setupTwoRevisions();
+
+      const exitCode = await runCli(
+        ["preview", "--date", "2026-06-01", "--rev", "rev-999"],
+        io,
+        { homeDir }
+      );
+
+      expect(exitCode).toBe(1);
+      expect(stdout).toEqual([]);
+      expect(stderr.join("\n")).toContain(
+        "No draft rev-999 found for 2026-06-01"
+      );
+    });
+
+    it("(e) preview latest still works (backward compat)", async () => {
+      const { io, stdout, stderr } = createIo();
+      const { homeDir, draftRoot, rev002Dir } = await setupTwoRevisions();
+
+      // Make rev-002 the latest pointer.
+      const pointer = {
+        schemaVersion: 1,
+        targetDate: "2026-06-01",
+        revision: "rev-002",
+        path: rev002Dir,
+        updatedAt: "2026-06-01T00:00:00.000Z"
+      };
+      await writeFile(
+        join(draftRoot, "latest.json"),
+        JSON.stringify(pointer, null, 2),
+        "utf8"
+      );
+
+      const exitCode = await runCli(["preview", "latest"], io, { homeDir });
+
+      expect(exitCode).toBe(0);
+      expect(stderr).toEqual([]);
+      const out = stdout.join("\n");
+      expect(out).toContain("rev-002");
+      expect(out).toContain("Rev two caption");
+    });
+
+    it("(f1) --date with malformed value exits 1 with usage error", async () => {
+      const { io, stdout, stderr } = createIo();
+      const homeDir = await mkdtemp(
+        join(tmpdir(), "uncommitted-preview-bad-date-")
+      );
+
+      const exitCode = await runCli(
+        ["preview", "--date", "2026/06/02"],
+        io,
+        { homeDir }
+      );
+
+      expect(exitCode).toBe(1);
+      expect(stdout).toEqual([]);
+      expect(stderr.join("\n")).toMatch(/YYYY-MM-DD|--date/);
+    });
+
+    it("(f2) --rev with malformed value exits 1 with usage error", async () => {
+      const { io, stdout, stderr } = createIo();
+      const { homeDir } = await setupTwoRevisions();
+
+      const exitCode = await runCli(
+        ["preview", "--date", "2026-06-01", "--rev", "rev-1"],
+        io,
+        { homeDir }
+      );
+
+      expect(exitCode).toBe(1);
+      expect(stdout).toEqual([]);
+      expect(stderr.join("\n")).toMatch(/rev-NNN|--rev|Invalid revision/);
+    });
+
+    it("(f3) mixing positional 'latest' with --date exits 1 with usage error", async () => {
+      const { io, stdout, stderr } = createIo();
+      const { homeDir } = await setupTwoRevisions();
+
+      const exitCode = await runCli(
+        ["preview", "latest", "--date", "2026-06-01"],
+        io,
+        { homeDir }
+      );
+
+      expect(exitCode).toBe(1);
+      expect(stdout).toEqual([]);
+      expect(stderr.join("\n")).toMatch(/Usage|cannot combine|latest/i);
+    });
+
+    it("(f4) --rev without --date exits 1 with usage error mentioning --date", async () => {
+      const { io, stdout, stderr } = createIo();
+      const { homeDir } = await setupTwoRevisions();
+
+      const exitCode = await runCli(
+        ["preview", "--rev", "rev-001"],
+        io,
+        { homeDir }
+      );
+
+      expect(exitCode).toBe(1);
+      expect(stdout).toEqual([]);
+      expect(stderr.join("\n")).toMatch(/--date/);
+    });
+  });
 });
 
 it("`feedback --help` lists --date in the usage block", async () => {

--- a/tests/draft-revision-resolver.test.ts
+++ b/tests/draft-revision-resolver.test.ts
@@ -31,6 +31,29 @@ async function makeRevDir(
   return outputDir;
 }
 
+// Mirror the shape draft-storage writes to `<date>/latest.json` after a
+// generation finishes writing all artifacts.
+async function writeDateLatestPointer(
+  draftRoot: string,
+  targetDate: string,
+  revision: string
+): Promise<void> {
+  const dateDir = join(draftRoot, targetDate);
+  await mkdir(dateDir, { recursive: true });
+  const pointer = {
+    schemaVersion: 1,
+    targetDate,
+    revision,
+    path: join(dateDir, revision),
+    updatedAt: "2026-06-01T00:00:00.000Z"
+  };
+  await writeFile(
+    join(dateDir, "latest.json"),
+    `${JSON.stringify(pointer, null, 2)}\n`,
+    "utf8"
+  );
+}
+
 // ---------------------------------------------------------------------------
 // resolveLatestRevForDate
 // ---------------------------------------------------------------------------
@@ -68,6 +91,39 @@ describe("resolveLatestRevForDate", () => {
     const result = await resolveLatestRevForDate(draftRoot, "2026-06-01");
 
     expect(result).toBeNull();
+  });
+
+  it("prefers the date latest pointer over a higher incomplete rev dir", async () => {
+    const draftRoot = await createDraftRoot();
+    // rev-001 is the last completed draft the date pointer records.
+    const completeDir = await makeRevDir(draftRoot, "2026-06-01", "rev-001");
+    // rev-002 dir exists (e.g. a crashed generation) but never became latest.
+    await makeRevDir(draftRoot, "2026-06-01", "rev-002");
+    await writeDateLatestPointer(draftRoot, "2026-06-01", "rev-001");
+
+    const result = await resolveLatestRevForDate(draftRoot, "2026-06-01");
+
+    expect(result).not.toBeNull();
+    expect(result!.revision).toBe("rev-001");
+    expect(result!.outputDir).toBe(completeDir);
+  });
+
+  it("falls back to the highest rev when the date pointer is malformed", async () => {
+    const draftRoot = await createDraftRoot();
+    await makeRevDir(draftRoot, "2026-06-01", "rev-001");
+    const expectedDir = await makeRevDir(draftRoot, "2026-06-01", "rev-002");
+    // A corrupt pointer must not strand the resolver.
+    await writeFile(
+      join(draftRoot, "2026-06-01", "latest.json"),
+      "{ not json",
+      "utf8"
+    );
+
+    const result = await resolveLatestRevForDate(draftRoot, "2026-06-01");
+
+    expect(result).not.toBeNull();
+    expect(result!.revision).toBe("rev-002");
+    expect(result!.outputDir).toBe(expectedDir);
   });
 });
 

--- a/tests/draft-revision-resolver.test.ts
+++ b/tests/draft-revision-resolver.test.ts
@@ -1,0 +1,135 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  RevisionFormatError,
+  resolveLatestRevForDate,
+  resolveSpecificRev
+} from "../src/draft-revision-resolver.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function createDraftRoot(): Promise<string> {
+  const root = join(tmpdir(), `draft-revision-resolver-${randomUUID()}`);
+  await mkdir(root, { recursive: true });
+  return root;
+}
+
+async function makeRevDir(
+  draftRoot: string,
+  targetDate: string,
+  revision: string
+): Promise<string> {
+  const outputDir = join(draftRoot, targetDate, revision);
+  await mkdir(outputDir, { recursive: true });
+  // Drop a sentinel file so a future readdir on the rev dir would see content.
+  await writeFile(join(outputDir, ".sentinel"), "", "utf8");
+  return outputDir;
+}
+
+// ---------------------------------------------------------------------------
+// resolveLatestRevForDate
+// ---------------------------------------------------------------------------
+
+describe("resolveLatestRevForDate", () => {
+  it("returns the highest rev when a date has multiple revisions", async () => {
+    const draftRoot = await createDraftRoot();
+    await makeRevDir(draftRoot, "2026-06-01", "rev-001");
+    await makeRevDir(draftRoot, "2026-06-01", "rev-002");
+    const expectedDir = await makeRevDir(draftRoot, "2026-06-01", "rev-003");
+
+    const result = await resolveLatestRevForDate(draftRoot, "2026-06-01");
+
+    expect(result).not.toBeNull();
+    expect(result!.revision).toBe("rev-003");
+    expect(result!.outputDir).toBe(expectedDir);
+  });
+
+  it("returns null when the date directory does not exist (ENOENT)", async () => {
+    const draftRoot = await createDraftRoot();
+
+    const result = await resolveLatestRevForDate(draftRoot, "2026-06-01");
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the date directory has no rev-NNN entries", async () => {
+    const draftRoot = await createDraftRoot();
+    const dateDir = join(draftRoot, "2026-06-01");
+    await mkdir(dateDir, { recursive: true });
+    // Non-rev entries should be ignored.
+    await mkdir(join(dateDir, "scratch"), { recursive: true });
+    await writeFile(join(dateDir, "notes.txt"), "ignore", "utf8");
+
+    const result = await resolveLatestRevForDate(draftRoot, "2026-06-01");
+
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveSpecificRev
+// ---------------------------------------------------------------------------
+
+describe("resolveSpecificRev", () => {
+  it("returns the requested rev when it exists", async () => {
+    const draftRoot = await createDraftRoot();
+    await makeRevDir(draftRoot, "2026-06-01", "rev-001");
+    const expectedDir = await makeRevDir(draftRoot, "2026-06-01", "rev-002");
+
+    const result = await resolveSpecificRev(
+      draftRoot,
+      "2026-06-01",
+      "rev-002"
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.revision).toBe("rev-002");
+    expect(result!.outputDir).toBe(expectedDir);
+  });
+
+  it("returns null when the requested rev does not exist", async () => {
+    const draftRoot = await createDraftRoot();
+    await makeRevDir(draftRoot, "2026-06-01", "rev-001");
+
+    const result = await resolveSpecificRev(
+      draftRoot,
+      "2026-06-01",
+      "rev-999"
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the date directory itself is missing", async () => {
+    const draftRoot = await createDraftRoot();
+
+    const result = await resolveSpecificRev(
+      draftRoot,
+      "2026-06-01",
+      "rev-001"
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("throws RevisionFormatError for malformed revision strings", async () => {
+    const draftRoot = await createDraftRoot();
+
+    await expect(
+      resolveSpecificRev(draftRoot, "2026-06-01", "rev-1")
+    ).rejects.toBeInstanceOf(RevisionFormatError);
+
+    await expect(
+      resolveSpecificRev(draftRoot, "2026-06-01", "rev-1234")
+    ).rejects.toBeInstanceOf(RevisionFormatError);
+
+    await expect(
+      resolveSpecificRev(draftRoot, "2026-06-01", "latest")
+    ).rejects.toBeInstanceOf(RevisionFormatError);
+  });
+});

--- a/tests/preview-loader.test.ts
+++ b/tests/preview-loader.test.ts
@@ -3,7 +3,10 @@ import { randomUUID } from "node:crypto";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { loadLatestDraftPreview } from "../src/preview-loader.js";
+import {
+  loadDraftPreviewForRevision,
+  loadLatestDraftPreview
+} from "../src/preview-loader.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -326,5 +329,80 @@ describe("loadLatestDraftPreview", () => {
     await writeLatestPointer(draftRoot, "2026-05-19", "rev-001", outputDir);
 
     await expect(loadLatestDraftPreview(draftRoot)).rejects.toThrow();
+  });
+});
+
+describe("loadDraftPreviewForRevision", () => {
+  it("returns success for an arbitrary revision under the draft root", async () => {
+    const draftRoot = await createDraftRoot();
+    const outputDir = await writeDraftRevision(draftRoot, "2026-05-17", "rev-002", {
+      caption: "Older rev caption\n",
+      story: defaultStory,
+      metadata: defaultMetadata,
+      safetyReport: defaultSafetyReport,
+      carouselPngs: ["01.png"]
+    });
+
+    const result = await loadDraftPreviewForRevision(
+      draftRoot,
+      outputDir,
+      "2026-05-17",
+      "rev-002"
+    );
+
+    expect(result.outcome).toBe("success");
+    if (result.outcome === "success") {
+      expect(result.targetDate).toBe("2026-05-17");
+      expect(result.revision).toBe("rev-002");
+      expect(result.caption).toBe("Older rev caption\n");
+      expect(result.carouselPngs).toEqual(["carousel/01.png"]);
+    }
+  });
+
+  it("returns malformed when outputDir escapes draftRoot", async () => {
+    const draftRoot = await createDraftRoot();
+    const outsideRoot = await createDraftRoot();
+    const outsideDir = await writeDraftRevision(
+      outsideRoot,
+      "2026-05-17",
+      "rev-001",
+      {
+        caption: "outside\n",
+        story: defaultStory,
+        metadata: defaultMetadata,
+        safetyReport: defaultSafetyReport
+      }
+    );
+
+    const result = await loadDraftPreviewForRevision(
+      draftRoot,
+      outsideDir,
+      "2026-05-17",
+      "rev-001"
+    );
+
+    expect(result.outcome).toBe("malformed");
+  });
+
+  it("returns malformed when metadata.json is missing", async () => {
+    const draftRoot = await createDraftRoot();
+    const outputDir = await writeDraftRevision(draftRoot, "2026-05-17", "rev-001", {
+      caption: "no metadata\n",
+      story: defaultStory,
+      // no metadata
+      safetyReport: defaultSafetyReport
+    });
+
+    const result = await loadDraftPreviewForRevision(
+      draftRoot,
+      outputDir,
+      "2026-05-17",
+      "rev-001"
+    );
+
+    expect(result.outcome).toBe("malformed");
+    if (result.outcome === "malformed") {
+      expect(result.file).toContain("metadata.json");
+    }
   });
 });


### PR DESCRIPTION
🤖 **Auto-generated by Uncommitted Builder (Routine B v2)**

## Parent issue

[UNC-122: `uncommitted preview`에 날짜/리비전 지정 지원](<https://linear.app/sangchu/issue/UNC-122/improvement-uncommitted-preview%EC%97%90-%EB%82%A0%EC%A7%9C%EB%A6%AC%EB%B9%84%EC%A0%84-%EC%A7%80%EC%A0%95-%EC%A7%80%EC%9B%90-%ED%98%84%EC%9E%AC-latest%EB%A7%8C-%EA%B0%80%EB%8A%A5>)

Closes [UNC-122](https://linear.app/sangchu/issue/UNC-122/improvement-uncommitted-preview%EC%97%90-%EB%82%A0%EC%A7%9C%EB%A6%AC%EB%B9%84%EC%A0%84-%EC%A7%80%EC%A0%95-%EC%A7%80%EC%9B%90-%ED%98%84%EC%9E%AC-latest%EB%A7%8C-%EA%B0%80%EB%8A%A5)

## Sub-issues progress

- [X] [UNC-131](https://linear.app/sangchu/issue/UNC-131/t1-extract-resolvelatestrevfordate-into-a-shared-draft-revision) — \[T1\] Extract `resolveLatestRevForDate` into a shared draft revision resolver module (✅ done)
- [X] [UNC-132](https://linear.app/sangchu/issue/UNC-132/t2-add-date-and-rev-flag-support-to-uncommitted-preview) — \[T2\] Add `--date` and `--rev` flag support to `uncommitted preview` (✅ done)

## Status

* Branch: `claude/UNC-122-preview-date-rev`
* Tests: ✅ 416 passing / 1 skipped (vitest, 38 files)
* Build: ✅ clean
* Lint: ✅ clean
* Type check: ✅ clean

## TDD trail

[UNC-131](https://linear.app/sangchu/issue/UNC-131/t1-extract-resolvelatestrevfordate-into-a-shared-draft-revision) (`64c2fc7`):

* RED → new `src/draft-revision-resolver.ts` module surface didn't exist → 7 resolver tests fail
* GREEN → implemented `resolveLatestRevForDate` + `resolveSpecificRev` + `RevisionFormatError` → 7/7 pass
* REFACTOR → `feedback-command.ts` delegates to shared module (no behavior change, feedback tests still 25/25)

[UNC-132](https://linear.app/sangchu/issue/UNC-132/t2-add-date-and-rev-flag-support-to-uncommitted-preview) (`3bd550e`):

* RED → 10 new preview tests for `--date`/`--rev` flow fail
* GREEN → added `loadDraftPreviewForRevision` helper (shared core extracted into private `loadDraftArtifacts`); wired CLI flag parser + format validation → 81/81 focused
* Full suite: 416/417 (1 skipped)

## Subagent dispatch

* implementer (Sonnet): DONE first try, both subs in sequence
* spec reviewer: PASS for both subs
* quality reviewer: APPROVE — no Critical/Important findings; a few Minor UX suggestions captured below

### Minor follow-ups noted by quality reviewer (non-blocking)

* `runPreview` flag parser doesn't reject adjacent `--flag --flag` (would consume the next flag as value, then format-validate it). Error message still appears; just a slightly confusing UX. Could add a `value.startsWith("--")` precheck.
* `loadDraftPreviewForRevision`'s `isPathInside` guard is defense-in-depth (CLI always passes a resolver-built path that's inside `draftRoot` by construction). Kept per spec; could note in a comment that the check protects non-resolver callers.

## Notes

* Tests live in `tests/` (per `vitest.config.ts include: ["tests/**/*.test.ts"]`), not next to source as initial brief assumed — followed actual repo convention.
* No locked files touched (`pnpm-lock.yaml`, `.env*`, `AGENTS.md` all untouched).
* No auto-publish code introduced.
* New error strings are short and actionable: `No draft found for <date>` / `No draft <rev> found for <date>` + Usage line.

## Review checklist

- [X] Review each sub-issue's commit separately (T1 = `64c2fc7`, T2 = `3bd550e`)
- [X] Verify TDD test coverage (resolver: `tests/draft-revision-resolver.test.ts`, preview flow: new `tests/cli.test.ts` block, loader: `tests/preview-loader.test.ts`)
- [X] Confirm no lockfile changes (`git diff --stat origin/main..HEAD -- pnpm-lock.yaml` should be empty)
- [X] Run `pnpm install && pnpm test && pnpm build` locally
- [ ] Confirm no auto-publish code introduced
- [x] Optional: address the two Minor follow-ups above before merge

---

이 PR은 자동 생성되었습니다. 머지 전 사람의 리뷰가 반드시 필요합니다.