### PR TITLE
🤖 Codex 세션 로그 어댑터 + collect codex (UNC-118)

### DIFF
--- a/src/activity-summary.ts
+++ b/src/activity-summary.ts
@@ -38,6 +38,9 @@ export type ActivitySummaryInput = {
   // Optional and source-agnostic: they feed the synthesis stream and the
   // activity score so the diary reflects Claude work, not just Git + notes.
   claudeSignals?: ActivitySignal[];
+  // Already-redacted Codex session signals (from `uncommitted collect codex`).
+  // Treated identically to Claude signals so a Codex-only day isn't quiet.
+  codexSignals?: ActivitySignal[];
 };
 
 export type ActivityProjectSummary = {
@@ -204,17 +207,21 @@ export function buildActivitySummary(
     }
   }
 
-  // Claude signals arrive already redacted and normalized; keep only the ones
-  // that belong to the target date (undated entries are treated as current).
-  const claudeSignals = (input.claudeSignals ?? []).filter(
+  // Claude and Codex session signals arrive already redacted and normalized;
+  // keep only the ones that belong to the target date (undated entries are
+  // treated as current). Both sources are handled identically.
+  const sessionSignals = [
+    ...(input.claudeSignals ?? []),
+    ...(input.codexSignals ?? [])
+  ].filter(
     (signal) =>
       signal.timestamp === "" ||
       signal.timestamp.slice(0, 10) === input.targetDate
   );
 
   // Build a normalized signal stream from the source-shaped inputs and append
-  // the Claude signals, then derive the 4 source-agnostic synthesis fields
-  // generically. Claude signals are opaque kinds, so they are pattern-classified
+  // the session signals, then derive the 4 source-agnostic synthesis fields
+  // generically. Session signals are opaque kinds, so they are pattern-classified
   // for themes / small wins / blockers / unfinished threads.
   const signals = [
     ...buildSignalsFromInput({
@@ -222,7 +229,7 @@ export function buildActivitySummary(
       gitEvents,
       manualNotes: manualNotesForDate
     }),
-    ...claudeSignals
+    ...sessionSignals
   ];
   const synthesis = deriveSynthesisFromSignals(signals);
 
@@ -245,7 +252,7 @@ export function buildActivitySummary(
     filesChanged +
     uncommittedFiles.length +
     manualNotes.length * 2 +
-    claudeSignals.length;
+    sessionSignals.length;
   const activityLevel = classifyActivityLevel(score);
   const dominantTheme = deriveDominantTheme(activityLevel, synthesis.themes);
 
@@ -264,7 +271,7 @@ export function buildActivitySummary(
     manualNoteCount: manualNotes.length,
     themeCount: synthesis.themes.length,
     uncommittedChangeCount: uncommittedFiles.length,
-    claudeSignalCount: claudeSignals.length
+    sessionSignalCount: sessionSignals.length
   });
   const publicSafetyNotes = buildPublicSafetyNotes({
     hasManualPrivateItems,
@@ -489,7 +496,7 @@ function buildUncertaintyNotes(
     manualNoteCount: number;
     themeCount: number;
     uncommittedChangeCount: number;
-    claudeSignalCount: number;
+    sessionSignalCount: number;
   }
 ): string[] {
   const notes: string[] = [];
@@ -498,7 +505,7 @@ function buildUncertaintyNotes(
     signals.gitEventCount === 0 &&
     signals.manualNoteCount === 0 &&
     signals.uncommittedChangeCount === 0 &&
-    signals.claudeSignalCount === 0
+    signals.sessionSignalCount === 0
   ) {
     notes.push(`No Git activity or manual notes were found for ${input.targetDate}.`);
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,10 @@ import {
   collectClaudeForRegisteredProjects,
   CollectClaudeCommandError
 } from "./collect-claude-command.js";
+import {
+  collectCodexForRegisteredProjects,
+  CollectCodexCommandError
+} from "./collect-codex-command.js";
 import { AiGenerationError, type AiProvider } from "./ai-provider.js";
 import { commands, isKnownCommand } from "./commands.js";
 import { formatDoctorReport, runDoctorCommand } from "./doctor-command.js";
@@ -77,6 +81,7 @@ export type CliOptions = {
   cwd?: string;
   homeDir?: string;
   claudeHome?: string;
+  codexHome?: string;
   draftRoot?: string;
   now?: () => string;
   aiProvider?: AiProvider;
@@ -752,8 +757,8 @@ async function runCollect(
   io: CliIo,
   options: CliOptions
 ): Promise<number> {
-  if (args.length !== 1 || (args[0] !== "git" && args[0] !== "claude")) {
-    io.stderr("Usage: uncommitted collect <git|claude>");
+  if (args.length < 1 || (args[0] !== "git" && args[0] !== "claude" && args[0] !== "codex")) {
+    io.stderr("Usage: uncommitted collect <git|claude|codex>");
     return 1;
   }
 
@@ -786,18 +791,65 @@ async function runCollect(
     }
   }
 
-  // args[0] === "claude"
-  try {
-    const result = await collectClaudeForRegisteredProjects(options);
+  if (args[0] === "claude") {
+    try {
+      const result = await collectClaudeForRegisteredProjects(options);
 
-    if (result.claudeLogsMissing) {
-      io.stdout("No Claude session logs found at ~/.claude/projects. Skipping.");
+      if (result.claudeLogsMissing) {
+        io.stdout("No Claude session logs found at ~/.claude/projects. Skipping.");
+        return 0;
+      }
+
+      if (result.successes.length > 0) {
+        io.stdout(
+          `Collected Claude activity for ${formatProjectCount(result.successes.length)}.`
+        );
+        for (const success of result.successes) {
+          io.stdout(
+            `${success.projectId}: ${success.signalCount} signals, ${success.conversationCount} turns, ${success.toolFactCount} tool facts.`
+          );
+        }
+      }
+
+      for (const failure of result.failures) {
+        io.stderr(`Failed to collect ${failure.projectId}: ${failure.message}`);
+      }
+
+      return result.failures.length > 0 ? 3 : 0;
+    } catch (error) {
+      if (error instanceof CollectClaudeCommandError) {
+        io.stderr(error.message);
+        return error.code === "invalid-projects-file" ? 2 : 3;
+      }
+      throw error;
+    }
+  }
+
+  // args[0] === "codex"
+  const codexArgs = args.slice(1);
+  let targetDate: string | undefined;
+  for (let i = 0; i < codexArgs.length; i++) {
+    if (codexArgs[i] === "--date" && i + 1 < codexArgs.length) {
+      targetDate = codexArgs[++i];
+    }
+  }
+
+  try {
+    const result = await collectCodexForRegisteredProjects({
+      homeDir: options.homeDir,
+      codexHome: options.codexHome,
+      now: options.now ?? (() => new Date().toISOString()),
+      targetDate
+    });
+
+    if (result.codexLogsMissing) {
+      io.stdout("No Codex session logs found at ~/.codex/sessions. Skipping.");
       return 0;
     }
 
     if (result.successes.length > 0) {
       io.stdout(
-        `Collected Claude activity for ${formatProjectCount(result.successes.length)}.`
+        `Collected Codex activity for ${formatProjectCount(result.successes.length)}.`
       );
       for (const success of result.successes) {
         io.stdout(
@@ -812,9 +864,9 @@ async function runCollect(
 
     return result.failures.length > 0 ? 3 : 0;
   } catch (error) {
-    if (error instanceof CollectClaudeCommandError) {
+    if (error instanceof CollectCodexCommandError) {
       io.stderr(error.message);
-      return error.code === "invalid-projects-file" ? 2 : 3;
+      return error.code === "invalid-projects-file" || error.code === "invalid-date" ? 2 : 3;
     }
     throw error;
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -762,6 +762,13 @@ async function runCollect(
     return 1;
   }
 
+  // git and claude take no further arguments; reject trailing tokens so an
+  // unsupported flag can't silently collect/overwrite today's events.
+  if ((args[0] === "git" || args[0] === "claude") && args.length > 1) {
+    io.stderr(`Usage: uncommitted collect ${args[0]}`);
+    return 1;
+  }
+
   if (args[0] === "git") {
     try {
       const result = await collectGitForRegisteredProjects(options);
@@ -829,9 +836,19 @@ async function runCollect(
   const codexArgs = args.slice(1);
   let targetDate: string | undefined;
   for (let i = 0; i < codexArgs.length; i++) {
-    if (codexArgs[i] === "--date" && i + 1 < codexArgs.length) {
+    if (codexArgs[i] === "--date") {
+      // --date must be followed by a value; otherwise the collector would fall
+      // back to today and overwrite today's events on a typo.
+      if (i + 1 >= codexArgs.length) {
+        io.stderr("Usage: uncommitted collect codex [--date YYYY-MM-DD]");
+        return 1;
+      }
       targetDate = codexArgs[++i];
+      continue;
     }
+    // Reject unknown/extra tokens rather than silently ignoring them.
+    io.stderr("Usage: uncommitted collect codex [--date YYYY-MM-DD]");
+    return 1;
   }
 
   try {

--- a/src/codex-session-attribution.ts
+++ b/src/codex-session-attribution.ts
@@ -1,0 +1,29 @@
+// src/codex-session-attribution.ts
+import { readFile } from "node:fs/promises";
+
+export async function readCodexSessionCwd(path: string): Promise<string | null> {
+  const contents = await readFile(path, "utf8");
+  for (const line of contents.split("\n")) {
+    if (line.trim() === "") continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (typeof parsed !== "object" || parsed === null) continue;
+    const top = parsed as Record<string, unknown>;
+    if (top.type !== "session_meta" && top.type !== "turn_context") continue;
+    const payload = top.payload;
+    if (typeof payload !== "object" || payload === null) continue;
+    const cwd = (payload as Record<string, unknown>).cwd;
+    if (typeof cwd === "string") return cwd;
+  }
+  return null;
+}
+
+// Re-export the shared attribution function so the Codex command does not
+// need to import from a Claude-named module. Implementation lives in
+// claude-session-attribution.ts and is source-agnostic.
+export { attributeCwdToProject } from "./claude-session-attribution.js";
+export type { ClaudeSessionAttribution as CodexSessionAttribution } from "./claude-session-attribution.js";

--- a/src/codex-session-discovery.ts
+++ b/src/codex-session-discovery.ts
@@ -1,0 +1,98 @@
+import { readdir, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export type CodexSessionLogFile = {
+  year: string;
+  month: string;
+  day: string;
+  sessionId: string;
+  path: string;
+};
+
+export type DiscoverCodexSessionLogsOptions = {
+  codexHome?: string;
+  targetDate?: string; // "YYYY-MM-DD"; when set, only that day is walked
+};
+
+export async function discoverCodexSessionLogs(
+  options: DiscoverCodexSessionLogsOptions = {}
+): Promise<CodexSessionLogFile[]> {
+  const codexHome = options.codexHome ?? join(homedir(), ".codex");
+  const sessionsDir = join(codexHome, "sessions");
+
+  const results: CodexSessionLogFile[] = [];
+
+  const years = options.targetDate
+    ? [options.targetDate.slice(0, 4)]
+    : await readDirSafe(sessionsDir);
+  for (const year of years) {
+    const yearDir = join(sessionsDir, year);
+    if (!(await isDirectory(yearDir))) continue;
+
+    const months = options.targetDate
+      ? [options.targetDate.slice(5, 7)]
+      : await readDirSafe(yearDir);
+    for (const month of months) {
+      const monthDir = join(yearDir, month);
+      if (!(await isDirectory(monthDir))) continue;
+
+      const days = options.targetDate
+        ? [options.targetDate.slice(8, 10)]
+        : await readDirSafe(monthDir);
+      for (const day of days) {
+        const dayDir = join(monthDir, day);
+        if (!(await isDirectory(dayDir))) continue;
+
+        const entries = await readDirSafe(dayDir);
+        for (const entry of entries) {
+          if (!entry.startsWith("rollout-") || !entry.endsWith(".jsonl")) continue;
+          const entryPath = join(dayDir, entry);
+          const info = await statSafe(entryPath);
+          if (!info || !info.isFile()) continue;
+          results.push({
+            year,
+            month,
+            day,
+            sessionId: entry.slice(0, -".jsonl".length),
+            path: entryPath
+          });
+        }
+      }
+    }
+  }
+
+  results.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+  return results;
+}
+
+async function readDirSafe(dir: string): Promise<string[]> {
+  try {
+    return await readdir(dir);
+  } catch (error) {
+    if (isMissing(error)) return [];
+    throw error;
+  }
+}
+
+async function statSafe(path: string) {
+  try {
+    return await stat(path);
+  } catch (error) {
+    if (isMissing(error)) return null;
+    throw error;
+  }
+}
+
+async function isDirectory(path: string): Promise<boolean> {
+  const info = await statSafe(path);
+  return info?.isDirectory() ?? false;
+}
+
+function isMissing(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    (error as NodeJS.ErrnoException).code === "ENOENT"
+  );
+}

--- a/src/codex-session-parser.ts
+++ b/src/codex-session-parser.ts
@@ -1,0 +1,247 @@
+// src/codex-session-parser.ts
+import type { ActivitySignal } from "./event-source.js";
+
+export type ConversationTurn = {
+  role: "user" | "assistant";
+  text: string;
+  timestamp: string;
+};
+
+export type ToolFact = {
+  tool: string;
+  target?: string;
+  timestamp: string;
+};
+
+export type CodexSessionParseResult = {
+  signals: ActivitySignal[];
+  conversation: ConversationTurn[];
+  toolFacts: ToolFact[];
+};
+
+export type CodexSessionParseInput = {
+  projectId: string;
+  contents: string;
+};
+
+const SUMMARY_LIMIT = 200;
+const COMMAND_LIMIT = 200;
+
+export function parseCodexSession(
+  input: CodexSessionParseInput
+): CodexSessionParseResult {
+  const signals: ActivitySignal[] = [];
+  const conversation: ConversationTurn[] = [];
+  const toolFacts: ToolFact[] = [];
+
+  for (const raw of input.contents.split("\n")) {
+    if (raw.trim() === "") continue;
+    let entry: unknown;
+    try {
+      entry = JSON.parse(raw);
+    } catch {
+      continue;
+    }
+    if (!isRecord(entry)) continue;
+
+    const timestamp = typeof entry.timestamp === "string" ? entry.timestamp : "";
+    const topType = entry.type;
+
+    if (topType === "response_item") {
+      handleResponseItem(input.projectId, entry, timestamp, {
+        signals,
+        conversation,
+        toolFacts
+      });
+      continue;
+    }
+
+    if (topType === "event_msg") {
+      handleEventMsg(input.projectId, entry, timestamp, {
+        signals,
+        conversation,
+        toolFacts
+      });
+      continue;
+    }
+    // session_meta, turn_context, token_count, and unknown types: skip.
+  }
+
+  return { signals, conversation, toolFacts };
+}
+
+type Sink = {
+  signals: ActivitySignal[];
+  conversation: ConversationTurn[];
+  toolFacts: ToolFact[];
+};
+
+function handleResponseItem(
+  projectId: string,
+  entry: Record<string, unknown>,
+  timestamp: string,
+  sink: Sink
+): void {
+  const payload = entry.payload;
+  if (!isRecord(payload)) return;
+  const ptype = payload.type;
+
+  if (ptype === "message") {
+    const role = payload.role;
+    if (role !== "user" && role !== "assistant") return;
+    const blocks = Array.isArray(payload.content) ? payload.content : [];
+    for (const block of blocks) {
+      if (!isRecord(block)) continue;
+      const bType = block.type;
+      const bText = typeof block.text === "string" ? block.text : null;
+      if (bText === null) continue;
+      if (
+        bType !== "input_text" &&
+        bType !== "output_text" &&
+        bType !== "text"
+      ) {
+        continue;
+      }
+      sink.conversation.push({ role, text: bText, timestamp });
+      sink.signals.push(
+        makeSignal(
+          projectId,
+          timestamp,
+          role === "user" ? "codex-user-turn" : "codex-assistant-text",
+          bText
+        )
+      );
+    }
+    return;
+  }
+
+  if (ptype === "reasoning") {
+    const text = extractReasoningText(payload);
+    if (!text) return;
+    sink.conversation.push({ role: "assistant", text, timestamp });
+    return;
+  }
+
+  if (ptype === "function_call" || ptype === "custom_tool_call") {
+    const tool =
+      typeof payload.name === "string" ? payload.name : String(ptype);
+    const target = extractFunctionTarget(payload);
+    sink.toolFacts.push({ tool, target, timestamp });
+    const summary = (target ? `${tool} ${target}` : tool).trim();
+    sink.signals.push(makeSignal(projectId, timestamp, "codex-tool", summary));
+    return;
+  }
+  // function_call_output, custom_tool_call_output: discard body.
+}
+
+function handleEventMsg(
+  projectId: string,
+  entry: Record<string, unknown>,
+  timestamp: string,
+  sink: Sink
+): void {
+  const payload = entry.payload;
+  if (!isRecord(payload)) return;
+  const ptype = payload.type;
+
+  if (ptype === "user_message" || ptype === "agent_message") {
+    const text = typeof payload.message === "string" ? payload.message : "";
+    if (!text) return;
+    const role: "user" | "assistant" =
+      ptype === "user_message" ? "user" : "assistant";
+    sink.conversation.push({ role, text, timestamp });
+    sink.signals.push(
+      makeSignal(
+        projectId,
+        timestamp,
+        role === "user" ? "codex-user-turn" : "codex-assistant-text",
+        text
+      )
+    );
+    return;
+  }
+
+  if (
+    ptype === "exec_command_end" ||
+    ptype === "exec_command_begin" ||
+    ptype === "patch_apply_end" ||
+    ptype === "patch_apply_begin"
+  ) {
+    const target = extractEventTarget(payload);
+    sink.toolFacts.push({ tool: String(ptype), target, timestamp });
+    const summary = (target ? `${ptype} ${target}` : String(ptype)).trim();
+    sink.signals.push(makeSignal(projectId, timestamp, "codex-tool", summary));
+    return;
+  }
+}
+
+function makeSignal(
+  projectId: string,
+  timestamp: string,
+  kind: string,
+  text: string
+): ActivitySignal {
+  return {
+    projectId,
+    timestamp,
+    kind,
+    summary: text.length > SUMMARY_LIMIT ? text.slice(0, SUMMARY_LIMIT) : text,
+    safetyNotes: []
+  };
+}
+
+function extractReasoningText(payload: Record<string, unknown>): string {
+  if (typeof payload.text === "string") return payload.text;
+  if (Array.isArray(payload.summary)) {
+    const parts: string[] = [];
+    for (const block of payload.summary) {
+      if (isRecord(block) && typeof block.text === "string") {
+        parts.push(block.text);
+      }
+    }
+    return parts.join("\n");
+  }
+  return "";
+}
+
+function extractFunctionTarget(payload: Record<string, unknown>): string | undefined {
+  const args = payload.arguments;
+  if (typeof args !== "string") return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(args);
+  } catch {
+    return truncate(args, COMMAND_LIMIT);
+  }
+  if (!isRecord(parsed)) return undefined;
+  if (typeof parsed.file_path === "string") return parsed.file_path;
+  if (typeof parsed.path === "string") return parsed.path;
+  if (typeof parsed.command === "string") return truncate(parsed.command, COMMAND_LIMIT);
+  if (Array.isArray(parsed.command)) {
+    const joined = parsed.command.filter((x) => typeof x === "string").join(" ");
+    return truncate(joined, COMMAND_LIMIT);
+  }
+  if (typeof parsed.url === "string") return parsed.url;
+  return undefined;
+}
+
+function extractEventTarget(payload: Record<string, unknown>): string | undefined {
+  if (Array.isArray(payload.command)) {
+    const joined = payload.command.filter((x) => typeof x === "string").join(" ");
+    if (joined) return truncate(joined, COMMAND_LIMIT);
+  }
+  if (typeof payload.command === "string") {
+    return truncate(payload.command, COMMAND_LIMIT);
+  }
+  if (typeof payload.path === "string") return payload.path;
+  if (typeof payload.cwd === "string") return payload.cwd;
+  return undefined;
+}
+
+function truncate(s: string, limit: number): string {
+  return s.length > limit ? s.slice(0, limit) : s;
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null;
+}

--- a/src/codex-session-parser.ts
+++ b/src/codex-session-parser.ts
@@ -150,14 +150,15 @@ function handleEventMsg(
     const role: "user" | "assistant" =
       ptype === "user_message" ? "user" : "assistant";
     sink.conversation.push({ role, text, timestamp });
-    sink.signals.push(
-      makeSignal(
-        projectId,
-        timestamp,
-        role === "user" ? "codex-user-turn" : "codex-assistant-text",
-        text
-      )
-    );
+    // agent_message is a UI echo of the assistant turn already captured via
+    // response_item/message (and may carry reasoning). Keep it in the raw
+    // archive but don't emit a Tier 2 signal, mirroring reasoning handling, so
+    // it isn't double-counted or surfaced into activity summaries.
+    if (role === "user") {
+      sink.signals.push(
+        makeSignal(projectId, timestamp, "codex-user-turn", text)
+      );
+    }
     return;
   }
 
@@ -216,6 +217,13 @@ function extractFunctionTarget(payload: Record<string, unknown>): string | undef
   if (!isRecord(parsed)) return undefined;
   if (typeof parsed.file_path === "string") return parsed.file_path;
   if (typeof parsed.path === "string") return parsed.path;
+  // Codex exec_command calls encode the shell text in `cmd`; read it before
+  // falling back to `command` so shell invocations keep their target.
+  if (typeof parsed.cmd === "string") return truncate(parsed.cmd, COMMAND_LIMIT);
+  if (Array.isArray(parsed.cmd)) {
+    const joined = parsed.cmd.filter((x) => typeof x === "string").join(" ");
+    if (joined) return truncate(joined, COMMAND_LIMIT);
+  }
   if (typeof parsed.command === "string") return truncate(parsed.command, COMMAND_LIMIT);
   if (Array.isArray(parsed.command)) {
     const joined = parsed.command.filter((x) => typeof x === "string").join(" ");

--- a/src/codex-session-redactor.ts
+++ b/src/codex-session-redactor.ts
@@ -1,0 +1,95 @@
+import type {
+  CodexSessionParseResult,
+  ConversationTurn,
+  ToolFact
+} from "./codex-session-parser.js";
+import type { ActivitySignal } from "./event-source.js";
+import {
+  REDACTION_CATEGORY_ORDER,
+  sanitizeText,
+  type RedactionCategory
+} from "./redaction.js";
+import {
+  detectSecrets,
+  SECRET_CATEGORY_ORDER,
+  type SecretCategory
+} from "./credential-detector.js";
+
+export type CodexRedactionCategory = RedactionCategory | SecretCategory;
+
+export type RedactedCodexSession = {
+  signals: ActivitySignal[];
+  conversation: ConversationTurn[];
+  toolFacts: ToolFact[];
+  appliedCategories: CodexRedactionCategory[];
+};
+
+const COMBINED_ORDER: CodexRedactionCategory[] = [
+  ...SECRET_CATEGORY_ORDER,
+  ...REDACTION_CATEGORY_ORDER
+];
+
+function sortCategories(
+  set: Set<CodexRedactionCategory>
+): CodexRedactionCategory[] {
+  return COMBINED_ORDER.filter((c) => set.has(c));
+}
+
+// Mirror the Claude adapter: catch SSH-style git URLs before the email
+// regex eats them.
+const SSH_GIT_URL = /\b[\w.-]{1,64}@[\w.-]{1,253}:[^\s]{1,4096}/g;
+
+function redactString(value: string): {
+  value: string;
+  categories: CodexRedactionCategory[];
+} {
+  const secretPass = detectSecrets(value);
+
+  let preUrl = secretPass.value;
+  const preUrlCategories = new Set<CodexRedactionCategory>();
+  if (SSH_GIT_URL.test(preUrl)) {
+    preUrlCategories.add("private URLs");
+    SSH_GIT_URL.lastIndex = 0;
+    preUrl = preUrl.replace(SSH_GIT_URL, "[redacted-url]");
+  }
+
+  const textPass = sanitizeText(preUrl);
+  const set = new Set<CodexRedactionCategory>([
+    ...secretPass.categories,
+    ...preUrlCategories,
+    ...textPass.categories
+  ]);
+  return { value: textPass.value, categories: sortCategories(set) };
+}
+
+export function redactCodexSession(
+  parsed: CodexSessionParseResult
+): RedactedCodexSession {
+  const aggregate = new Set<CodexRedactionCategory>();
+
+  const conversation = parsed.conversation.map((turn) => {
+    const r = redactString(turn.text);
+    r.categories.forEach((c) => aggregate.add(c));
+    return { ...turn, text: r.value };
+  });
+
+  const signals = parsed.signals.map((sig) => {
+    const r = redactString(sig.summary);
+    r.categories.forEach((c) => aggregate.add(c));
+    return { ...sig, summary: r.value, safetyNotes: r.categories };
+  });
+
+  const toolFacts = parsed.toolFacts.map((fact) => {
+    if (fact.target === undefined) return { ...fact };
+    const r = redactString(fact.target);
+    r.categories.forEach((c) => aggregate.add(c));
+    return { ...fact, target: r.value };
+  });
+
+  return {
+    signals,
+    conversation,
+    toolFacts,
+    appliedCategories: sortCategories(aggregate)
+  };
+}

--- a/src/codex-session-writer.ts
+++ b/src/codex-session-writer.ts
@@ -1,0 +1,77 @@
+// src/codex-session-writer.ts
+import { chmod, mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { ActivitySignal } from "./event-source.js";
+import type { ConversationTurn, ToolFact } from "./codex-session-parser.js";
+
+export type CodexSessionWriteInput = {
+  projectRoot: string;
+  targetDate: string;
+  signals: ActivitySignal[];
+  conversation: ConversationTurn[];
+  toolFacts: ToolFact[];
+};
+
+export type CodexSessionWriteResult = {
+  signalsFile: string;
+  rawArchiveFile: string;
+  signalCount: number;
+  conversationCount: number;
+  toolFactCount: number;
+};
+
+export async function writeCodexSessionOutputs(
+  input: CodexSessionWriteInput
+): Promise<CodexSessionWriteResult> {
+  const baseDir = join(input.projectRoot, ".uncommitted", "events", "codex");
+  const rawDir = join(baseDir, "raw");
+  await mkdir(rawDir, { recursive: true });
+
+  const signalsFile = join(baseDir, `${input.targetDate}.jsonl`);
+  const rawArchiveFile = join(rawDir, `${input.targetDate}.jsonl`);
+
+  const signalsBody = input.signals.length
+    ? input.signals.map((s) => JSON.stringify(s)).join("\n") + "\n"
+    : "";
+
+  const rawEntries: { timestamp: string; line: string }[] = [];
+  for (const turn of input.conversation) {
+    rawEntries.push({
+      timestamp: turn.timestamp,
+      line: JSON.stringify({
+        kind: "turn",
+        role: turn.role,
+        text: turn.text,
+        timestamp: turn.timestamp
+      })
+    });
+  }
+  for (const fact of input.toolFacts) {
+    const payload: Record<string, unknown> = {
+      kind: "tool",
+      tool: fact.tool,
+      timestamp: fact.timestamp
+    };
+    if (fact.target !== undefined) payload.target = fact.target;
+    rawEntries.push({ timestamp: fact.timestamp, line: JSON.stringify(payload) });
+  }
+  rawEntries.sort((a, b) =>
+    a.timestamp < b.timestamp ? -1 : a.timestamp > b.timestamp ? 1 : 0
+  );
+  const rawBody = rawEntries.length
+    ? rawEntries.map((entry) => entry.line).join("\n") + "\n"
+    : "";
+
+  await writeFile(signalsFile, signalsBody, "utf8");
+  await writeFile(rawArchiveFile, rawBody, { encoding: "utf8", mode: 0o600 });
+  // chmod ensures the 0600 invariant survives even on rewrites of an existing file.
+  await chmod(rawArchiveFile, 0o600);
+
+  return {
+    signalsFile,
+    rawArchiveFile,
+    signalCount: input.signals.length,
+    conversationCount: input.conversation.length,
+    toolFactCount: input.toolFacts.length
+  };
+}

--- a/src/collect-codex-command.ts
+++ b/src/collect-codex-command.ts
@@ -99,9 +99,25 @@ export async function collectCodexForRegisteredProjects(
     targetDate = now.slice(0, 10);
   }
 
-  const logs = await discoverCodexSessionLogs({
-    codexHome: options.codexHome,
-    targetDate
+  // A Codex session that starts before midnight stays under its start day's
+  // `sessions/YYYY/MM/DD` directory even when work continues into the next day.
+  // Discover both the target day and the previous day so cross-midnight entries
+  // (kept by the per-entry timestamp filter below) aren't dropped.
+  const discovered = [
+    ...(await discoverCodexSessionLogs({
+      codexHome: options.codexHome,
+      targetDate
+    })),
+    ...(await discoverCodexSessionLogs({
+      codexHome: options.codexHome,
+      targetDate: previousDate(targetDate)
+    }))
+  ];
+  const seenPaths = new Set<string>();
+  const logs = discovered.filter((log) => {
+    if (seenPaths.has(log.path)) return false;
+    seenPaths.add(log.path);
+    return true;
   });
   if (logs.length === 0) {
     return {
@@ -191,6 +207,12 @@ export async function collectCodexForRegisteredProjects(
   }
 
   return { targetDate, successes, failures, codexLogsMissing: false };
+}
+
+function previousDate(targetDate: string): string {
+  const d = new Date(`${targetDate}T00:00:00.000Z`);
+  d.setUTCDate(d.getUTCDate() - 1);
+  return d.toISOString().slice(0, 10);
 }
 
 function isOnTargetDate(timestamp: string, targetDate: string): boolean {

--- a/src/collect-codex-command.ts
+++ b/src/collect-codex-command.ts
@@ -1,0 +1,200 @@
+import { readFile } from "node:fs/promises";
+import { resolveConfigPaths } from "./config-paths.js";
+import { readProjectsFile } from "./project-registry.js";
+import type { ProjectRecord } from "./project-registry.js";
+import {
+  discoverCodexSessionLogs,
+  type CodexSessionLogFile
+} from "./codex-session-discovery.js";
+import {
+  attributeCwdToProject,
+  readCodexSessionCwd
+} from "./codex-session-attribution.js";
+import {
+  parseCodexSession,
+  type CodexSessionParseResult
+} from "./codex-session-parser.js";
+import { redactCodexSession } from "./codex-session-redactor.js";
+import { writeCodexSessionOutputs } from "./codex-session-writer.js";
+
+export type CollectCodexCommandOptions = {
+  homeDir?: string;
+  codexHome?: string;
+  now?: () => string;
+  targetDate?: string;
+};
+
+export type CollectCodexSuccess = {
+  projectId: string;
+  signalsFile: string;
+  rawArchiveFile: string;
+  signalCount: number;
+  conversationCount: number;
+  toolFactCount: number;
+};
+
+export type CollectCodexFailure = {
+  projectId: string;
+  message: string;
+};
+
+export type CollectCodexCommandResult = {
+  targetDate: string;
+  successes: CollectCodexSuccess[];
+  failures: CollectCodexFailure[];
+  codexLogsMissing: boolean;
+};
+
+export type CollectCodexCommandErrorCode =
+  | "invalid-projects-file"
+  | "no-projects"
+  | "invalid-date";
+
+export class CollectCodexCommandError extends Error {
+  constructor(
+    message: string,
+    public readonly code: CollectCodexCommandErrorCode
+  ) {
+    super(message);
+    this.name = "CollectCodexCommandError";
+  }
+}
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export async function collectCodexForRegisteredProjects(
+  options: CollectCodexCommandOptions = {}
+): Promise<CollectCodexCommandResult> {
+  const paths = resolveConfigPaths({ homeDir: options.homeDir });
+  let projectsFile;
+  try {
+    projectsFile = await readProjectsFile(paths.projectsFile, {
+      missingAsEmpty: true
+    });
+  } catch {
+    throw new CollectCodexCommandError(
+      "Invalid projects file.",
+      "invalid-projects-file"
+    );
+  }
+  const projects = projectsFile.projects.filter((p) => p.enabled);
+  if (projects.length === 0) {
+    throw new CollectCodexCommandError(
+      "No registered projects. Run `uncommitted project add .` first.",
+      "no-projects"
+    );
+  }
+
+  let targetDate: string;
+  if (options.targetDate) {
+    if (!DATE_RE.test(options.targetDate)) {
+      throw new CollectCodexCommandError(
+        "Invalid --date; expected YYYY-MM-DD.",
+        "invalid-date"
+      );
+    }
+    targetDate = options.targetDate;
+  } else {
+    const now = options.now ? options.now() : new Date().toISOString();
+    targetDate = now.slice(0, 10);
+  }
+
+  const logs = await discoverCodexSessionLogs({
+    codexHome: options.codexHome,
+    targetDate
+  });
+  if (logs.length === 0) {
+    return {
+      targetDate,
+      successes: [],
+      failures: [],
+      codexLogsMissing: true
+    };
+  }
+
+  const logsByProject = new Map<
+    string,
+    { project: ProjectRecord; logs: CodexSessionLogFile[] }
+  >();
+  for (const project of projects) {
+    logsByProject.set(project.id, { project, logs: [] });
+  }
+
+  for (const log of logs) {
+    let projectId: string | null = null;
+    try {
+      const cwd = await readCodexSessionCwd(log.path);
+      if (cwd) {
+        const attr = attributeCwdToProject(cwd, projects);
+        if (attr) projectId = attr.projectId;
+      }
+    } catch {
+      continue;
+    }
+    if (projectId) logsByProject.get(projectId)?.logs.push(log);
+  }
+
+  const successes: CollectCodexSuccess[] = [];
+  const failures: CollectCodexFailure[] = [];
+
+  for (const { project, logs: projectLogs } of logsByProject.values()) {
+    try {
+      const aggregate: CodexSessionParseResult = {
+        signals: [],
+        conversation: [],
+        toolFacts: []
+      };
+      for (const log of projectLogs) {
+        const contents = await readFile(log.path, "utf8");
+        const parsed = parseCodexSession({
+          projectId: project.id,
+          contents
+        });
+        // A single session can span midnight; only keep entries on the target
+        // date so yesterday's Codex work doesn't leak into today's diary.
+        aggregate.signals.push(
+          ...parsed.signals.filter((s) => isOnTargetDate(s.timestamp, targetDate))
+        );
+        aggregate.conversation.push(
+          ...parsed.conversation.filter((c) =>
+            isOnTargetDate(c.timestamp, targetDate)
+          )
+        );
+        aggregate.toolFacts.push(
+          ...parsed.toolFacts.filter((t) =>
+            isOnTargetDate(t.timestamp, targetDate)
+          )
+        );
+      }
+      const redacted = redactCodexSession(aggregate);
+      const written = await writeCodexSessionOutputs({
+        projectRoot: project.root,
+        targetDate,
+        signals: redacted.signals,
+        conversation: redacted.conversation,
+        toolFacts: redacted.toolFacts
+      });
+      successes.push({
+        projectId: project.id,
+        signalsFile: written.signalsFile,
+        rawArchiveFile: written.rawArchiveFile,
+        signalCount: written.signalCount,
+        conversationCount: written.conversationCount,
+        toolFactCount: written.toolFactCount
+      });
+    } catch (error) {
+      failures.push({
+        projectId: project.id,
+        message: error instanceof Error ? error.message : "Collection failed."
+      });
+    }
+  }
+
+  return { targetDate, successes, failures, codexLogsMissing: false };
+}
+
+function isOnTargetDate(timestamp: string, targetDate: string): boolean {
+  // Undated entries can't be proven to belong to another day, so keep them
+  // with the current collection; dated entries must match the target date.
+  return timestamp === "" || timestamp.slice(0, 10) === targetDate;
+}

--- a/src/generate-command.ts
+++ b/src/generate-command.ts
@@ -198,12 +198,14 @@ export async function runGenerateCommand(
   const gitEvents = await readGitActivityEvents(projects, targetDate);
   const manualNotes = await readManualNoteEvents(projects, targetDate);
   const claudeSignals = await readClaudeActivitySignals(projects, targetDate);
+  const codexSignals = await readCodexActivitySignals(projects, targetDate);
   const activitySummary = buildActivitySummary({
     targetDate,
     generatedAt,
     gitEvents,
     manualNotes,
-    claudeSignals
+    claudeSignals,
+    codexSignals
   });
   const draftRevision = await runDraftStorageOperation(() =>
     createDraftRevision({
@@ -679,15 +681,30 @@ async function readManualNoteEvents(
   return notes;
 }
 
-async function readClaudeActivitySignals(
+function readClaudeActivitySignals(
   projects: ProjectRecord[],
   targetDate: string
+): Promise<ActivitySignal[]> {
+  return readSessionActivitySignals(projects, targetDate, "claude");
+}
+
+function readCodexActivitySignals(
+  projects: ProjectRecord[],
+  targetDate: string
+): Promise<ActivitySignal[]> {
+  return readSessionActivitySignals(projects, targetDate, "codex");
+}
+
+async function readSessionActivitySignals(
+  projects: ProjectRecord[],
+  targetDate: string,
+  source: "claude" | "codex"
 ): Promise<ActivitySignal[]> {
   const signals: ActivitySignal[] = [];
 
   for (const project of projects) {
     const content = await readOptionalText(
-      join(project.root, ".uncommitted", "events", "claude", `${targetDate}.jsonl`)
+      join(project.root, ".uncommitted", "events", source, `${targetDate}.jsonl`)
     );
 
     if (content === undefined) {
@@ -699,9 +716,9 @@ async function readClaudeActivitySignals(
         continue;
       }
 
-      // Claude signals are a supplementary, already-redacted input. Skip any
+      // Session signals are a supplementary, already-redacted input. Skip any
       // malformed line rather than failing the whole diary — a single bad
-      // Claude record should never block generation from Git + notes.
+      // session record should never block generation from Git + notes.
       let parsed: unknown;
       try {
         parsed = JSON.parse(line);

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -65,7 +65,7 @@ describe("cli", () => {
 
     expect(exitCode).toBe(1);
     expect(stdout).toEqual([]);
-    expect(stderr.join("\n")).toContain("Usage: uncommitted collect <git|claude>");
+    expect(stderr.join("\n")).toContain("Usage: uncommitted collect <git|claude|codex>");
   });
 
   it("reports skip and exits 0 when collect claude finds no session logs", async () => {
@@ -108,6 +108,48 @@ describe("cli", () => {
     expect(exitCode).toBe(0);
     expect(stderr).toEqual([]);
     expect(stdout.join("\n")).toContain("No Claude session logs found");
+  });
+
+  it("reports skip and exits 0 when collect codex finds no session logs", async () => {
+    const { io, stdout, stderr } = createIo();
+    const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-collect-codex-"));
+    const repoDir = join(directory, "repo");
+    const homeDir = join(directory, "home");
+
+    await mkdir(repoDir, { recursive: true });
+    await mkdir(join(homeDir, ".uncommitted"), { recursive: true });
+    await writeFile(
+      join(homeDir, ".uncommitted", "projects.json"),
+      JSON.stringify(
+        {
+          schemaVersion: 1,
+          projects: [
+            {
+              schemaVersion: 1,
+              id: "p1",
+              name: "demo",
+              root: repoDir,
+              gitRoot: repoDir,
+              enabled: true,
+              createdAt: "2026-05-01T00:00:00.000Z"
+            }
+          ]
+        },
+        null,
+        2
+      ) + "\n",
+      "utf8"
+    );
+
+    const exitCode = await runCli(["collect", "codex"], io, {
+      homeDir,
+      codexHome: join(directory, "codex-home"),
+      now: () => "2026-05-06T13:30:00.000Z"
+    });
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toEqual([]);
+    expect(stdout.join("\n")).toContain("No Codex session logs found");
   });
 
   it("collects today's Git activity for registered projects", async () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -68,6 +68,46 @@ describe("cli", () => {
     expect(stderr.join("\n")).toContain("Usage: uncommitted collect <git|claude|codex>");
   });
 
+  it("rejects extra arguments for collect git instead of silently ignoring them", async () => {
+    const { io, stdout, stderr } = createIo();
+
+    const exitCode = await runCli(["collect", "git", "--date", "2026-06-14"], io);
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toEqual([]);
+    expect(stderr.join("\n")).toContain("Usage: uncommitted collect git");
+  });
+
+  it("rejects extra arguments for collect claude instead of silently ignoring them", async () => {
+    const { io, stdout, stderr } = createIo();
+
+    const exitCode = await runCli(["collect", "claude", "typo"], io);
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toEqual([]);
+    expect(stderr.join("\n")).toContain("Usage: uncommitted collect claude");
+  });
+
+  it("rejects collect codex --date without a value", async () => {
+    const { io, stdout, stderr } = createIo();
+
+    const exitCode = await runCli(["collect", "codex", "--date"], io);
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toEqual([]);
+    expect(stderr.join("\n")).toContain("Usage: uncommitted collect codex");
+  });
+
+  it("rejects unknown collect codex flags", async () => {
+    const { io, stdout, stderr } = createIo();
+
+    const exitCode = await runCli(["collect", "codex", "--bogus"], io);
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toEqual([]);
+    expect(stderr.join("\n")).toContain("Usage: uncommitted collect codex");
+  });
+
   it("reports skip and exits 0 when collect claude finds no session logs", async () => {
     const { io, stdout, stderr } = createIo();
     const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-collect-claude-"));

--- a/tests/codex-session-attribution.test.ts
+++ b/tests/codex-session-attribution.test.ts
@@ -1,0 +1,47 @@
+// tests/codex-session-attribution.test.ts
+import { describe, it, expect } from "vitest";
+import { readCodexSessionCwd } from "../src/codex-session-attribution.js";
+import { writeFile } from "node:fs/promises";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+async function tmpFile(content: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "codex-attr-"));
+  const path = join(dir, "rollout.jsonl");
+  await writeFile(path, content);
+  return path;
+}
+
+describe("readCodexSessionCwd", () => {
+  it("returns the cwd from session_meta.payload.cwd", async () => {
+    const line = JSON.stringify({
+      type: "session_meta",
+      payload: { cwd: "/repo/my-project", id: "x" }
+    });
+    expect(await readCodexSessionCwd(await tmpFile(line))).toBe(
+      "/repo/my-project"
+    );
+  });
+
+  it("falls back to turn_context.cwd", async () => {
+    const lines = [
+      JSON.stringify({ type: "session_meta", payload: { id: "no-cwd" } }),
+      JSON.stringify({ type: "turn_context", payload: { cwd: "/repo/fallback" } })
+    ].join("\n");
+    expect(await readCodexSessionCwd(await tmpFile(lines))).toBe("/repo/fallback");
+  });
+
+  it("returns null when no cwd is present", async () => {
+    const line = JSON.stringify({ type: "session_meta", payload: { id: "x" } });
+    expect(await readCodexSessionCwd(await tmpFile(line))).toBeNull();
+  });
+
+  it("skips malformed JSON lines", async () => {
+    const lines = [
+      "garbage",
+      JSON.stringify({ type: "session_meta", payload: { cwd: "/ok" } })
+    ].join("\n");
+    expect(await readCodexSessionCwd(await tmpFile(lines))).toBe("/ok");
+  });
+});

--- a/tests/codex-session-discovery.test.ts
+++ b/tests/codex-session-discovery.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { mkdir, writeFile } from "node:fs/promises";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { discoverCodexSessionLogs } from "../src/codex-session-discovery.js";
+
+async function makeCodexHome() {
+  return mkdtemp(join(tmpdir(), "codex-discovery-"));
+}
+
+describe("discoverCodexSessionLogs", () => {
+  it("returns empty array when codex home is missing", async () => {
+    const home = join(await makeCodexHome(), "does-not-exist");
+    expect(await discoverCodexSessionLogs({ codexHome: home })).toEqual([]);
+  });
+
+  it("returns empty array when sessions dir is empty", async () => {
+    const home = await makeCodexHome();
+    await mkdir(join(home, "sessions"), { recursive: true });
+    expect(await discoverCodexSessionLogs({ codexHome: home })).toEqual([]);
+  });
+
+  it("discovers rollout files under YYYY/MM/DD", async () => {
+    const home = await makeCodexHome();
+    const day = join(home, "sessions", "2026", "06", "13");
+    await mkdir(day, { recursive: true });
+    const path1 = join(day, "rollout-2026-06-13T01-00-00-aaa.jsonl");
+    const path2 = join(day, "rollout-2026-06-13T02-00-00-bbb.jsonl");
+    await writeFile(path1, "");
+    await writeFile(path2, "");
+    const result = await discoverCodexSessionLogs({ codexHome: home });
+    expect(result.map((r) => r.path).sort()).toEqual([path1, path2].sort());
+    expect(result[0].sessionId).toMatch(/^rollout-/);
+  });
+
+  it("filters by targetDate when provided", async () => {
+    const home = await makeCodexHome();
+    const day1 = join(home, "sessions", "2026", "06", "13");
+    const day2 = join(home, "sessions", "2026", "06", "14");
+    await mkdir(day1, { recursive: true });
+    await mkdir(day2, { recursive: true });
+    await writeFile(join(day1, "rollout-2026-06-13T01-00-00-a.jsonl"), "");
+    await writeFile(join(day2, "rollout-2026-06-14T01-00-00-b.jsonl"), "");
+    const onlyJun14 = await discoverCodexSessionLogs({
+      codexHome: home,
+      targetDate: "2026-06-14"
+    });
+    expect(onlyJun14).toHaveLength(1);
+    expect(onlyJun14[0].path).toContain("2026/06/14");
+  });
+
+  it("ignores non-rollout files and non-jsonl extensions", async () => {
+    const home = await makeCodexHome();
+    const day = join(home, "sessions", "2026", "06", "13");
+    await mkdir(day, { recursive: true });
+    await writeFile(join(day, "rollout-good.jsonl"), "");
+    await writeFile(join(day, "notes.txt"), "");
+    await writeFile(join(day, "config.json"), "");
+    const result = await discoverCodexSessionLogs({ codexHome: home });
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toContain("rollout-good.jsonl");
+  });
+});

--- a/tests/codex-session-parser.test.ts
+++ b/tests/codex-session-parser.test.ts
@@ -1,0 +1,189 @@
+// tests/codex-session-parser.test.ts
+import { describe, it, expect } from "vitest";
+import { parseCodexSession } from "../src/codex-session-parser.js";
+
+const META_LINE = JSON.stringify({
+  timestamp: "2026-06-13T14:17:57.191Z",
+  type: "session_meta",
+  payload: { id: "sess-1", cwd: "/repo" }
+});
+
+const USER_MESSAGE = JSON.stringify({
+  timestamp: "2026-06-13T14:18:00.000Z",
+  type: "response_item",
+  payload: {
+    type: "message",
+    role: "user",
+    content: [{ type: "input_text", text: "hello codex" }]
+  }
+});
+
+const ASSISTANT_MESSAGE = JSON.stringify({
+  timestamp: "2026-06-13T14:18:05.000Z",
+  type: "response_item",
+  payload: {
+    type: "message",
+    role: "assistant",
+    content: [
+      { type: "output_text", text: "hi there" },
+      { type: "output_text", text: " and more" }
+    ]
+  }
+});
+
+const FUNCTION_CALL = JSON.stringify({
+  timestamp: "2026-06-13T14:18:10.000Z",
+  type: "response_item",
+  payload: {
+    type: "function_call",
+    name: "read_file",
+    arguments: JSON.stringify({ file_path: "/repo/src/index.ts" })
+  }
+});
+
+const FUNCTION_OUTPUT = JSON.stringify({
+  timestamp: "2026-06-13T14:18:11.000Z",
+  type: "response_item",
+  payload: {
+    type: "function_call_output",
+    output: "BIG SECRET BODY THAT MUST NOT LEAK"
+  }
+});
+
+const EVENT_USER = JSON.stringify({
+  timestamp: "2026-06-13T14:18:12.000Z",
+  type: "event_msg",
+  payload: { type: "user_message", message: "from event_msg user" }
+});
+
+const EVENT_AGENT = JSON.stringify({
+  timestamp: "2026-06-13T14:18:13.000Z",
+  type: "event_msg",
+  payload: { type: "agent_message", message: "from event_msg agent" }
+});
+
+const EXEC_END = JSON.stringify({
+  timestamp: "2026-06-13T14:18:14.000Z",
+  type: "event_msg",
+  payload: {
+    type: "exec_command_end",
+    command: ["ls", "-la"],
+    stdout: "SHOULD NOT APPEAR",
+    stderr: "ALSO NOT"
+  }
+});
+
+const DEVELOPER_PROMPT = JSON.stringify({
+  timestamp: "2026-06-13T14:18:00.500Z",
+  type: "response_item",
+  payload: {
+    type: "message",
+    role: "developer",
+    content: [{ type: "input_text", text: "system prompt scaffolding" }]
+  }
+});
+
+describe("parseCodexSession", () => {
+  it("ignores meta-only lines", () => {
+    const result = parseCodexSession({ projectId: "p1", contents: META_LINE });
+    expect(result.signals).toEqual([]);
+    expect(result.conversation).toEqual([]);
+    expect(result.toolFacts).toEqual([]);
+  });
+
+  it("captures user message text from response_item.message", () => {
+    const result = parseCodexSession({ projectId: "p1", contents: USER_MESSAGE });
+    expect(result.conversation).toEqual([
+      {
+        role: "user",
+        text: "hello codex",
+        timestamp: "2026-06-13T14:18:00.000Z"
+      }
+    ]);
+    expect(result.signals).toHaveLength(1);
+    expect(result.signals[0].kind).toBe("codex-user-turn");
+  });
+
+  it("concatenates assistant message blocks and emits one turn + signal per block", () => {
+    const result = parseCodexSession({
+      projectId: "p1",
+      contents: ASSISTANT_MESSAGE
+    });
+    expect(result.conversation).toHaveLength(2);
+    expect(result.conversation[0].role).toBe("assistant");
+    expect(result.conversation.map((c) => c.text)).toEqual([
+      "hi there",
+      " and more"
+    ]);
+    expect(result.signals.map((s) => s.kind)).toEqual([
+      "codex-assistant-text",
+      "codex-assistant-text"
+    ]);
+  });
+
+  it("extracts function_call as a tool fact with target", () => {
+    const result = parseCodexSession({ projectId: "p1", contents: FUNCTION_CALL });
+    expect(result.toolFacts).toEqual([
+      {
+        tool: "read_file",
+        target: "/repo/src/index.ts",
+        timestamp: "2026-06-13T14:18:10.000Z"
+      }
+    ]);
+    expect(result.signals).toHaveLength(1);
+    expect(result.signals[0].kind).toBe("codex-tool");
+  });
+
+  it("discards function_call_output body entirely (no signal, no fact, no conversation)", () => {
+    const result = parseCodexSession({
+      projectId: "p1",
+      contents: FUNCTION_OUTPUT
+    });
+    expect(result.signals).toEqual([]);
+    expect(result.conversation).toEqual([]);
+    expect(result.toolFacts).toEqual([]);
+  });
+
+  it("captures event_msg.user_message and agent_message", () => {
+    const result = parseCodexSession({
+      projectId: "p1",
+      contents: [EVENT_USER, EVENT_AGENT].join("\n")
+    });
+    expect(result.conversation).toEqual([
+      {
+        role: "user",
+        text: "from event_msg user",
+        timestamp: "2026-06-13T14:18:12.000Z"
+      },
+      {
+        role: "assistant",
+        text: "from event_msg agent",
+        timestamp: "2026-06-13T14:18:13.000Z"
+      }
+    ]);
+  });
+
+  it("records exec_command_end as a tool fact without body", () => {
+    const result = parseCodexSession({ projectId: "p1", contents: EXEC_END });
+    expect(result.toolFacts).toHaveLength(1);
+    expect(result.toolFacts[0].tool).toBe("exec_command_end");
+    expect(JSON.stringify(result.toolFacts[0])).not.toContain("SHOULD NOT APPEAR");
+    expect(JSON.stringify(result)).not.toContain("SHOULD NOT APPEAR");
+    expect(JSON.stringify(result)).not.toContain("ALSO NOT");
+  });
+
+  it("drops developer/system role messages (prompt scaffolding)", () => {
+    const result = parseCodexSession({
+      projectId: "p1",
+      contents: DEVELOPER_PROMPT
+    });
+    expect(result.conversation).toEqual([]);
+    expect(result.signals).toEqual([]);
+  });
+
+  it("skips malformed JSON lines and continues parsing", () => {
+    const contents = ["not json", USER_MESSAGE, "{broken"].join("\n");
+    const result = parseCodexSession({ projectId: "p1", contents });
+    expect(result.conversation).toHaveLength(1);
+  });
+});

--- a/tests/codex-session-parser.test.ts
+++ b/tests/codex-session-parser.test.ts
@@ -73,6 +73,16 @@ const EXEC_END = JSON.stringify({
   }
 });
 
+const EXEC_FUNCTION_CALL_CMD = JSON.stringify({
+  timestamp: "2026-06-13T14:18:15.000Z",
+  type: "response_item",
+  payload: {
+    type: "function_call",
+    name: "exec_command",
+    arguments: JSON.stringify({ cmd: "cargo test" })
+  }
+});
+
 const DEVELOPER_PROMPT = JSON.stringify({
   timestamp: "2026-06-13T14:18:00.500Z",
   type: "response_item",
@@ -161,6 +171,32 @@ describe("parseCodexSession", () => {
         timestamp: "2026-06-13T14:18:13.000Z"
       }
     ]);
+  });
+
+  it("does not emit a Tier 2 signal for event_msg.agent_message (kept in raw archive only)", () => {
+    // agent_message is a UI echo of the assistant turn already captured as a
+    // response_item/message signal. Emitting it again double-counts (and can
+    // surface reasoning) into activity summaries, so it stays conversation-only.
+    const result = parseCodexSession({ projectId: "p1", contents: EVENT_AGENT });
+    expect(result.conversation).toHaveLength(1);
+    expect(result.conversation[0].role).toBe("assistant");
+    expect(result.signals).toEqual([]);
+  });
+
+  it("reads exec_command cmd argument as the tool target", () => {
+    const result = parseCodexSession({
+      projectId: "p1",
+      contents: EXEC_FUNCTION_CALL_CMD
+    });
+    expect(result.toolFacts).toEqual([
+      {
+        tool: "exec_command",
+        target: "cargo test",
+        timestamp: "2026-06-13T14:18:15.000Z"
+      }
+    ]);
+    expect(result.signals).toHaveLength(1);
+    expect(result.signals[0].summary).toBe("exec_command cargo test");
   });
 
   it("records exec_command_end as a tool fact without body", () => {

--- a/tests/codex-session-redactor.test.ts
+++ b/tests/codex-session-redactor.test.ts
@@ -1,0 +1,54 @@
+// tests/codex-session-redactor.test.ts
+import { describe, it, expect } from "vitest";
+import { redactCodexSession } from "../src/codex-session-redactor.js";
+
+describe("redactCodexSession", () => {
+  it("masks vendor secrets in conversation and signals", () => {
+    const result = redactCodexSession({
+      signals: [
+        {
+          projectId: "p1",
+          timestamp: "t",
+          kind: "codex-user-turn",
+          summary: "token AKIAABCDEFGHIJKLMNOP and email a@b.com",
+          safetyNotes: []
+        }
+      ],
+      conversation: [
+        { role: "user", text: "key=ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", timestamp: "t" }
+      ],
+      toolFacts: [
+        { tool: "read_file", target: "/Users/me/secret.env", timestamp: "t" }
+      ]
+    });
+
+    expect(result.signals[0].summary).not.toContain("AKIAABCDEFGHIJKLMNOP");
+    expect(result.signals[0].summary).not.toContain("a@b.com");
+    expect(result.conversation[0].text).not.toContain("ghp_");
+    expect(result.toolFacts[0].target).not.toContain("/Users/me");
+    expect(result.appliedCategories.length).toBeGreaterThan(0);
+  });
+
+  it("leaves benign prose untouched", () => {
+    const result = redactCodexSession({
+      signals: [],
+      conversation: [
+        { role: "user", text: "hello what is this codebase doing", timestamp: "t" }
+      ],
+      toolFacts: []
+    });
+    expect(result.conversation[0].text).toBe(
+      "hello what is this codebase doing"
+    );
+    expect(result.appliedCategories).toEqual([]);
+  });
+
+  it("passes through tool facts without target", () => {
+    const result = redactCodexSession({
+      signals: [],
+      conversation: [],
+      toolFacts: [{ tool: "exec_command_end", timestamp: "t" }]
+    });
+    expect(result.toolFacts[0].target).toBeUndefined();
+  });
+});

--- a/tests/codex-session-writer.test.ts
+++ b/tests/codex-session-writer.test.ts
@@ -1,0 +1,90 @@
+// tests/codex-session-writer.test.ts
+import { describe, it, expect } from "vitest";
+import { mkdtemp, readFile, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writeCodexSessionOutputs } from "../src/codex-session-writer.js";
+
+async function tmpProject() {
+  return mkdtemp(join(tmpdir(), "codex-writer-"));
+}
+
+describe("writeCodexSessionOutputs", () => {
+  it("writes signals JSONL and raw archive with 0600 mode", async () => {
+    const root = await tmpProject();
+    const result = await writeCodexSessionOutputs({
+      projectRoot: root,
+      targetDate: "2026-06-14",
+      signals: [
+        {
+          projectId: "p1",
+          timestamp: "2026-06-14T01:00:00Z",
+          kind: "codex-user-turn",
+          summary: "hi",
+          safetyNotes: []
+        }
+      ],
+      conversation: [
+        { role: "user", text: "hi", timestamp: "2026-06-14T01:00:00Z" }
+      ],
+      toolFacts: [
+        { tool: "read_file", target: "/src/a.ts", timestamp: "2026-06-14T01:00:01Z" }
+      ]
+    });
+
+    expect(result.signalsFile.endsWith("events/codex/2026-06-14.jsonl")).toBe(true);
+    expect(result.rawArchiveFile.endsWith("events/codex/raw/2026-06-14.jsonl")).toBe(
+      true
+    );
+
+    const signals = await readFile(result.signalsFile, "utf8");
+    expect(signals.trim().split("\n")).toHaveLength(1);
+
+    const raw = await readFile(result.rawArchiveFile, "utf8");
+    const rawLines = raw.trim().split("\n");
+    expect(rawLines).toHaveLength(2);
+    expect(JSON.parse(rawLines[0]).kind).toBe("turn");
+    expect(JSON.parse(rawLines[1]).kind).toBe("tool");
+
+    const info = await stat(result.rawArchiveFile);
+    expect(info.mode & 0o777).toBe(0o600);
+  });
+
+  it("interleaves conversation and tool facts by timestamp", async () => {
+    const root = await tmpProject();
+    const result = await writeCodexSessionOutputs({
+      projectRoot: root,
+      targetDate: "2026-06-14",
+      signals: [],
+      conversation: [
+        { role: "user", text: "u1", timestamp: "2026-06-14T01:00:00Z" },
+        { role: "assistant", text: "a1", timestamp: "2026-06-14T01:00:02Z" }
+      ],
+      toolFacts: [
+        { tool: "read_file", target: "/a", timestamp: "2026-06-14T01:00:01Z" }
+      ]
+    });
+    const lines = (await readFile(result.rawArchiveFile, "utf8"))
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l));
+    expect(lines.map((l) => l.timestamp)).toEqual([
+      "2026-06-14T01:00:00Z",
+      "2026-06-14T01:00:01Z",
+      "2026-06-14T01:00:02Z"
+    ]);
+  });
+
+  it("writes empty files when no signals/conversation", async () => {
+    const root = await tmpProject();
+    const result = await writeCodexSessionOutputs({
+      projectRoot: root,
+      targetDate: "2026-06-14",
+      signals: [],
+      conversation: [],
+      toolFacts: []
+    });
+    expect((await readFile(result.signalsFile, "utf8")).length).toBe(0);
+    expect((await readFile(result.rawArchiveFile, "utf8")).length).toBe(0);
+  });
+});

--- a/tests/collect-codex-command.test.ts
+++ b/tests/collect-codex-command.test.ts
@@ -83,6 +83,66 @@ describe("collectCodexForRegisteredProjects", () => {
     expect(raw).toContain('"role":"user"');
   });
 
+  it("discovers cross-midnight sessions stored under the previous day's directory", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "codex-cmd-"));
+    const codexHome = join(homeDir, ".codex");
+    const projectRoot = await mkdtemp(join(tmpdir(), "codex-proj-"));
+    await mkdir(join(homeDir, ".uncommitted"), { recursive: true });
+    await writeFile(
+      join(homeDir, ".uncommitted", "projects.json"),
+      JSON.stringify({
+        schemaVersion: 1,
+        projects: [
+          {
+            schemaVersion: 1,
+            id: "p1",
+            name: "demo",
+            root: projectRoot,
+            gitRoot: projectRoot,
+            enabled: true,
+            createdAt: "2026-06-14T00:00:00Z"
+          }
+        ]
+      })
+    );
+
+    // Session started 2026-06-13 (file lives under that day's dir) but the user
+    // kept working past midnight; the meaningful entry is timestamped 06-14.
+    const startDayDir = join(codexHome, "sessions", "2026", "06", "13");
+    await mkdir(startDayDir, { recursive: true });
+    await writeFile(
+      join(startDayDir, "rollout-cross.jsonl"),
+      [
+        JSON.stringify({
+          timestamp: "2026-06-13T23:59:00.000Z",
+          type: "session_meta",
+          payload: { id: "s1", cwd: projectRoot }
+        }),
+        JSON.stringify({
+          timestamp: "2026-06-14T00:05:00.000Z",
+          type: "response_item",
+          payload: {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: "after midnight" }]
+          }
+        })
+      ].join("\n")
+    );
+
+    const result = await collectCodexForRegisteredProjects({
+      homeDir,
+      codexHome,
+      targetDate: "2026-06-14"
+    });
+
+    expect(result.codexLogsMissing).toBe(false);
+    expect(result.successes).toHaveLength(1);
+    expect(result.successes[0].signalCount).toBeGreaterThan(0);
+    const raw = await readFile(result.successes[0].rawArchiveFile, "utf8");
+    expect(raw).toContain("after midnight");
+  });
+
   it("reports codexLogsMissing when no rollout files exist", async () => {
     const homeDir = await mkdtemp(join(tmpdir(), "codex-cmd-"));
     const codexHome = join(homeDir, ".codex");

--- a/tests/collect-codex-command.test.ts
+++ b/tests/collect-codex-command.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp, mkdir, writeFile, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  collectCodexForRegisteredProjects,
+  CollectCodexCommandError
+} from "../src/collect-codex-command.js";
+
+async function seed(opts: {
+  projectRoot: string;
+  codexHome: string;
+  cwd: string;
+  date: string;
+}) {
+  const dayDir = join(
+    opts.codexHome,
+    "sessions",
+    opts.date.slice(0, 4),
+    opts.date.slice(5, 7),
+    opts.date.slice(8, 10)
+  );
+  await mkdir(dayDir, { recursive: true });
+  const lines = [
+    JSON.stringify({
+      timestamp: `${opts.date}T01:00:00.000Z`,
+      type: "session_meta",
+      payload: { id: "s1", cwd: opts.cwd }
+    }),
+    JSON.stringify({
+      timestamp: `${opts.date}T01:00:01.000Z`,
+      type: "response_item",
+      payload: {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "hi" }]
+      }
+    })
+  ].join("\n");
+  await writeFile(join(dayDir, "rollout-x.jsonl"), lines);
+}
+
+describe("collectCodexForRegisteredProjects", () => {
+  it("writes signal + raw archive for matching projects", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "codex-cmd-"));
+    const codexHome = join(homeDir, ".codex");
+    const projectRoot = await mkdtemp(join(tmpdir(), "codex-proj-"));
+    await mkdir(join(homeDir, ".uncommitted"), { recursive: true });
+    await writeFile(
+      join(homeDir, ".uncommitted", "projects.json"),
+      JSON.stringify({
+        schemaVersion: 1,
+        projects: [
+          {
+            schemaVersion: 1,
+            id: "p1",
+            name: "demo",
+            root: projectRoot,
+            gitRoot: projectRoot,
+            enabled: true,
+            createdAt: "2026-06-14T00:00:00Z"
+          }
+        ]
+      })
+    );
+    await seed({
+      projectRoot,
+      codexHome,
+      cwd: projectRoot,
+      date: "2026-06-14"
+    });
+
+    const result = await collectCodexForRegisteredProjects({
+      homeDir,
+      codexHome,
+      now: () => "2026-06-14T05:00:00Z"
+    });
+    expect(result.codexLogsMissing).toBe(false);
+    expect(result.successes).toHaveLength(1);
+    expect(result.successes[0].signalCount).toBeGreaterThan(0);
+
+    const raw = await readFile(result.successes[0].rawArchiveFile, "utf8");
+    expect(raw).toContain('"role":"user"');
+  });
+
+  it("reports codexLogsMissing when no rollout files exist", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "codex-cmd-"));
+    const codexHome = join(homeDir, ".codex");
+    const projectRoot = await mkdtemp(join(tmpdir(), "codex-proj-"));
+    await mkdir(join(homeDir, ".uncommitted"), { recursive: true });
+    await writeFile(
+      join(homeDir, ".uncommitted", "projects.json"),
+      JSON.stringify({
+        schemaVersion: 1,
+        projects: [
+          {
+            schemaVersion: 1,
+            id: "p1",
+            name: "demo",
+            root: projectRoot,
+            gitRoot: projectRoot,
+            enabled: true,
+            createdAt: "2026-06-14T00:00:00Z"
+          }
+        ]
+      })
+    );
+
+    const result = await collectCodexForRegisteredProjects({
+      homeDir,
+      codexHome,
+      now: () => "2026-06-14T05:00:00Z"
+    });
+    expect(result.codexLogsMissing).toBe(true);
+    expect(result.successes).toEqual([]);
+    expect(result.failures).toEqual([]);
+  });
+
+  it("throws no-projects error when registry is empty", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "codex-cmd-"));
+    await mkdir(join(homeDir, ".uncommitted"), { recursive: true });
+    await writeFile(
+      join(homeDir, ".uncommitted", "projects.json"),
+      JSON.stringify({ schemaVersion: 1, projects: [] })
+    );
+    await expect(
+      collectCodexForRegisteredProjects({ homeDir })
+    ).rejects.toBeInstanceOf(CollectCodexCommandError);
+  });
+});

--- a/tests/generate-command.test.ts
+++ b/tests/generate-command.test.ts
@@ -202,6 +202,39 @@ describe("generate command", () => {
     );
   });
 
+  it("incorporates collected Codex signals into the activity summary", async () => {
+    const { io, stderr } = createIo();
+    const fixture = await createRegisteredProjectFixture();
+    const provider = new TaskAwareProvider();
+
+    await writeGitEvent(fixture.project, "2026-05-12");
+    await writeCodexSignals(fixture.project, "2026-05-12", [
+      {
+        projectId: fixture.project.id,
+        timestamp: "2026-05-12T09:00:00.000Z",
+        kind: "codex-assistant-text",
+        summary: "implement the codex session adapter",
+        safetyNotes: []
+      }
+    ]);
+
+    const exitCode = await runCli(["generate", "today"], io, {
+      homeDir: fixture.homeDir,
+      now: () => "2026-05-12T23:30:00.000Z",
+      aiProvider: provider
+    });
+    const outputDir = join(fixture.draftRoot, "2026-05-12", "rev-001");
+    const activitySummary = (await readJson(
+      join(outputDir, "activity-summary.json")
+    )) as { smallWins: string[] };
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toEqual([]);
+    expect(activitySummary.smallWins).toContain(
+      "implement the codex session adapter"
+    );
+  });
+
   it("completes warning drafts with a visible safety warning and metadata state", async () => {
     const { io, stdout, stderr } = createIo();
     const fixture = await createRegisteredProjectFixture();
@@ -931,6 +964,27 @@ async function writeClaudeSignals(
   }[]
 ): Promise<void> {
   const eventsDir = join(project.root, ".uncommitted", "events", "claude");
+
+  await mkdir(eventsDir, { recursive: true });
+  await writeFile(
+    join(eventsDir, `${targetDate}.jsonl`),
+    signals.map((signal) => JSON.stringify(signal)).join("\n") + "\n",
+    "utf8"
+  );
+}
+
+async function writeCodexSignals(
+  project: ProjectRecord,
+  targetDate: string,
+  signals: {
+    projectId: string;
+    timestamp: string;
+    kind: string;
+    summary: string;
+    safetyNotes: string[];
+  }[]
+): Promise<void> {
+  const eventsDir = join(project.root, ".uncommitted", "events", "codex");
 
   await mkdir(eventsDir, { recursive: true });
   await writeFile(


### PR DESCRIPTION
🤖 **Auto-generated by Uncommitted Builder (Routine B v2)**

## Parent issue
[UNC-118: Codex 세션 로그 어댑터 + collect codex](https://linear.app/sangchu/issue/UNC-118)

Mirror of the just-merged UNC-117 (Claude session adapter, [#102](https://github.com/james20140802/uncommitted/pull/102)) — same 2-tier raw+signal architecture, same shared credential detector (UNC-155, already on main), independent parser for the Codex `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` format.

## Sub-issues progress
- [x] [UNC-143](https://linear.app/sangchu/issue/UNC-143): [T1] Codex session log discovery — `d8cc395`
- [x] [UNC-144](https://linear.app/sangchu/issue/UNC-144): [T2] Parse Codex entries → signals + conversation + tool facts — `a1f18d2`
- [x] [UNC-145](https://linear.app/sangchu/issue/UNC-145): [T3] Attribute Codex sessions to registered projects via cwd — `91b2023`
- [x] [UNC-146](https://linear.app/sangchu/issue/UNC-146): [T4] Tier 1 raw archive (0600) + Tier 2 signal events — `0855fa8`
- [x] [UNC-147](https://linear.app/sangchu/issue/UNC-147): [T5] Redact Codex via shared credential detector + redaction — `cd445e6`
- [x] [UNC-148](https://linear.app/sangchu/issue/UNC-148): [T6] `uncommitted collect codex` CLI subcommand — `8f94e9a`

## Status
- Branch: `claude/UNC-118-codex-session-adapter`
- Tests: ✅ 513 passed / 1 skipped (vitest, 52 test files)
- Build: ✅ `pnpm build` clean
- Type check: ✅ `pnpm typecheck` clean
- Lint: ✅ `pnpm lint` clean

## TDD trail
Each sub-task followed strict TDD via subagent-driven-development:
- T1 (discovery): implementer (Sonnet) ✅ → spec review ✅ → quality review ✅ (approved with minor temp-dir cleanup note)
- T2 (parser): implementer ✅ → combined spec+quality review ✅
- T3 (attribution): implementer ✅ → combined review ✅
- T4 (writer): implementer ✅ → combined review ✅
- T5 (redactor): implementer ✅ → combined review ✅
- T6 (CLI): implementer ✅ → combined review ✅ (implementer caught and fixed a plan inconsistency: `no-projects` → exit 3 to match existing `collect claude` / `collect git`, not exit 2 as the plan said)

## Design highlights
- **Independent parser, shared principles.** Codex log format (`response_item` / `event_msg` with nested `payload.type`) is completely different from Claude (`type=user|assistant`), so the parser is a brand-new module. But the redactor, writer shape, and CLI plumbing all mirror the proven UNC-117 patterns.
- **2-tier persistence.** `events/codex/<date>.jsonl` (signals, Tier 2) + `events/codex/raw/<date>.jsonl` (interleaved conversation+tool facts, **0600 local-only**, never transmitted).
- **Tool output body strictly discarded.** Function call outputs and exec command stdout/stderr are dropped at the parser boundary — only tool name + minimal target survive. Test 7 in `codex-session-parser.test.ts` literally greps the result for `SHOULD NOT APPEAR` / `ALSO NOT` to prove it.
- **Developer/system role messages dropped.** Codex puts prompt scaffolding under `role: "developer"`/`"system"` — these are not user/assistant content and are filtered out.
- **`--date YYYY-MM-DD` flag.** Backfill support; default = today (UTC).
- **Graceful skip.** Missing `~/.codex/sessions/` or no rollout files for the day → `codexLogsMissing: true` and exit 0.

## Notes
- No `pnpm-lock.yaml`, `.env`, `AGENTS.md`, or secret-file changes.
- No new HTTP / network / SNS upload code.
- No LLM calls — redaction is regex + entropy only via the existing `credential-detector.ts` (UNC-155).
- macOS-first; no cross-platform refactors.

## Review checklist
- [ ] Review each sub-issue's commit separately (6 commits, one per sub).
- [ ] Verify TDD test coverage in each `tests/codex-session-*.test.ts`.
- [ ] Confirm no lockfile changes (`git diff --stat origin/main..HEAD`).
- [ ] Run locally: `pnpm install --frozen-lockfile && pnpm test && pnpm lint && pnpm typecheck && pnpm build`.
- [ ] Spot-check `src/cli.ts` diff to confirm only the `collect codex` block was added.
- [ ] Spot-check that no auto-publish / external-upload code was introduced.

---
이 PR은 자동 생성되었습니다. 머지 전 사람의 리뷰가 반드시 필요합니다.