### PR TITLE
🤖 EventSource 정규화 추상화 + git collector 정렬 (UNC-116)

### DIFF
--- a/src/activity-summary.ts
+++ b/src/activity-summary.ts
@@ -2,6 +2,11 @@ import type { GitActivityEvent } from "./collect-git-command.js";
 import type { ActivitySignal } from "./event-source.js";
 import type { DirtyFileStatus, DirtyStatusTotals } from "./git-activity-collector.js";
 import type { ManualNoteEvent } from "./note-command.js";
+import {
+  categorizeRedactedSubject,
+  REDACTION_CATEGORY_ORDER,
+  sanitizeText
+} from "./redaction.js";
 
 export type ActivityLevel = "none" | "low" | "medium" | "high";
 
@@ -89,11 +94,6 @@ export type ActivitySynthesis = {
   themes: Exclude<ActivityTheme, "mixed" | "quiet">[];
 };
 
-type SanitizedText = {
-  value: string;
-  privateItems: string[];
-};
-
 type ProjectAccumulator = {
   projectId: string;
   projectName: string;
@@ -115,13 +115,6 @@ const dirtyStatuses: DirtyFileStatus[] = [
   "copied",
   "untracked",
   "other"
-];
-
-const privateItemOrder = [
-  "emails",
-  "local absolute paths",
-  "private URLs",
-  "raw code snippets"
 ];
 
 export function buildActivitySummary(
@@ -154,7 +147,7 @@ export function buildActivitySummary(
 
     for (const commit of event.activity.commits) {
       const sanitizedSubject = sanitizeText(commit.subject);
-      addPrivateItems(privateItems, sanitizedSubject.privateItems);
+      addPrivateItems(privateItems, sanitizedSubject.categories);
 
       totalCommits += 1;
       filesChanged += commit.stats.filesChanged;
@@ -173,7 +166,7 @@ export function buildActivitySummary(
 
     for (const file of event.activity.dirty.files) {
       const sanitizedPath = sanitizeText(file.path);
-      addPrivateItems(privateItems, sanitizedPath.privateItems);
+      addPrivateItems(privateItems, sanitizedPath.categories);
       project.uncommittedChangeCount += 1;
       uncommittedTotals[file.status] += 1;
       uncommittedFiles.push({
@@ -187,8 +180,8 @@ export function buildActivitySummary(
 
   for (const note of manualNotesForDate) {
     const sanitizedNote = sanitizeText(note.text);
-    addPrivateItems(privateItems, sanitizedNote.privateItems);
-    hasManualPrivateItems ||= sanitizedNote.privateItems.length > 0;
+    addPrivateItems(privateItems, sanitizedNote.categories);
+    hasManualPrivateItems ||= sanitizedNote.categories.length > 0;
 
     const project = getProject(projects, note.projectId, note.projectId);
     project.manualNoteCount += 1;
@@ -313,10 +306,12 @@ export function buildActivitySummary(
  *    legacy `smallWins.push(sanitizedSubject.value)` rule in the git path).
  *  - "note" signals: summary is classified for smallWin / blocker /
  *    unfinished using the existing looksLike* predicates.
- *  - "dirty-file" signals: skipped for smallWins/blockers/threads. The
- *    uncommitted-files thread aggregate is derived separately from the
- *    source-shaped uncommittedChanges output, not from signals.
- *  - Themes: every signal's summary is fed through classifyThemes.
+ *  - "dirty-file" signals: skipped entirely — no themes, smallWins,
+ *    blockers, or threads. Their "<status>: <path>" summary is file-status
+ *    context only and must not infer intent (e.g. a "src/fix-bug.ts" path
+ *    must not set a debugging theme). The uncommitted-files thread aggregate
+ *    is derived separately from the source-shaped uncommittedChanges output.
+ *  - Themes: every non-dirty signal's summary is fed through classifyThemes.
  */
 export function deriveSynthesisFromSignals(
   signals: ActivitySignal[]
@@ -327,12 +322,15 @@ export function deriveSynthesisFromSignals(
   const themes = new Set<Exclude<ActivityTheme, "mixed" | "quiet">>();
 
   for (const signal of signals) {
-    for (const theme of classifyThemes(signal.summary)) {
-      themes.add(theme);
-    }
-
+    // dirty-file summaries are "<status>: <path>" — file-status context only,
+    // never intent. Skip them entirely (no themes, wins, blockers, threads) so
+    // an uncommitted path like "src/fix-bug.ts" can't invent a dominant theme.
     if (signal.kind === "dirty-file") {
       continue;
+    }
+
+    for (const theme of classifyThemes(signal.summary)) {
+      themes.add(theme);
     }
 
     if (signal.kind === "commit") {
@@ -360,7 +358,13 @@ export function deriveSynthesisFromSignals(
   };
 }
 
-function buildSignalsFromInput(input: {
+/**
+ * Normalize source-shaped inputs (git events + manual notes) into the
+ * ActivitySignal stream consumed by deriveSynthesisFromSignals. Commit
+ * signals are built with the same shared redaction path as
+ * collectGitActivitySignals, so the two git producers stay equivalent.
+ */
+export function buildSignalsFromInput(input: {
   targetDate: string;
   gitEvents: GitActivityEvent[];
   manualNotes: ManualNoteEvent[];
@@ -370,13 +374,17 @@ function buildSignalsFromInput(input: {
 
   for (const event of input.gitEvents) {
     for (const commit of event.activity.commits) {
-      const sanitized = sanitizeText(commit.subject);
+      // commit.subject already went through collectGitActivity's 3-rule
+      // redaction; recover those categories from markers and strip any raw
+      // code the collector left intact. Mirrors collectGitActivitySignals so
+      // both producers emit identical commit signals.
+      const sanitized = categorizeRedactedSubject(commit.subject);
       signals.push({
         projectId: event.project.id,
         timestamp: commit.authoredAt,
         kind: "commit",
         summary: sanitized.value,
-        safetyNotes: sanitized.privateItems
+        safetyNotes: sanitized.categories
       });
     }
 
@@ -387,7 +395,7 @@ function buildSignalsFromInput(input: {
         timestamp: dirtyTimestamp,
         kind: "dirty-file",
         summary: `${file.status}: ${sanitized.value}`,
-        safetyNotes: sanitized.privateItems
+        safetyNotes: sanitized.categories
       });
     }
   }
@@ -399,7 +407,7 @@ function buildSignalsFromInput(input: {
       timestamp: note.timestamp,
       kind: "note",
       summary: sanitized.value,
-      safetyNotes: sanitized.privateItems
+      safetyNotes: sanitized.categories
     });
   }
 
@@ -637,68 +645,14 @@ function buildPublicSafetyNotes(options: {
   return notes;
 }
 
-function sanitizeText(value: string): SanitizedText {
-  const privateItems = new Set<string>();
-  let sanitized = value;
-
-  if (/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i.test(sanitized)) {
-    privateItems.add("emails");
-    sanitized = sanitized.replace(
-      /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi,
-      "[redacted-email]"
-    );
-  }
-
-  if (/(^|[\s(["'])\/[^\s)"']+/.test(sanitized)) {
-    privateItems.add("local absolute paths");
-    sanitized = sanitized.replace(
-      /(^|[\s(["'])\/[^\s)"']+/g,
-      "$1[redacted-path]"
-    );
-  }
-
-  if (/\b(?:https?|ssh|git):\/\/\S+|git@[\w.-]+:[^\s]+/.test(sanitized)) {
-    privateItems.add("private URLs");
-    sanitized = sanitized.replace(
-      /\b(?:https?|ssh|git):\/\/\S+|git@[\w.-]+:[^\s]+/g,
-      "[redacted-url]"
-    );
-  }
-
-  if (containsRawCodeSnippet(sanitized)) {
-    privateItems.add("raw code snippets");
-    sanitized = redactRawCodeSnippets(sanitized);
-  }
-
-  return {
-    value: sanitized,
-    privateItems: sortPrivateItems(privateItems)
-  };
-}
-
 function addPrivateItems(target: Set<string>, items: string[]): void {
   for (const item of items) {
     target.add(item);
   }
 }
 
-function containsRawCodeSnippet(value: string): boolean {
-  return redactRawCodeSnippets(value) !== value;
-}
-
-function redactRawCodeSnippets(value: string): string {
-  return value
-    .replace(/\bdiff --git\b[^\n]*/g, "[redacted-code]")
-    .replace(/`[^`]+`/g, "[redacted-code]")
-    .replace(
-      /\b(?:const|let|var)\s+[A-Za-z_$][\w$]*\s*=\s*(?:process\.env\.[A-Z0-9_]+|["'][^"']*["']|[A-Za-z0-9_$.[\]]+)/g,
-      "[redacted-code]"
-    )
-    .replace(/\bprocess\.env\.[A-Z0-9_]+\b/g, "[redacted-code]");
-}
-
 function sortPrivateItems(items: Set<string>): string[] {
-  return privateItemOrder.filter((item) => items.has(item));
+  return REDACTION_CATEGORY_ORDER.filter((item) => items.has(item));
 }
 
 function sortThemes(

--- a/src/activity-summary.ts
+++ b/src/activity-summary.ts
@@ -1,4 +1,5 @@
 import type { GitActivityEvent } from "./collect-git-command.js";
+import type { ActivitySignal } from "./event-source.js";
 import type { DirtyFileStatus, DirtyStatusTotals } from "./git-activity-collector.js";
 import type { ManualNoteEvent } from "./note-command.js";
 
@@ -81,6 +82,13 @@ export type ActivitySummary = {
   uncertaintyNotes: string[];
 };
 
+export type ActivitySynthesis = {
+  smallWins: string[];
+  blockersOrConfusion: string[];
+  unfinishedThreads: string[];
+  themes: Exclude<ActivityTheme, "mixed" | "quiet">[];
+};
+
 type SanitizedText = {
   value: string;
   privateItems: string[];
@@ -124,17 +132,15 @@ export function buildActivitySummary(
       event.targetDate === input.targetDate &&
       event.activity.targetDate === input.targetDate
   );
+  const manualNotesForDate = input.manualNotes.filter(
+    (note) => note.date === input.targetDate
+  );
   const privateItems = new Set<string>();
   const projects = new Map<string, ProjectAccumulator>();
   const subjects: string[] = [];
-  const commitThemes = new Set<Exclude<ActivityTheme, "mixed" | "quiet">>();
   const uncommittedFiles: UncommittedChangeSummary["files"] = [];
   const uncommittedTotals = createEmptyDirtyTotals();
   const manualNotes: ManualContextSummary["notes"] = [];
-  const manualThemes = new Set<Exclude<ActivityTheme, "mixed" | "quiet">>();
-  const smallWins: string[] = [];
-  const blockersOrConfusion: string[] = [];
-  const unfinishedThreads: string[] = [];
   let hasManualPrivateItems = false;
 
   let totalCommits = 0;
@@ -159,10 +165,8 @@ export function buildActivitySummary(
       project.insertions += commit.stats.insertions;
       project.deletions += commit.stats.deletions;
       subjects.push(sanitizedSubject.value);
-      smallWins.push(sanitizedSubject.value);
 
       for (const theme of classifyThemes(sanitizedSubject.value)) {
-        commitThemes.add(theme);
         project.themes.add(theme);
       }
     }
@@ -181,7 +185,7 @@ export function buildActivitySummary(
     }
   }
 
-  for (const note of input.manualNotes.filter((note) => note.date === input.targetDate)) {
+  for (const note of manualNotesForDate) {
     const sanitizedNote = sanitizeText(note.text);
     addPrivateItems(privateItems, sanitizedNote.privateItems);
     hasManualPrivateItems ||= sanitizedNote.privateItems.length > 0;
@@ -194,30 +198,29 @@ export function buildActivitySummary(
       text: sanitizedNote.value
     });
 
-    const noteThemes = classifyThemes(sanitizedNote.value);
-    for (const theme of noteThemes) {
-      manualThemes.add(theme);
+    for (const theme of classifyThemes(sanitizedNote.value)) {
       project.themes.add(theme);
-    }
-
-    if (looksLikeSmallWin(sanitizedNote.value)) {
-      smallWins.push(sanitizedNote.value);
-    }
-
-    if (looksLikeBlocker(sanitizedNote.value)) {
-      blockersOrConfusion.push(sanitizedNote.value);
-    }
-
-    if (looksUnfinished(sanitizedNote.value)) {
-      unfinishedThreads.push(sanitizedNote.value);
     }
   }
 
+  // Build a normalized signal stream from the source-shaped inputs,
+  // then derive the 4 source-agnostic synthesis fields generically.
+  const signals = buildSignalsFromInput({
+    targetDate: input.targetDate,
+    gitEvents,
+    manualNotes: manualNotesForDate
+  });
+  const synthesis = deriveSynthesisFromSignals(signals);
+
+  // The uncommitted-files unfinished thread is a source-shaped aggregate
+  // (count + project name), so it stays sourced from the per-project
+  // accumulator and is prepended to the signal-derived list (matches the
+  // legacy `unshift` ordering: uncommitted entries appear first).
+  const unfinishedThreads = [...synthesis.unfinishedThreads];
   for (const project of projects.values()) {
     if (project.uncommittedChangeCount === 0) {
       continue;
     }
-
     unfinishedThreads.unshift(
       `${project.uncommittedChangeCount} ${project.uncommittedChangeCount === 1 ? "uncommitted file remains" : "uncommitted files remain"} in ${project.projectName}.`
     );
@@ -229,13 +232,22 @@ export function buildActivitySummary(
     uncommittedFiles.length +
     manualNotes.length * 2;
   const activityLevel = classifyActivityLevel(score);
-  const allThemes = sortThemes(new Set([...commitThemes, ...manualThemes]));
-  const dominantTheme = deriveDominantTheme(activityLevel, allThemes);
+  const dominantTheme = deriveDominantTheme(activityLevel, synthesis.themes);
+
+  // commitSignals.themes is a git-only rollup — re-classify just the
+  // accumulated commit subjects (synthesis.themes mixes commit + note themes).
+  const commitOnlyThemeSet = new Set<Exclude<ActivityTheme, "mixed" | "quiet">>();
+  for (const subject of subjects) {
+    for (const theme of classifyThemes(subject)) {
+      commitOnlyThemeSet.add(theme);
+    }
+  }
+
   const uncertaintyNotes = buildUncertaintyNotes(input, {
     gitEventCount: gitEvents.length,
     totalCommits,
     manualNoteCount: manualNotes.length,
-    themeCount: allThemes.length,
+    themeCount: synthesis.themes.length,
     uncommittedChangeCount: uncommittedFiles.length
   });
   const publicSafetyNotes = buildPublicSafetyNotes({
@@ -256,7 +268,7 @@ export function buildActivitySummary(
       insertions,
       deletions,
       subjects,
-      themes: sortThemes(commitThemes)
+      themes: sortThemes(commitOnlyThemeSet)
     },
     uncommittedChanges: {
       totalFiles: uncommittedFiles.length,
@@ -267,17 +279,131 @@ export function buildActivitySummary(
       noteCount: manualNotes.length,
       notes: manualNotes
     },
-    smallWins,
-    blockersOrConfusion,
+    smallWins: synthesis.smallWins,
+    blockersOrConfusion: synthesis.blockersOrConfusion,
     unfinishedThreads,
     possibleJokes: buildPossibleJokes(activityLevel, {
-      hasBlockers: blockersOrConfusion.length > 0,
+      hasBlockers: synthesis.blockersOrConfusion.length > 0,
       hasUncommittedChanges: uncommittedFiles.length > 0
     }),
     publicSafetyNotes,
     privateItemsToAvoid: sortPrivateItems(privateItems),
     uncertaintyNotes
   };
+}
+
+/**
+ * Source-agnostic synthesis of an ActivitySignal stream.
+ *
+ * Derives only the 4 fields that have no source-shape dependency:
+ *   - themes (used by dominantTheme)
+ *   - smallWins
+ *   - unfinishedThreads
+ *   - blockersOrConfusion
+ *
+ * possibleJokes is derived separately because it depends on aggregate
+ * presence/absence flags (hasBlockers, hasUncommittedChanges) rather than
+ * on individual signals.
+ *
+ * Behavior is keyed on (kind, summary), never on source type. Unknown
+ * kinds are treated as opaque — only the summary text drives synthesis.
+ *
+ * Rules:
+ *  - "commit" signals: summary is always added to smallWins (matches the
+ *    legacy `smallWins.push(sanitizedSubject.value)` rule in the git path).
+ *  - "note" signals: summary is classified for smallWin / blocker /
+ *    unfinished using the existing looksLike* predicates.
+ *  - "dirty-file" signals: skipped for smallWins/blockers/threads. The
+ *    uncommitted-files thread aggregate is derived separately from the
+ *    source-shaped uncommittedChanges output, not from signals.
+ *  - Themes: every signal's summary is fed through classifyThemes.
+ */
+export function deriveSynthesisFromSignals(
+  signals: ActivitySignal[]
+): ActivitySynthesis {
+  const smallWins: string[] = [];
+  const blockersOrConfusion: string[] = [];
+  const unfinishedThreads: string[] = [];
+  const themes = new Set<Exclude<ActivityTheme, "mixed" | "quiet">>();
+
+  for (const signal of signals) {
+    for (const theme of classifyThemes(signal.summary)) {
+      themes.add(theme);
+    }
+
+    if (signal.kind === "dirty-file") {
+      continue;
+    }
+
+    if (signal.kind === "commit") {
+      smallWins.push(signal.summary);
+      continue;
+    }
+
+    // All other kinds (note, pr, future) are pattern-classified.
+    if (looksLikeSmallWin(signal.summary)) {
+      smallWins.push(signal.summary);
+    }
+    if (looksLikeBlocker(signal.summary)) {
+      blockersOrConfusion.push(signal.summary);
+    }
+    if (looksUnfinished(signal.summary)) {
+      unfinishedThreads.push(signal.summary);
+    }
+  }
+
+  return {
+    smallWins,
+    blockersOrConfusion,
+    unfinishedThreads,
+    themes: sortThemes(themes)
+  };
+}
+
+function buildSignalsFromInput(input: {
+  targetDate: string;
+  gitEvents: GitActivityEvent[];
+  manualNotes: ManualNoteEvent[];
+}): ActivitySignal[] {
+  const signals: ActivitySignal[] = [];
+  const dirtyTimestamp = `${input.targetDate}T00:00:00.000Z`;
+
+  for (const event of input.gitEvents) {
+    for (const commit of event.activity.commits) {
+      const sanitized = sanitizeText(commit.subject);
+      signals.push({
+        projectId: event.project.id,
+        timestamp: commit.authoredAt,
+        kind: "commit",
+        summary: sanitized.value,
+        safetyNotes: sanitized.privateItems
+      });
+    }
+
+    for (const file of event.activity.dirty.files) {
+      const sanitized = sanitizeText(file.path);
+      signals.push({
+        projectId: event.project.id,
+        timestamp: dirtyTimestamp,
+        kind: "dirty-file",
+        summary: `${file.status}: ${sanitized.value}`,
+        safetyNotes: sanitized.privateItems
+      });
+    }
+  }
+
+  for (const note of input.manualNotes) {
+    const sanitized = sanitizeText(note.text);
+    signals.push({
+      projectId: note.projectId,
+      timestamp: note.timestamp,
+      kind: "note",
+      summary: sanitized.value,
+      safetyNotes: sanitized.privateItems
+    });
+  }
+
+  return signals;
 }
 
 export function isActivitySummary(value: unknown): value is ActivitySummary {

--- a/src/event-source.ts
+++ b/src/event-source.ts
@@ -1,0 +1,55 @@
+/**
+ * Normalized activity signal contract shared by all event sources
+ * (git, Claude session logs, Codex session logs, GitHub PRs, manual notes).
+ *
+ * The shape is intentionally minimal:
+ *   - projectId    — stable id of the originating project
+ *   - timestamp    — ISO-8601 UTC instant of the signal
+ *   - kind         — extensible union string; consumers should treat
+ *                    unknown kinds as opaque and route by string match
+ *   - summary      — short human-readable line, already sanitized
+ *   - safetyNotes  — redaction categories that were applied to summary
+ *                    (subset of the canonical list maintained by
+ *                    activity-summary.ts: 'emails', 'local absolute paths',
+ *                    'private URLs', 'raw code snippets')
+ *
+ * Source-specific metadata (commit stats, file status, etc.) is NOT
+ * carried on the signal. Consumers needing source-specific aggregation
+ * must read it from the source-shaped event input (e.g. GitActivityEvent),
+ * not from the signal stream.
+ */
+export type ActivitySignalKind =
+  | "commit"
+  | "pr"
+  | "note"
+  | "dirty-file"
+  | (string & {}); // extensible union — future sources may add their own kinds
+
+export type ActivitySignal = {
+  projectId: string;
+  timestamp: string;
+  kind: ActivitySignalKind;
+  summary: string;
+  safetyNotes: string[];
+};
+
+export interface EventSource {
+  collect(): Promise<ActivitySignal[]>;
+}
+
+export function isActivitySignal(value: unknown): value is ActivitySignal {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+
+  return (
+    typeof candidate.projectId === "string" &&
+    typeof candidate.timestamp === "string" &&
+    typeof candidate.kind === "string" &&
+    typeof candidate.summary === "string" &&
+    Array.isArray(candidate.safetyNotes) &&
+    candidate.safetyNotes.every((note) => typeof note === "string")
+  );
+}

--- a/src/event-source.ts
+++ b/src/event-source.ts
@@ -23,7 +23,10 @@ export type ActivitySignalKind =
   | "pr"
   | "note"
   | "dirty-file"
-  | (string & {}); // extensible union — future sources may add their own kinds
+  // `(string & {})` keeps editor autocomplete for the known kinds above while
+  // still accepting any other string, so future sources (claude/codex/etc.)
+  // can introduce new kinds without a breaking change to this union.
+  | (string & {});
 
 export type ActivitySignal = {
   projectId: string;

--- a/src/git-activity-collector.ts
+++ b/src/git-activity-collector.ts
@@ -360,10 +360,12 @@ function redactSensitiveText(value: string): RedactionResult {
   const categories = new Set<RedactionCategory>();
   let sanitized = value;
 
-  if (/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i.test(sanitized)) {
+  // Bounded quantifiers (see redaction.ts) keep email matching linear and
+  // clear the polynomial-ReDoS warning; real emails match identically.
+  if (/[A-Z0-9._%+-]{1,64}@[A-Z0-9.-]{1,255}\.[A-Z]{2,24}/i.test(sanitized)) {
     categories.add("emails");
     sanitized = sanitized.replace(
-      /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi,
+      /[A-Z0-9._%+-]{1,64}@[A-Z0-9.-]{1,255}\.[A-Z]{2,24}/gi,
       "[redacted-email]"
     );
   }

--- a/src/git-activity-collector.ts
+++ b/src/git-activity-collector.ts
@@ -3,6 +3,7 @@ import { constants } from "node:fs";
 import { access, realpath } from "node:fs/promises";
 import { basename } from "node:path";
 import { promisify } from "node:util";
+import type { ActivitySignal, EventSource } from "./event-source.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -164,9 +165,9 @@ function parseGitLog(stdout: string): ParsedCommit[] {
       currentCommit = {
         hash: fields[0],
         shortHash: fields[1],
-        authorName: redactSensitiveText(fields[2]),
+        authorName: redactSensitiveText(fields[2]).value,
         authoredAt: fields[3],
-        subject: redactSensitiveText(fields[4]),
+        subject: redactSensitiveText(fields[4]).value,
         stats: {
           filesChanged: 0,
           insertions: 0,
@@ -339,15 +340,127 @@ function getDateWindow(targetDate: string): { start: string; end: string } {
   };
 }
 
-function redactSensitiveText(value: string): string {
-  return value
-    .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, "[redacted-email]")
-    .replace(
+type RedactionCategory =
+  | "emails"
+  | "local absolute paths"
+  | "private URLs"
+  | "raw code snippets";
+
+type RedactionResult = {
+  value: string;
+  categories: RedactionCategory[];
+};
+
+const REDACTION_CATEGORY_ORDER: RedactionCategory[] = [
+  "emails",
+  "local absolute paths",
+  "private URLs",
+  "raw code snippets"
+];
+
+function redactSensitiveText(value: string): RedactionResult {
+  const categories = new Set<RedactionCategory>();
+  let sanitized = value;
+
+  if (/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i.test(sanitized)) {
+    categories.add("emails");
+    sanitized = sanitized.replace(
+      /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi,
+      "[redacted-email]"
+    );
+  }
+
+  if (/\b(?:https?|ssh|git):\/\/\S+|git@[\w.-]+:[^\s]+/.test(sanitized)) {
+    categories.add("private URLs");
+    sanitized = sanitized.replace(
       /\b(?:https?|ssh|git):\/\/\S+|git@[\w.-]+:[^\s]+/g,
       "[redacted-url]"
-    )
-    .replace(
+    );
+  }
+
+  if (/(^|[\s(["'])\/[^\s)"']+/.test(sanitized)) {
+    categories.add("local absolute paths");
+    sanitized = sanitized.replace(
       /(^|[\s(["'])\/[^\s)"']+/g,
       "$1[redacted-path]"
     );
+  }
+
+  return {
+    value: sanitized,
+    categories: REDACTION_CATEGORY_ORDER.filter((category) => categories.has(category))
+  };
+}
+
+export type CollectGitActivitySignalsOptions = {
+  projectId: string;
+  projectRoot: string;
+  targetDate: string;
+};
+
+export async function collectGitActivitySignals(
+  options: CollectGitActivitySignalsOptions
+): Promise<ActivitySignal[]> {
+  const activity = await collectGitActivity({
+    projectRoot: options.projectRoot,
+    targetDate: options.targetDate
+  });
+
+  const signals: ActivitySignal[] = [];
+
+  for (const commit of activity.commits) {
+    // commit.subject was already redacted in parseGitLog; re-run redaction
+    // categorization on the SOURCE subject to surface safetyNotes accurately.
+    // Since the redacted string is what we ship, derive categories from the
+    // mismatch between commit.subject and the redaction markers it now
+    // contains. Easier and more precise: keep the original subject around.
+    // For simplicity here, we re-derive categories from the redacted subject
+    // by detecting the presence of [redacted-*] markers.
+    const safetyNotes = deriveSafetyNotesFromRedactedText(commit.subject);
+
+    signals.push({
+      projectId: options.projectId,
+      timestamp: commit.authoredAt,
+      kind: "commit",
+      summary: commit.subject,
+      safetyNotes
+    });
+  }
+
+  const dirtyTimestamp = `${options.targetDate}T00:00:00.000Z`;
+
+  for (const file of activity.dirty.files) {
+    const { value: redactedPath, categories } = redactSensitiveText(file.path);
+    signals.push({
+      projectId: options.projectId,
+      timestamp: dirtyTimestamp,
+      kind: "dirty-file",
+      summary: `${file.status}: ${redactedPath}`,
+      safetyNotes: categories
+    });
+  }
+
+  return signals;
+}
+
+export class GitActivityEventSource implements EventSource {
+  constructor(private readonly options: CollectGitActivitySignalsOptions) {}
+
+  collect(): Promise<ActivitySignal[]> {
+    return collectGitActivitySignals(this.options);
+  }
+}
+
+function deriveSafetyNotesFromRedactedText(value: string): RedactionCategory[] {
+  const categories = new Set<RedactionCategory>();
+  if (value.includes("[redacted-email]")) {
+    categories.add("emails");
+  }
+  if (value.includes("[redacted-path]")) {
+    categories.add("local absolute paths");
+  }
+  if (value.includes("[redacted-url]")) {
+    categories.add("private URLs");
+  }
+  return REDACTION_CATEGORY_ORDER.filter((category) => categories.has(category));
 }

--- a/src/git-activity-collector.ts
+++ b/src/git-activity-collector.ts
@@ -4,6 +4,13 @@ import { access, realpath } from "node:fs/promises";
 import { basename } from "node:path";
 import { promisify } from "node:util";
 import type { ActivitySignal, EventSource } from "./event-source.js";
+import {
+  categorizeRedactedSubject,
+  REDACTION_CATEGORY_ORDER,
+  sanitizeText,
+  type RedactionCategory,
+  type RedactionResult
+} from "./redaction.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -340,24 +347,15 @@ function getDateWindow(targetDate: string): { start: string; end: string } {
   };
 }
 
-type RedactionCategory =
-  | "emails"
-  | "local absolute paths"
-  | "private URLs"
-  | "raw code snippets";
-
-type RedactionResult = {
-  value: string;
-  categories: RedactionCategory[];
-};
-
-const REDACTION_CATEGORY_ORDER: RedactionCategory[] = [
-  "emails",
-  "local absolute paths",
-  "private URLs",
-  "raw code snippets"
-];
-
+/**
+ * 3-rule redaction applied to legacy collectGitActivity output (commit
+ * subjects + author names): emails, absolute paths, private URLs. Raw-code
+ * redaction is intentionally NOT applied here — buildActivitySummary runs the
+ * full canonical sanitizeText on these subjects downstream, and adding the
+ * 4th rule here would strip raw code before that pass and drop "raw code
+ * snippets" from privateItemsToAvoid. Signal builders use the shared
+ * categorizeRedactedSubject to add raw-code handling on top of this output.
+ */
 function redactSensitiveText(value: string): RedactionResult {
   const categories = new Set<RedactionCategory>();
   let sanitized = value;
@@ -409,34 +407,29 @@ export async function collectGitActivitySignals(
   const signals: ActivitySignal[] = [];
 
   for (const commit of activity.commits) {
-    // commit.subject was already redacted in parseGitLog; re-run redaction
-    // categorization on the SOURCE subject to surface safetyNotes accurately.
-    // Since the redacted string is what we ship, derive categories from the
-    // mismatch between commit.subject and the redaction markers it now
-    // contains. Easier and more precise: keep the original subject around.
-    // For simplicity here, we re-derive categories from the redacted subject
-    // by detecting the presence of [redacted-*] markers.
-    const safetyNotes = deriveSafetyNotesFromRedactedText(commit.subject);
-
+    // commit.subject was already 3-rule redacted in parseGitLog; recover those
+    // categories and strip any raw code that pass left intact so the shipped
+    // signal honors the "already sanitized" contract.
+    const sanitized = categorizeRedactedSubject(commit.subject);
     signals.push({
       projectId: options.projectId,
       timestamp: commit.authoredAt,
       kind: "commit",
-      summary: commit.subject,
-      safetyNotes
+      summary: sanitized.value,
+      safetyNotes: sanitized.categories
     });
   }
 
   const dirtyTimestamp = `${options.targetDate}T00:00:00.000Z`;
 
   for (const file of activity.dirty.files) {
-    const { value: redactedPath, categories } = redactSensitiveText(file.path);
+    const sanitized = sanitizeText(file.path);
     signals.push({
       projectId: options.projectId,
       timestamp: dirtyTimestamp,
       kind: "dirty-file",
-      summary: `${file.status}: ${redactedPath}`,
-      safetyNotes: categories
+      summary: `${file.status}: ${sanitized.value}`,
+      safetyNotes: sanitized.categories
     });
   }
 
@@ -449,18 +442,4 @@ export class GitActivityEventSource implements EventSource {
   collect(): Promise<ActivitySignal[]> {
     return collectGitActivitySignals(this.options);
   }
-}
-
-function deriveSafetyNotesFromRedactedText(value: string): RedactionCategory[] {
-  const categories = new Set<RedactionCategory>();
-  if (value.includes("[redacted-email]")) {
-    categories.add("emails");
-  }
-  if (value.includes("[redacted-path]")) {
-    categories.add("local absolute paths");
-  }
-  if (value.includes("[redacted-url]")) {
-    categories.add("private URLs");
-  }
-  return REDACTION_CATEGORY_ORDER.filter((category) => categories.has(category));
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,13 @@ export type {
   EventSource
 } from "./event-source.js";
 export {
+  collectGitActivitySignals,
+  GitActivityEventSource
+} from "./git-activity-collector.js";
+export type {
+  CollectGitActivitySignalsOptions
+} from "./git-activity-collector.js";
+export {
   ensureConfigDirectories,
   expandHomePath,
   resolveConfigPaths

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,12 @@ export type {
   DoctorReport,
   DoctorStatus
 } from "./doctor-command.js";
+export { isActivitySignal } from "./event-source.js";
+export type {
+  ActivitySignal,
+  ActivitySignalKind,
+  EventSource
+} from "./event-source.js";
 export {
   ensureConfigDirectories,
   expandHomePath,

--- a/src/redaction.ts
+++ b/src/redaction.ts
@@ -1,0 +1,128 @@
+/**
+ * Canonical text redaction shared by every activity source.
+ *
+ * One sanitizer, one category vocabulary, one ordering — so the git
+ * EventSource (git-activity-collector.ts) and the summary synthesis
+ * (activity-summary.ts) can never drift on what counts as sensitive or on
+ * how a sanitized signal reports its safetyNotes. Before this module the two
+ * producers each kept their own regex block and category list, which let a
+ * commit signal leak raw code that the summary path would have masked.
+ */
+
+export type RedactionCategory =
+  | "emails"
+  | "local absolute paths"
+  | "private URLs"
+  | "raw code snippets";
+
+/**
+ * Stable display/compare order for redaction categories. Both producers sort
+ * safetyNotes through this list so equal inputs yield byte-equal arrays.
+ */
+export const REDACTION_CATEGORY_ORDER: RedactionCategory[] = [
+  "emails",
+  "local absolute paths",
+  "private URLs",
+  "raw code snippets"
+];
+
+export type RedactionResult = {
+  value: string;
+  categories: RedactionCategory[];
+};
+
+/**
+ * Full 4-rule sanitizer for raw text (commit subjects before collector
+ * redaction, dirty-file paths, manual notes). Applies, in order, email →
+ * absolute-path → private-URL → raw-code redaction and reports every
+ * category that fired.
+ */
+export function sanitizeText(value: string): RedactionResult {
+  const categories = new Set<RedactionCategory>();
+  let sanitized = value;
+
+  if (/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i.test(sanitized)) {
+    categories.add("emails");
+    sanitized = sanitized.replace(
+      /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi,
+      "[redacted-email]"
+    );
+  }
+
+  if (/(^|[\s(["'])\/[^\s)"']+/.test(sanitized)) {
+    categories.add("local absolute paths");
+    sanitized = sanitized.replace(
+      /(^|[\s(["'])\/[^\s)"']+/g,
+      "$1[redacted-path]"
+    );
+  }
+
+  if (/\b(?:https?|ssh|git):\/\/\S+|git@[\w.-]+:[^\s]+/.test(sanitized)) {
+    categories.add("private URLs");
+    sanitized = sanitized.replace(
+      /\b(?:https?|ssh|git):\/\/\S+|git@[\w.-]+:[^\s]+/g,
+      "[redacted-url]"
+    );
+  }
+
+  if (containsRawCodeSnippet(sanitized)) {
+    categories.add("raw code snippets");
+    sanitized = redactRawCodeSnippets(sanitized);
+  }
+
+  return { value: sanitized, categories: sortCategories(categories) };
+}
+
+/**
+ * Categorize a subject that the collector already redacted with the 3-rule
+ * pass (emails / absolute paths / private URLs), then redact any raw code the
+ * collector left intact. Email/path/URL categories are recovered from the
+ * redaction markers; raw code is detected fresh on the remaining text.
+ *
+ * This is how commit signals are built in both producers: collectGitActivity
+ * masks emails/paths/URLs first, so re-running the email/path/URL rules here
+ * would no longer match the markers — but raw code never got a rule in that
+ * pass and must still be removed before the signal ships.
+ */
+export function categorizeRedactedSubject(redactedSubject: string): RedactionResult {
+  const categories = new Set<RedactionCategory>();
+
+  if (redactedSubject.includes("[redacted-email]")) {
+    categories.add("emails");
+  }
+  if (redactedSubject.includes("[redacted-path]")) {
+    categories.add("local absolute paths");
+  }
+  if (redactedSubject.includes("[redacted-url]")) {
+    categories.add("private URLs");
+  }
+
+  let value = redactedSubject;
+  if (containsRawCodeSnippet(value)) {
+    categories.add("raw code snippets");
+    value = redactRawCodeSnippets(value);
+  }
+
+  return { value, categories: sortCategories(categories) };
+}
+
+export function sortCategories(
+  categories: Set<RedactionCategory>
+): RedactionCategory[] {
+  return REDACTION_CATEGORY_ORDER.filter((category) => categories.has(category));
+}
+
+function containsRawCodeSnippet(value: string): boolean {
+  return redactRawCodeSnippets(value) !== value;
+}
+
+function redactRawCodeSnippets(value: string): string {
+  return value
+    .replace(/\bdiff --git\b[^\n]*/g, "[redacted-code]")
+    .replace(/`[^`]+`/g, "[redacted-code]")
+    .replace(
+      /\b(?:const|let|var)\s+[A-Za-z_$][\w$]*\s*=\s*(?:process\.env\.[A-Z0-9_]+|["'][^"']*["']|[A-Za-z0-9_$.[\]]+)/g,
+      "[redacted-code]"
+    )
+    .replace(/\bprocess\.env\.[A-Z0-9_]+\b/g, "[redacted-code]");
+}

--- a/src/redaction.ts
+++ b/src/redaction.ts
@@ -41,10 +41,13 @@ export function sanitizeText(value: string): RedactionResult {
   const categories = new Set<RedactionCategory>();
   let sanitized = value;
 
-  if (/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i.test(sanitized)) {
+  // Quantifiers are bounded (RFC-5321-ish limits) to keep matching linear and
+  // avoid the polynomial-ReDoS CodeQL flags on the unbounded form. Real emails
+  // match identically.
+  if (/[A-Z0-9._%+-]{1,64}@[A-Z0-9.-]{1,255}\.[A-Z]{2,24}/i.test(sanitized)) {
     categories.add("emails");
     sanitized = sanitized.replace(
-      /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi,
+      /[A-Z0-9._%+-]{1,64}@[A-Z0-9.-]{1,255}\.[A-Z]{2,24}/gi,
       "[redacted-email]"
     );
   }

--- a/tests/activity-summary.test.ts
+++ b/tests/activity-summary.test.ts
@@ -4,6 +4,8 @@ import {
   isActivitySummary,
   type ActivitySummaryInput
 } from "../src/activity-summary.js";
+import { deriveSynthesisFromSignals } from "../src/activity-summary.js";
+import type { ActivitySignal } from "../src/event-source.js";
 
 describe("activity summary", () => {
   it("summarizes an active Git day with safe project, commit, and dirty signals", () => {
@@ -320,3 +322,75 @@ function createCommit(options: {
     }
   };
 }
+
+describe("activity summary — signal-driven synthesis (UNC-135)", () => {
+  it("derives smallWins, unfinishedThreads, possibleJokes, dominantTheme from kind+summary alone", () => {
+    const signals: ActivitySignal[] = [
+      {
+        projectId: "cli",
+        timestamp: "2026-05-12T10:00:00.000Z",
+        kind: "commit",
+        summary: "implement collect git command",
+        safetyNotes: []
+      },
+      {
+        projectId: "cli",
+        timestamp: "2026-05-12T11:00:00.000Z",
+        kind: "commit",
+        summary: "fix flaky collector path handling",
+        safetyNotes: []
+      },
+      {
+        projectId: "cli",
+        timestamp: "2026-05-12T12:00:00.000Z",
+        kind: "note",
+        summary: "TODO revisit edge case tomorrow",
+        safetyNotes: []
+      }
+    ];
+
+    const synthesis = deriveSynthesisFromSignals(signals);
+
+    expect(synthesis.smallWins).toEqual(
+      expect.arrayContaining([
+        "implement collect git command",
+        "fix flaky collector path handling"
+      ])
+    );
+    expect(synthesis.unfinishedThreads).toContain("TODO revisit edge case tomorrow");
+    expect(synthesis.themes).toEqual(expect.arrayContaining(["coding", "debugging"]));
+  });
+
+  it("treats an unknown future kind as opaque — uses summary text only, no branching", () => {
+    const signals: ActivitySignal[] = [
+      {
+        projectId: "cli",
+        timestamp: "2026-05-12T10:00:00.000Z",
+        kind: "claude-session" as ActivitySignal["kind"],
+        summary: "refactor note parsing for clarity",
+        safetyNotes: []
+      }
+    ];
+
+    const synthesis = deriveSynthesisFromSignals(signals);
+    expect(synthesis.themes).toContain("refactoring");
+    expect(synthesis.smallWins).toEqual([]); // no "add/built/fixed/..." in summary
+  });
+
+  it("ignores dirty-file signals for smallWins (they are not wins) but counts their themes", () => {
+    const signals: ActivitySignal[] = [
+      {
+        projectId: "cli",
+        timestamp: "2026-05-12T00:00:00.000Z",
+        kind: "dirty-file",
+        summary: "modified: src/foo.ts",
+        safetyNotes: []
+      }
+    ];
+
+    const synthesis = deriveSynthesisFromSignals(signals);
+    expect(synthesis.smallWins).toEqual([]);
+    // dirty files do not trigger any of the existing theme keywords, so themes empty
+    expect(synthesis.themes).toEqual([]);
+  });
+});

--- a/tests/activity-summary.test.ts
+++ b/tests/activity-summary.test.ts
@@ -377,7 +377,7 @@ describe("activity summary — signal-driven synthesis (UNC-135)", () => {
     expect(synthesis.smallWins).toEqual([]); // no "add/built/fixed/..." in summary
   });
 
-  it("ignores dirty-file signals for smallWins (they are not wins) but counts their themes", () => {
+  it("ignores dirty-file signals for smallWins (they are not wins)", () => {
     const signals: ActivitySignal[] = [
       {
         projectId: "cli",
@@ -390,7 +390,34 @@ describe("activity summary — signal-driven synthesis (UNC-135)", () => {
 
     const synthesis = deriveSynthesisFromSignals(signals);
     expect(synthesis.smallWins).toEqual([]);
-    // dirty files do not trigger any of the existing theme keywords, so themes empty
+  });
+
+  it("does not infer themes from dirty-file path summaries", () => {
+    // A day with only uncommitted files whose paths carry theme keywords
+    // must not set a dominant theme — uncommitted changes are file-status
+    // context only, never intent (matches the legacy commit+note-only theme
+    // rollup). Regression guard for the EventSource synthesis refactor.
+    const signals: ActivitySignal[] = [
+      {
+        projectId: "cli",
+        timestamp: "2026-05-12T00:00:00.000Z",
+        kind: "dirty-file",
+        summary: "modified: src/fix-bug.ts",
+        safetyNotes: []
+      },
+      {
+        projectId: "cli",
+        timestamp: "2026-05-12T00:00:00.000Z",
+        kind: "dirty-file",
+        summary: "untracked: todo.md",
+        safetyNotes: []
+      }
+    ];
+
+    const synthesis = deriveSynthesisFromSignals(signals);
     expect(synthesis.themes).toEqual([]);
+    expect(synthesis.smallWins).toEqual([]);
+    expect(synthesis.blockersOrConfusion).toEqual([]);
+    expect(synthesis.unfinishedThreads).toEqual([]);
   });
 });

--- a/tests/event-source.test.ts
+++ b/tests/event-source.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+  isActivitySignal,
+  type ActivitySignal,
+  type ActivitySignalKind,
+  type EventSource
+} from "../src/event-source.js";
+
+describe("event-source contract", () => {
+  it("accepts a valid signal with all required fields and empty safetyNotes", () => {
+    const signal: ActivitySignal = {
+      projectId: "cli",
+      timestamp: "2026-06-10T10:00:00.000Z",
+      kind: "commit",
+      summary: "implement collect git command",
+      safetyNotes: []
+    };
+
+    expect(isActivitySignal(signal)).toBe(true);
+  });
+
+  it("accepts safetyNotes carrying redaction categories", () => {
+    const signal: ActivitySignal = {
+      projectId: "cli",
+      timestamp: "2026-06-10T10:00:00.000Z",
+      kind: "note",
+      summary: "Planned activity with [redacted-email]",
+      safetyNotes: ["emails"]
+    };
+
+    expect(isActivitySignal(signal)).toBe(true);
+  });
+
+  it("rejects signals missing required fields", () => {
+    expect(isActivitySignal({})).toBe(false);
+    expect(
+      isActivitySignal({
+        projectId: "cli",
+        timestamp: "2026-06-10T10:00:00.000Z",
+        kind: "commit",
+        summary: "missing safetyNotes"
+      })
+    ).toBe(false);
+  });
+
+  it("rejects non-array safetyNotes", () => {
+    expect(
+      isActivitySignal({
+        projectId: "cli",
+        timestamp: "2026-06-10T10:00:00.000Z",
+        kind: "commit",
+        summary: "bad shape",
+        safetyNotes: "emails"
+      })
+    ).toBe(false);
+  });
+
+  it("treats kind as an extensible string so future sources are not blocked at the contract level", () => {
+    const futureSignal: ActivitySignal = {
+      projectId: "cli",
+      timestamp: "2026-06-10T10:00:00.000Z",
+      kind: "claude-session" as ActivitySignalKind,
+      summary: "Claude session summary placeholder",
+      safetyNotes: []
+    };
+
+    expect(isActivitySignal(futureSignal)).toBe(true);
+  });
+
+  it("permits any object implementing collect() to satisfy EventSource", async () => {
+    const source: EventSource = {
+      async collect() {
+        return [
+          {
+            projectId: "cli",
+            timestamp: "2026-06-10T10:00:00.000Z",
+            kind: "commit",
+            summary: "fixture",
+            safetyNotes: []
+          }
+        ];
+      }
+    };
+
+    const signals = await source.collect();
+    expect(signals).toHaveLength(1);
+    expect(isActivitySignal(signals[0])).toBe(true);
+  });
+});

--- a/tests/git-activity-collector.test.ts
+++ b/tests/git-activity-collector.test.ts
@@ -7,8 +7,11 @@ import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
 import {
   collectGitActivity,
-  GitActivityCollectionError
+  collectGitActivitySignals,
+  GitActivityCollectionError,
+  GitActivityEventSource
 } from "../src/git-activity-collector.js";
+import { isActivitySignal } from "../src/event-source.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -180,6 +183,143 @@ describe("Git activity collector", () => {
     ).rejects.toBeInstanceOf(GitActivityCollectionError);
   });
 });
+
+describe("collectGitActivitySignals", () => {
+  it("emits one commit signal per commit with subject as summary and authoredAt as timestamp", async () => {
+    const { gitRoot, targetDate } = await createRepoWithCommits([
+      { subject: "implement collect git command" },
+      { subject: "fix flaky collector path handling" }
+    ]);
+
+    const signals = await collectGitActivitySignals({
+      projectId: "cli",
+      projectRoot: gitRoot,
+      targetDate
+    });
+
+    const commitSignals = signals.filter((signal) => signal.kind === "commit");
+    expect(commitSignals).toHaveLength(2);
+    for (const signal of commitSignals) {
+      expect(isActivitySignal(signal)).toBe(true);
+      expect(signal.projectId).toBe("cli");
+      expect(signal.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+      expect(typeof signal.summary).toBe("string");
+      expect(signal.summary.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("emits one dirty-file signal per uncommitted file with '<status>: <path>' summary", async () => {
+    const { gitRoot, targetDate } = await createRepoWithDirtyFile({
+      path: "src/foo.ts",
+      content: "// dirty\n"
+    });
+
+    const signals = await collectGitActivitySignals({
+      projectId: "cli",
+      projectRoot: gitRoot,
+      targetDate
+    });
+
+    const dirtySignals = signals.filter((signal) => signal.kind === "dirty-file");
+    expect(dirtySignals).toHaveLength(1);
+    expect(dirtySignals[0].summary).toMatch(/^(modified|added|untracked): /);
+    expect(dirtySignals[0].timestamp).toBe(`${targetDate}T00:00:00.000Z`);
+  });
+
+  it("populates safetyNotes with redaction categories that fired on the summary", async () => {
+    const { gitRoot, targetDate } = await createRepoWithCommits([
+      { subject: "store creds at /Users/me/keys/prod.txt" }
+    ]);
+
+    const signals = await collectGitActivitySignals({
+      projectId: "cli",
+      projectRoot: gitRoot,
+      targetDate
+    });
+
+    const commitSignal = signals.find((signal) => signal.kind === "commit");
+    expect(commitSignal).toBeDefined();
+    expect(commitSignal!.summary).not.toContain("/Users/me/keys/prod.txt");
+    expect(commitSignal!.safetyNotes).toContain("local absolute paths");
+  });
+
+  it("GitActivityEventSource.collect() returns the same signals as collectGitActivitySignals", async () => {
+    const { gitRoot, targetDate } = await createRepoWithCommits([
+      { subject: "first commit" }
+    ]);
+
+    const direct = await collectGitActivitySignals({
+      projectId: "cli",
+      projectRoot: gitRoot,
+      targetDate
+    });
+    const viaSource = await new GitActivityEventSource({
+      projectId: "cli",
+      projectRoot: gitRoot,
+      targetDate
+    }).collect();
+
+    expect(viaSource).toEqual(direct);
+  });
+
+  it("leaves the existing collectGitActivity output unchanged (regression guard)", async () => {
+    const { gitRoot, targetDate } = await createRepoWithCommits([
+      { subject: "first commit" }
+    ]);
+
+    const activity = await collectGitActivity({
+      projectRoot: gitRoot,
+      targetDate
+    });
+
+    expect(activity.schemaVersion).toBe(1);
+    expect(activity.commits).toHaveLength(1);
+    expect(activity.totals.commits).toBe(1);
+  });
+});
+
+type CommitFixture = {
+  subject: string;
+};
+
+async function createRepoWithCommits(
+  commits: CommitFixture[]
+): Promise<{ gitRoot: string; targetDate: string }> {
+  const repoDir = await initGitRepo("signals-commits-repo");
+  const targetDate = "2026-05-05";
+  const baseHour = 10;
+
+  for (const [index, fixture] of commits.entries()) {
+    const fileName = `commit-${index}.txt`;
+    await writeFile(join(repoDir, fileName), `entry ${index}\n`, "utf8");
+    await git(repoDir, ["add", fileName]);
+    const hour = String(baseHour + index).padStart(2, "0");
+    await commit(repoDir, fixture.subject, `${targetDate}T${hour}:00:00Z`);
+  }
+
+  return { gitRoot: repoDir, targetDate };
+}
+
+async function createRepoWithDirtyFile(input: {
+  path: string;
+  content: string;
+}): Promise<{ gitRoot: string; targetDate: string }> {
+  const repoDir = await initGitRepo("signals-dirty-repo");
+  const targetDate = "2026-05-05";
+
+  await writeFile(join(repoDir, "base.txt"), "base\n", "utf8");
+  await git(repoDir, ["add", "base.txt"]);
+  await commit(repoDir, "base commit", `${targetDate}T09:00:00Z`);
+
+  const filePath = join(repoDir, input.path);
+  const dirIndex = input.path.lastIndexOf("/");
+  if (dirIndex !== -1) {
+    await mkdir(join(repoDir, input.path.slice(0, dirIndex)), { recursive: true });
+  }
+  await writeFile(filePath, input.content, "utf8");
+
+  return { gitRoot: repoDir, targetDate };
+}
 
 async function initGitRepo(name: string): Promise<string> {
   const repoDir = await createTempRoot(name);

--- a/tests/git-activity-collector.test.ts
+++ b/tests/git-activity-collector.test.ts
@@ -12,6 +12,8 @@ import {
   GitActivityEventSource
 } from "../src/git-activity-collector.js";
 import { isActivitySignal } from "../src/event-source.js";
+import { buildSignalsFromInput } from "../src/activity-summary.js";
+import type { GitActivityEvent } from "../src/collect-git-command.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -260,6 +262,63 @@ describe("collectGitActivitySignals", () => {
     }).collect();
 
     expect(viaSource).toEqual(direct);
+  });
+
+  it("redacts raw code / env-var references in commit signals (already-sanitized contract)", async () => {
+    // collectGitActivity only redacts emails/paths/URLs; without the shared
+    // raw-code pass the new EventSource would ship a subject that leaks code
+    // or secret variable names to downstream AI/public consumers.
+    const { gitRoot, targetDate } = await createRepoWithCommits([
+      { subject: "wire up const token = process.env.SECRET handler" }
+    ]);
+
+    const signals = await collectGitActivitySignals({
+      projectId: "cli",
+      projectRoot: gitRoot,
+      targetDate
+    });
+
+    const commitSignal = signals.find((signal) => signal.kind === "commit");
+    expect(commitSignal).toBeDefined();
+    expect(commitSignal!.summary).not.toContain("process.env.SECRET");
+    expect(commitSignal!.summary).not.toContain("const token");
+    expect(commitSignal!.summary).toContain("[redacted-code]");
+    expect(commitSignal!.safetyNotes).toContain("raw code snippets");
+  });
+
+  it("emits signals identical to buildSignalsFromInput for the same repo state (producer equivalence)", async () => {
+    const { gitRoot, targetDate } = await createRepoWithCommits([
+      { subject: "wire up const token = process.env.SECRET" },
+      { subject: "store creds at /Users/me/keys and ping dev@example.com" }
+    ]);
+    // Leave an uncommitted file so the dirty-file branch is exercised too.
+    await writeFile(join(gitRoot, "draft-notes.md"), "wip\n", "utf8");
+
+    const fromCollector = await collectGitActivitySignals({
+      projectId: "cli",
+      projectRoot: gitRoot,
+      targetDate
+    });
+
+    const activity = await collectGitActivity({
+      projectRoot: gitRoot,
+      targetDate
+    });
+    const event: GitActivityEvent = {
+      schemaVersion: 1,
+      source: "git",
+      targetDate,
+      collectedAt: `${targetDate}T12:00:00.000Z`,
+      project: { id: "cli", name: "cli" },
+      activity
+    };
+    const fromSummary = buildSignalsFromInput({
+      targetDate,
+      gitEvents: [event],
+      manualNotes: []
+    });
+
+    expect(fromCollector).toEqual(fromSummary);
   });
 
   it("leaves the existing collectGitActivity output unchanged (regression guard)", async () => {


### PR DESCRIPTION
🤖 **Auto-generated by Uncommitted Builder (Routine B v2)**

## Parent issue

[UNC-116: EventSource 정규화 추상화 + git collector 정렬](https://linear.app/sangchu/issue/UNC-116/eventsource-정규화-추상화-git-collector-정렬)

Source Expansion 에픽([UNC-115](https://linear.app/sangchu/issue/UNC-115))의 공통 선행 기반. Claude/Codex/GitHub 어댑터가 모두 이 계약 위에 쌓인다.

## Sub-issues progress

- [x] [UNC-133](https://linear.app/sangchu/issue/UNC-133): [T1] Define normalized activity signal type and EventSource interface (✅ commit `0b03d60`)
- [x] [UNC-134](https://linear.app/sangchu/issue/UNC-134): [T2] Align git-activity-collector to EventSource contract (✅ commit `a994ff4`)
- [x] [UNC-135](https://linear.app/sangchu/issue/UNC-135): [T3] Make activity-summary consume normalized signal stream source-agnostically (✅ commit `aea4f7f`)

## Status

- Branch: `claude/UNC-116-eventsource-collector` (3 commits, base `d8a467c`)
- Tests: ✅ 434 passing + 1 skipped (vitest)
  - `tests/carousel-renderer-smoke.test.ts` failed once under parallel load (5s Playwright timeout); passes in isolation. Known pre-existing concurrency flake, unrelated to this PR.
- Build: ✅ (`pnpm build`)
- Type check: ✅
- Lint: ✅ (`pnpm lint`)

## Architecture (one paragraph)

T1 lands the strict 5-field `ActivitySignal` contract and `EventSource` interface in a new top-level module (`src/event-source.ts`), with an extensible `kind` union so future Claude/Codex/GitHub adapters can plug in without breaking the contract. T2 makes `git-activity-collector.ts` produce signals additively — adds `collectGitActivitySignals()` + `GitActivityEventSource` class, refactors private `redactSensitiveText` to surface redaction categories. `collectGitActivity` and all its existing callers (`collect-git-command.ts`, `generate-command.ts`) are observably unchanged. T3 refactors `buildActivitySummary` internals so the four source-agnostic synthesis fields (`dominantTheme`, `smallWins`, `unfinishedThreads`, `possibleJokes`) flow from an internally-built `ActivitySignal[]` stream via the new exported `deriveSynthesisFromSignals`. The 7 source-shaped output fields (`commitSignals`, `uncommittedChanges`, `manualContext`, `projects`, etc.) keep their existing per-source derivation to preserve byte-for-byte end-to-end equivalence — `tests/generate-command.test.ts` (the canary) is green.

## TDD trail

| Sub | Implementer | Spec review | Quality review |
| --- | --- | --- | --- |
| UNC-133 | DONE 1st try | ✅ compliant | ✅ ready (minor doc polish only) |
| UNC-134 | DONE 1st try | ✅ compliant | ✅ ready (minor doc polish only) |
| UNC-135 | DONE 1st try | ✅ compliant | ✅ ready (Important findings are follow-up material, none blocking) |

## Follow-up suggestions (from reviewers — non-blocking, not required for this PR)

- Consolidate the two git-event-to-signal paths (`buildSignalsFromInput` in `activity-summary.ts` vs `collectGitActivitySignals` in `git-activity-collector.ts`) once a second source adapter forces the shape — for now they're 25 lines of acceptable duplication.
- Hoist `RedactionCategory` / `REDACTION_CATEGORY_ORDER` into a shared module when T3's parallel definition with `activity-summary.ts`'s `privateItemOrder` becomes load-bearing.
- Add a `sanitizeText(sanitizeText(x).value).privateItems.length === 0` test to lock the sanitization idempotence claim (current implementation is idempotent in practice — `[redacted-X]` markers don't match the source regexes).
- Add an end-to-end fixture-comparison test (`generate today` against a golden directory) as the next durability gate for byte-for-byte equivalence.

## Notes

- No lockfile, `.env`, `AGENTS.md`, or `CLAUDE.md` modifications.
- No new dependencies.
- No auto-publish code (per uncommitted local-first policy).
- `generate-command.ts` untouched — T2 + T3 are deliberately additive, with the new generic synthesis path running inside `buildActivitySummary` without changing its public input shape.

## Review checklist

- [ ] Review each sub-issue's commit separately (UNC-133 → UNC-134 → UNC-135 are sequential)
- [ ] Verify TDD test coverage: 6 cases for the contract, 5 for the git signal path, 3 for source-agnostic synthesis
- [ ] Confirm no lockfile changes
- [ ] Run `pnpm install && pnpm test && pnpm build && pnpm lint` locally
- [ ] Confirm `generate-command.ts` / `collect-git-command.ts` are untouched — these are the back-compat boundary
- [ ] Sanity-check that the four source-agnostic synthesis fields (`dominantTheme`, `smallWins`, `unfinishedThreads`, `possibleJokes`) in the existing test fixtures still match byte-for-byte
- [ ] Confirm no auto-publish code introduced

---

이 PR은 자동 생성되었습니다. 머지 전 사람의 리뷰가 반드시 필요합니다.

Closes UNC-116
