### PR TITLE
🤖 GitHub PR·Issue 수집기 + collect github (UNC-119)

### DIFF
--- a/src/activity-summary.ts
+++ b/src/activity-summary.ts
@@ -41,6 +41,10 @@ export type ActivitySummaryInput = {
   // Already-redacted Codex session signals (from `uncommitted collect codex`).
   // Treated identically to Claude signals so a Codex-only day isn't quiet.
   codexSignals?: ActivitySignal[];
+  // Already-redacted GitHub activity signals (from `uncommitted collect github`).
+  // Treated identically to session signals so a day of merged PRs / closed
+  // issues / reviews isn't quiet.
+  githubSignals?: ActivitySignal[];
 };
 
 export type ActivityProjectSummary = {
@@ -212,7 +216,8 @@ export function buildActivitySummary(
   // treated as current). Both sources are handled identically.
   const sessionSignals = [
     ...(input.claudeSignals ?? []),
-    ...(input.codexSignals ?? [])
+    ...(input.codexSignals ?? []),
+    ...(input.githubSignals ?? [])
   ].filter(
     (signal) =>
       signal.timestamp === "" ||

--- a/src/activity-summary.ts
+++ b/src/activity-summary.ts
@@ -119,6 +119,7 @@ type ProjectAccumulator = {
   deletions: number;
   uncommittedChangeCount: number;
   manualNoteCount: number;
+  githubSignalCount: number;
   themes: Set<Exclude<ActivityTheme, "mixed" | "quiet">>;
 };
 
@@ -223,6 +224,18 @@ export function buildActivitySummary(
       signal.timestamp === "" ||
       signal.timestamp.slice(0, 10) === input.targetDate
   );
+
+  // GitHub signals carry a registered projectId but never create a git event or
+  // manual note, so a PR/review-only day would leave `projects` empty and the
+  // diary would claim zero projects on an active day. Seed a project
+  // accumulator per GitHub signal so PR-only days keep their project
+  // attribution (name falls back to the id, as manual-note-only projects do).
+  for (const signal of input.githubSignals ?? []) {
+    if (signal.timestamp !== "" && signal.timestamp.slice(0, 10) !== input.targetDate) {
+      continue;
+    }
+    getProject(projects, signal.projectId, signal.projectId).githubSignalCount += 1;
+  }
 
   // Build a normalized signal stream from the source-shaped inputs and append
   // the session signals, then derive the 4 source-agnostic synthesis fields
@@ -425,6 +438,7 @@ function getProject(
     deletions: 0,
     uncommittedChangeCount: 0,
     manualNoteCount: 0,
+    githubSignalCount: 0,
     themes: new Set()
   };
 
@@ -461,6 +475,10 @@ function summarizeProject(project: ProjectAccumulator): string {
 
   if (project.uncommittedChangeCount > 0) {
     parts.push(`${project.uncommittedChangeCount} uncommitted ${project.uncommittedChangeCount === 1 ? "file" : "files"}`);
+  }
+
+  if (project.githubSignalCount > 0) {
+    parts.push(`${project.githubSignalCount} GitHub ${project.githubSignalCount === 1 ? "event" : "events"}`);
   }
 
   return parts.length > 0 ? parts.join(", ") : "No activity signals.";

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,10 @@ import {
   collectCodexForRegisteredProjects,
   CollectCodexCommandError
 } from "./collect-codex-command.js";
+import {
+  collectGitHubForRegisteredProjects,
+  CollectGitHubCommandError
+} from "./collect-github-command.js";
 import { AiGenerationError, type AiProvider } from "./ai-provider.js";
 import { commands, isKnownCommand } from "./commands.js";
 import { formatDoctorReport, runDoctorCommand } from "./doctor-command.js";
@@ -757,13 +761,20 @@ async function runCollect(
   io: CliIo,
   options: CliOptions
 ): Promise<number> {
-  if (args.length < 1 || (args[0] !== "git" && args[0] !== "claude" && args[0] !== "codex")) {
-    io.stderr("Usage: uncommitted collect <git|claude|codex>");
+  if (
+    args.length < 1 ||
+    (args[0] !== "git" &&
+      args[0] !== "claude" &&
+      args[0] !== "codex" &&
+      args[0] !== "github")
+  ) {
+    io.stderr("Usage: uncommitted collect <git|claude|codex|github>");
     return 1;
   }
 
   // git and claude take no further arguments; reject trailing tokens so an
-  // unsupported flag can't silently collect/overwrite today's events.
+  // unsupported flag can't silently collect/overwrite today's events. codex and
+  // github both accept --date so they validate their own argv below.
   if ((args[0] === "git" || args[0] === "claude") && args.length > 1) {
     io.stderr(`Usage: uncommitted collect ${args[0]}`);
     return 1;
@@ -832,58 +843,113 @@ async function runCollect(
     }
   }
 
-  // args[0] === "codex"
-  const codexArgs = args.slice(1);
-  let targetDate: string | undefined;
-  for (let i = 0; i < codexArgs.length; i++) {
-    if (codexArgs[i] === "--date") {
-      // --date must be followed by a value; otherwise the collector would fall
-      // back to today and overwrite today's events on a typo.
-      if (i + 1 >= codexArgs.length) {
-        io.stderr("Usage: uncommitted collect codex [--date YYYY-MM-DD]");
+  if (args[0] === "codex") {
+    const codexArgs = args.slice(1);
+    let targetDate: string | undefined;
+    for (let i = 0; i < codexArgs.length; i++) {
+      if (codexArgs[i] === "--date") {
+        // --date must be followed by a value; otherwise the collector would fall
+        // back to today and overwrite today's events on a typo.
+        if (i + 1 >= codexArgs.length) {
+          io.stderr("Usage: uncommitted collect codex [--date YYYY-MM-DD]");
+          return 1;
+        }
+        targetDate = codexArgs[++i];
+        continue;
+      }
+      // Reject unknown/extra tokens rather than silently ignoring them.
+      io.stderr("Usage: uncommitted collect codex [--date YYYY-MM-DD]");
+      return 1;
+    }
+
+    try {
+      const result = await collectCodexForRegisteredProjects({
+        homeDir: options.homeDir,
+        codexHome: options.codexHome,
+        now: options.now ?? (() => new Date().toISOString()),
+        targetDate
+      });
+
+      if (result.codexLogsMissing) {
+        io.stdout("No Codex session logs found at ~/.codex/sessions. Skipping.");
+        return 0;
+      }
+
+      if (result.successes.length > 0) {
+        io.stdout(
+          `Collected Codex activity for ${formatProjectCount(result.successes.length)}.`
+        );
+        for (const success of result.successes) {
+          io.stdout(
+            `${success.projectId}: ${success.signalCount} signals, ${success.conversationCount} turns, ${success.toolFactCount} tool facts.`
+          );
+        }
+      }
+
+      for (const failure of result.failures) {
+        io.stderr(`Failed to collect ${failure.projectId}: ${failure.message}`);
+      }
+
+      return result.failures.length > 0 ? 3 : 0;
+    } catch (error) {
+      if (error instanceof CollectCodexCommandError) {
+        io.stderr(error.message);
+        return error.code === "invalid-projects-file" ||
+          error.code === "invalid-date"
+          ? 2
+          : 3;
+      }
+      throw error;
+    }
+  }
+
+  // args[0] === "github"
+  const ghArgs = args.slice(1);
+  let ghTargetDate: string | undefined;
+  for (let i = 0; i < ghArgs.length; i++) {
+    if (ghArgs[i] === "--date") {
+      if (i + 1 >= ghArgs.length) {
+        io.stderr("Usage: uncommitted collect github [--date YYYY-MM-DD]");
         return 1;
       }
-      targetDate = codexArgs[++i];
+      ghTargetDate = ghArgs[++i];
       continue;
     }
-    // Reject unknown/extra tokens rather than silently ignoring them.
-    io.stderr("Usage: uncommitted collect codex [--date YYYY-MM-DD]");
+    io.stderr("Usage: uncommitted collect github [--date YYYY-MM-DD]");
     return 1;
   }
 
   try {
-    const result = await collectCodexForRegisteredProjects({
+    const result = await collectGitHubForRegisteredProjects({
       homeDir: options.homeDir,
-      codexHome: options.codexHome,
-      now: options.now ?? (() => new Date().toISOString()),
-      targetDate
+      targetDate: ghTargetDate,
+      now: options.now ?? (() => new Date().toISOString())
     });
-
-    if (result.codexLogsMissing) {
-      io.stdout("No Codex session logs found at ~/.codex/sessions. Skipping.");
-      return 0;
-    }
 
     if (result.successes.length > 0) {
       io.stdout(
-        `Collected Codex activity for ${formatProjectCount(result.successes.length)}.`
+        `Collected GitHub activity for ${formatProjectCount(result.successes.length)}.`
       );
       for (const success of result.successes) {
         io.stdout(
-          `${success.projectId}: ${success.signalCount} signals, ${success.conversationCount} turns, ${success.toolFactCount} tool facts.`
+          `${success.projectId}: ${success.signalCount} signals, ${success.rawCount} authored bodies.`
         );
       }
     }
-
+    for (const skip of result.skippedProjects) {
+      io.stdout(`${skip.projectId}: skipped (non-GitHub remote).`);
+    }
     for (const failure of result.failures) {
       io.stderr(`Failed to collect ${failure.projectId}: ${failure.message}`);
     }
-
     return result.failures.length > 0 ? 3 : 0;
   } catch (error) {
-    if (error instanceof CollectCodexCommandError) {
+    if (error instanceof CollectGitHubCommandError) {
       io.stderr(error.message);
-      return error.code === "invalid-projects-file" || error.code === "invalid-date" ? 2 : 3;
+      if (error.code === "invalid-projects-file") return 2;
+      if (error.code === "no-token") return 2;
+      if (error.code === "invalid-date") return 2;
+      return 3;
     }
     throw error;
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -903,56 +903,59 @@ async function runCollect(
     }
   }
 
-  // args[0] === "github"
-  const ghArgs = args.slice(1);
-  let ghTargetDate: string | undefined;
-  for (let i = 0; i < ghArgs.length; i++) {
-    if (ghArgs[i] === "--date") {
-      if (i + 1 >= ghArgs.length) {
-        io.stderr("Usage: uncommitted collect github [--date YYYY-MM-DD]");
-        return 1;
+  if (args[0] === "github") {
+    const ghArgs = args.slice(1);
+    let ghTargetDate: string | undefined;
+    for (let i = 0; i < ghArgs.length; i++) {
+      if (ghArgs[i] === "--date") {
+        if (i + 1 >= ghArgs.length) {
+          io.stderr("Usage: uncommitted collect github [--date YYYY-MM-DD]");
+          return 1;
+        }
+        ghTargetDate = ghArgs[++i];
+        continue;
       }
-      ghTargetDate = ghArgs[++i];
-      continue;
+      io.stderr("Usage: uncommitted collect github [--date YYYY-MM-DD]");
+      return 1;
     }
-    io.stderr("Usage: uncommitted collect github [--date YYYY-MM-DD]");
-    return 1;
-  }
 
-  try {
-    const result = await collectGitHubForRegisteredProjects({
-      homeDir: options.homeDir,
-      targetDate: ghTargetDate,
-      now: options.now ?? (() => new Date().toISOString())
-    });
+    try {
+      const result = await collectGitHubForRegisteredProjects({
+        homeDir: options.homeDir,
+        targetDate: ghTargetDate,
+        now: options.now ?? (() => new Date().toISOString())
+      });
 
-    if (result.successes.length > 0) {
-      io.stdout(
-        `Collected GitHub activity for ${formatProjectCount(result.successes.length)}.`
-      );
-      for (const success of result.successes) {
+      if (result.successes.length > 0) {
         io.stdout(
-          `${success.projectId}: ${success.signalCount} signals, ${success.rawCount} authored bodies.`
+          `Collected GitHub activity for ${formatProjectCount(result.successes.length)}.`
         );
+        for (const success of result.successes) {
+          io.stdout(
+            `${success.projectId}: ${success.signalCount} signals, ${success.rawCount} authored bodies.`
+          );
+        }
       }
+      for (const skip of result.skippedProjects) {
+        io.stdout(`${skip.projectId}: skipped (non-GitHub remote).`);
+      }
+      for (const failure of result.failures) {
+        io.stderr(`Failed to collect ${failure.projectId}: ${failure.message}`);
+      }
+      return result.failures.length > 0 ? 3 : 0;
+    } catch (error) {
+      if (error instanceof CollectGitHubCommandError) {
+        io.stderr(error.message);
+        if (error.code === "invalid-projects-file") return 2;
+        if (error.code === "no-token") return 2;
+        if (error.code === "invalid-date") return 2;
+        return 3;
+      }
+      throw error;
     }
-    for (const skip of result.skippedProjects) {
-      io.stdout(`${skip.projectId}: skipped (non-GitHub remote).`);
-    }
-    for (const failure of result.failures) {
-      io.stderr(`Failed to collect ${failure.projectId}: ${failure.message}`);
-    }
-    return result.failures.length > 0 ? 3 : 0;
-  } catch (error) {
-    if (error instanceof CollectGitHubCommandError) {
-      io.stderr(error.message);
-      if (error.code === "invalid-projects-file") return 2;
-      if (error.code === "no-token") return 2;
-      if (error.code === "invalid-date") return 2;
-      return 3;
-    }
-    throw error;
   }
+
+  return 1;
 }
 
 async function runNote(

--- a/src/collect-github-command.ts
+++ b/src/collect-github-command.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { homedir } from "node:os";
 import { promisify } from "node:util";
 import { resolveConfigPaths } from "./config-paths.js";
 import { readProjectsFile } from "./project-registry.js";
@@ -117,11 +118,8 @@ export async function collectGitHubForRegisteredProjects(
     targetDate = now.slice(0, 10);
   }
 
-  // resolveConfigPaths returns configDir = <homeDir>/.uncommitted; strip the
-  // suffix to recover the home dir the token resolver wants.
-  const homeDirForToken = paths.configDir.replace(/\/\.uncommitted$/, "");
   const resolved = await resolveGitHubToken({
-    homeDir: homeDirForToken,
+    homeDir: input.homeDir ?? homedir(),
     env: input.env
   });
   if (!resolved.token) {

--- a/src/collect-github-command.ts
+++ b/src/collect-github-command.ts
@@ -78,8 +78,18 @@ async function defaultRemoteUrlReader(projectRoot: string): Promise<string> {
       "origin"
     ]);
     return stdout.trim();
-  } catch {
-    return "";
+  } catch (error) {
+    // A repo that simply has no `origin` remote is a legitimate non-GitHub
+    // skip — return an empty URL. But a genuine command failure (path gone,
+    // not a Git repo, git unavailable) must surface so the project is reported
+    // as a failure instead of silently dropped from collection.
+    const stderr = (error as { stderr?: string }).stderr ?? "";
+    if (/no such remote/i.test(stderr)) {
+      return "";
+    }
+    const detail = (stderr.split("\n").find((line) => line.trim().length > 0) ??
+      (error instanceof Error ? error.message : "git remote read failed")).trim();
+    throw new Error(`Could not read git remote: ${detail}`, { cause: error });
   }
 }
 
@@ -134,7 +144,19 @@ export async function collectGitHubForRegisteredProjects(
     repo: string;
   }> = [];
   for (const project of projects) {
-    const remoteUrl = await remoteUrlReader(project.root);
+    let remoteUrl: string;
+    try {
+      remoteUrl = await remoteUrlReader(project.root);
+    } catch (error) {
+      // A broken project path or non-repo must not masquerade as a graceful
+      // non-GitHub skip; report it as a per-project failure.
+      failures.push({
+        projectId: project.id,
+        message:
+          error instanceof Error ? error.message : "Could not read git remote."
+      });
+      continue;
+    }
     const inferred = inferGitHubOriginRepo(remoteUrl);
     if (!inferred.isGitHub || !inferred.owner || !inferred.repo) {
       skippedProjects.push({

--- a/src/collect-github-command.ts
+++ b/src/collect-github-command.ts
@@ -1,5 +1,7 @@
 import { execFile } from "node:child_process";
+import { access } from "node:fs/promises";
 import { homedir } from "node:os";
+import { join } from "node:path";
 import { promisify } from "node:util";
 import { resolveConfigPaths } from "./config-paths.js";
 import { readProjectsFile } from "./project-registry.js";
@@ -118,22 +120,19 @@ export async function collectGitHubForRegisteredProjects(
     targetDate = now.slice(0, 10);
   }
 
-  const resolved = await resolveGitHubToken({
-    homeDir: input.homeDir ?? homedir(),
-    env: input.env
-  });
-  if (!resolved.token) {
-    throw new CollectGitHubCommandError(
-      "GITHUB_TOKEN not set and `githubToken` missing from config.",
-      "no-token"
-    );
-  }
-
   const remoteUrlReader = input.remoteUrlReader ?? defaultRemoteUrlReader;
   const successes: CollectGitHubSuccess[] = [];
   const failures: CollectGitHubFailure[] = [];
   const skippedProjects: CollectGitHubSkipped[] = [];
 
+  // Classify remotes before requiring a token: a workspace with only
+  // GitLab/local remotes has nothing to collect, so it should skip gracefully
+  // instead of failing with a config error the user can do nothing about.
+  const githubProjects: Array<{
+    project: (typeof projects)[number];
+    owner: string;
+    repo: string;
+  }> = [];
   for (const project of projects) {
     const remoteUrl = await remoteUrlReader(project.root);
     const inferred = inferGitHubOriginRepo(remoteUrl);
@@ -145,11 +144,34 @@ export async function collectGitHubForRegisteredProjects(
       });
       continue;
     }
+    githubProjects.push({
+      project,
+      owner: inferred.owner,
+      repo: inferred.repo
+    });
+  }
+
+  if (githubProjects.length === 0) {
+    return { targetDate, successes, failures, skippedProjects };
+  }
+
+  const resolved = await resolveGitHubToken({
+    homeDir: input.homeDir ?? homedir(),
+    env: input.env
+  });
+  if (!resolved.token) {
+    throw new CollectGitHubCommandError(
+      "GITHUB_TOKEN not set and `githubToken` missing from config.",
+      "no-token"
+    );
+  }
+
+  for (const { project, owner, repo } of githubProjects) {
     try {
       const fetched = await fetchGitHubActivity({
         token: resolved.token,
-        owner: inferred.owner,
-        repo: inferred.repo,
+        owner,
+        repo,
         targetDate,
         httpClient: input.httpClient,
         sleep: input.sleep
@@ -173,17 +195,32 @@ export async function collectGitHubForRegisteredProjects(
         rawCount: written.rawCount
       });
     } catch (error) {
-      // Flush empty canonical files so downstream readers can rely on the path
-      // contract even when a per-project fetch fails partway through.
-      try {
-        await writeGitHubEvents({
-          projectRoot: project.root,
-          targetDate,
-          signals: [],
-          ownAuthoredBodies: []
-        });
-      } catch {
-        // best effort
+      // On failure, never destroy a prior successful collection: if the
+      // canonical signal file already exists, leave it (and the raw archive)
+      // untouched. Only flush empty files on a first run so downstream readers
+      // can still rely on the path contract.
+      const signalsPath = join(
+        project.root,
+        ".uncommitted",
+        "events",
+        "github",
+        `${targetDate}.jsonl`
+      );
+      const hasExisting = await access(signalsPath).then(
+        () => true,
+        () => false
+      );
+      if (!hasExisting) {
+        try {
+          await writeGitHubEvents({
+            projectRoot: project.root,
+            targetDate,
+            signals: [],
+            ownAuthoredBodies: []
+          });
+        } catch {
+          // best effort
+        }
       }
       failures.push({
         projectId: project.id,

--- a/src/collect-github-command.ts
+++ b/src/collect-github-command.ts
@@ -1,0 +1,199 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { resolveConfigPaths } from "./config-paths.js";
+import { readProjectsFile } from "./project-registry.js";
+import { resolveGitHubToken } from "./github-token-resolver.js";
+import { inferGitHubOriginRepo } from "./github-repo-inference.js";
+import {
+  fetchGitHubActivity,
+  type HttpClient,
+  type Sleep
+} from "./github-fetcher.js";
+import { normalizeGitHubFetch } from "./github-event-normalizer.js";
+import { redactGitHubEvents } from "./github-event-redactor.js";
+import { writeGitHubEvents } from "./github-event-writer.js";
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const execFileP = promisify(execFile);
+
+export type CollectGitHubCommandErrorCode =
+  | "invalid-projects-file"
+  | "no-projects"
+  | "invalid-date"
+  | "no-token";
+
+export class CollectGitHubCommandError extends Error {
+  constructor(
+    message: string,
+    public readonly code: CollectGitHubCommandErrorCode
+  ) {
+    super(message);
+    this.name = "CollectGitHubCommandError";
+  }
+}
+
+export type CollectGitHubInput = {
+  homeDir?: string;
+  env?: Record<string, string | undefined>;
+  targetDate?: string;
+  now?: () => string;
+  httpClient?: HttpClient;
+  sleep?: Sleep;
+  remoteUrlReader?: (projectRoot: string) => Promise<string>;
+};
+
+export type CollectGitHubSuccess = {
+  projectId: string;
+  signalsFile: string;
+  rawArchiveFile: string;
+  signalCount: number;
+  rawCount: number;
+};
+
+export type CollectGitHubFailure = { projectId: string; message: string };
+
+export type CollectGitHubSkipped = {
+  projectId: string;
+  reason: "non-github-remote";
+  remoteUrl: string;
+};
+
+export type CollectGitHubResult = {
+  targetDate: string;
+  successes: CollectGitHubSuccess[];
+  failures: CollectGitHubFailure[];
+  skippedProjects: CollectGitHubSkipped[];
+};
+
+async function defaultRemoteUrlReader(projectRoot: string): Promise<string> {
+  try {
+    const { stdout } = await execFileP("git", [
+      "-C",
+      projectRoot,
+      "remote",
+      "get-url",
+      "origin"
+    ]);
+    return stdout.trim();
+  } catch {
+    return "";
+  }
+}
+
+export async function collectGitHubForRegisteredProjects(
+  input: CollectGitHubInput = {}
+): Promise<CollectGitHubResult> {
+  const paths = resolveConfigPaths({ homeDir: input.homeDir });
+  let projectsFile;
+  try {
+    projectsFile = await readProjectsFile(paths.projectsFile, {
+      missingAsEmpty: true
+    });
+  } catch {
+    throw new CollectGitHubCommandError(
+      "Invalid projects file.",
+      "invalid-projects-file"
+    );
+  }
+  const projects = projectsFile.projects.filter((p) => p.enabled);
+  if (projects.length === 0) {
+    throw new CollectGitHubCommandError(
+      "No registered projects. Run `uncommitted project add .` first.",
+      "no-projects"
+    );
+  }
+
+  let targetDate: string;
+  if (input.targetDate) {
+    if (!DATE_RE.test(input.targetDate)) {
+      throw new CollectGitHubCommandError(
+        "Invalid --date; expected YYYY-MM-DD.",
+        "invalid-date"
+      );
+    }
+    targetDate = input.targetDate;
+  } else {
+    const now = input.now ? input.now() : new Date().toISOString();
+    targetDate = now.slice(0, 10);
+  }
+
+  // resolveConfigPaths returns configDir = <homeDir>/.uncommitted; strip the
+  // suffix to recover the home dir the token resolver wants.
+  const homeDirForToken = paths.configDir.replace(/\/\.uncommitted$/, "");
+  const resolved = await resolveGitHubToken({
+    homeDir: homeDirForToken,
+    env: input.env
+  });
+  if (!resolved.token) {
+    throw new CollectGitHubCommandError(
+      "GITHUB_TOKEN not set and `githubToken` missing from config.",
+      "no-token"
+    );
+  }
+
+  const remoteUrlReader = input.remoteUrlReader ?? defaultRemoteUrlReader;
+  const successes: CollectGitHubSuccess[] = [];
+  const failures: CollectGitHubFailure[] = [];
+  const skippedProjects: CollectGitHubSkipped[] = [];
+
+  for (const project of projects) {
+    const remoteUrl = await remoteUrlReader(project.root);
+    const inferred = inferGitHubOriginRepo(remoteUrl);
+    if (!inferred.isGitHub || !inferred.owner || !inferred.repo) {
+      skippedProjects.push({
+        projectId: project.id,
+        reason: "non-github-remote",
+        remoteUrl
+      });
+      continue;
+    }
+    try {
+      const fetched = await fetchGitHubActivity({
+        token: resolved.token,
+        owner: inferred.owner,
+        repo: inferred.repo,
+        targetDate,
+        httpClient: input.httpClient,
+        sleep: input.sleep
+      });
+      const normalized = normalizeGitHubFetch({
+        projectId: project.id,
+        fetch: fetched
+      });
+      const redacted = redactGitHubEvents(normalized);
+      const written = await writeGitHubEvents({
+        projectRoot: project.root,
+        targetDate,
+        signals: redacted.signals,
+        ownAuthoredBodies: redacted.ownAuthoredBodies
+      });
+      successes.push({
+        projectId: project.id,
+        signalsFile: written.signalsFile,
+        rawArchiveFile: written.rawArchiveFile,
+        signalCount: written.signalCount,
+        rawCount: written.rawCount
+      });
+    } catch (error) {
+      // Flush empty canonical files so downstream readers can rely on the path
+      // contract even when a per-project fetch fails partway through.
+      try {
+        await writeGitHubEvents({
+          projectRoot: project.root,
+          targetDate,
+          signals: [],
+          ownAuthoredBodies: []
+        });
+      } catch {
+        // best effort
+      }
+      failures.push({
+        projectId: project.id,
+        message:
+          error instanceof Error ? error.message : "Collection failed."
+      });
+    }
+  }
+
+  return { targetDate, successes, failures, skippedProjects };
+}

--- a/src/generate-command.ts
+++ b/src/generate-command.ts
@@ -199,13 +199,15 @@ export async function runGenerateCommand(
   const manualNotes = await readManualNoteEvents(projects, targetDate);
   const claudeSignals = await readClaudeActivitySignals(projects, targetDate);
   const codexSignals = await readCodexActivitySignals(projects, targetDate);
+  const githubSignals = await readGitHubActivitySignals(projects, targetDate);
   const activitySummary = buildActivitySummary({
     targetDate,
     generatedAt,
     gitEvents,
     manualNotes,
     claudeSignals,
-    codexSignals
+    codexSignals,
+    githubSignals
   });
   const draftRevision = await runDraftStorageOperation(() =>
     createDraftRevision({
@@ -695,10 +697,17 @@ function readCodexActivitySignals(
   return readSessionActivitySignals(projects, targetDate, "codex");
 }
 
+function readGitHubActivitySignals(
+  projects: ProjectRecord[],
+  targetDate: string
+): Promise<ActivitySignal[]> {
+  return readSessionActivitySignals(projects, targetDate, "github");
+}
+
 async function readSessionActivitySignals(
   projects: ProjectRecord[],
   targetDate: string,
-  source: "claude" | "codex"
+  source: "claude" | "codex" | "github"
 ): Promise<ActivitySignal[]> {
   const signals: ActivitySignal[] = [];
 

--- a/src/github-event-normalizer.ts
+++ b/src/github-event-normalizer.ts
@@ -28,7 +28,7 @@ function trim(s: string): string {
 export function normalizeGitHubFetch(input: NormalizeInput): NormalizedGitHub {
   const signals: ActivitySignal[] = [];
   const bodies: OwnAuthoredBody[] = [];
-  const me = input.fetch.authenticatedLogin;
+  const me = input.fetch.authenticatedLogin.toLowerCase();
   const visibility = input.fetch.visibility;
 
   for (const pr of input.fetch.mergedPRs) {
@@ -39,7 +39,7 @@ export function normalizeGitHubFetch(input: NormalizeInput): NormalizedGitHub {
       summary: trim(`PR #${pr.number} merged: ${pr.title}`),
       safetyNotes: []
     });
-    if (pr.authorLogin === me && pr.body) {
+    if (pr.authorLogin.toLowerCase() === me && pr.body) {
       bodies.push({ source: "pr-body", number: pr.number, visibility, text: pr.body, timestamp: pr.mergedAt });
     }
   }
@@ -52,7 +52,7 @@ export function normalizeGitHubFetch(input: NormalizeInput): NormalizedGitHub {
       summary: trim(`Issue #${issue.number} closed: ${issue.title}`),
       safetyNotes: []
     });
-    if (issue.authorLogin === me && issue.body) {
+    if (issue.authorLogin.toLowerCase() === me && issue.body) {
       bodies.push({ source: "issue-body", number: issue.number, visibility, text: issue.body, timestamp: issue.closedAt });
     }
   }
@@ -65,7 +65,7 @@ export function normalizeGitHubFetch(input: NormalizeInput): NormalizedGitHub {
       summary: trim(`Review ${review.state} on PR #${review.prNumber}`),
       safetyNotes: []
     });
-    if (review.authorLogin === me && review.body) {
+    if (review.authorLogin.toLowerCase() === me && review.body) {
       bodies.push({
         source: "review-comment",
         number: review.prNumber,

--- a/src/github-event-normalizer.ts
+++ b/src/github-event-normalizer.ts
@@ -51,7 +51,8 @@ export function normalizeGitHubFetch(input: NormalizeInput): NormalizedGitHub {
   }
 
   for (const issue of input.fetch.closedIssues) {
-    if (issue.authorLogin.toLowerCase() !== me) continue;
+    // Attribute on the closer: only signal issues the authenticated user closed.
+    if (issue.closedByLogin.toLowerCase() !== me) continue;
     signals.push({
       projectId: input.projectId,
       timestamp: issue.closedAt,

--- a/src/github-event-normalizer.ts
+++ b/src/github-event-normalizer.ts
@@ -31,7 +31,13 @@ export function normalizeGitHubFetch(input: NormalizeInput): NormalizedGitHub {
   const me = input.fetch.authenticatedLogin.toLowerCase();
   const visibility = input.fetch.visibility;
 
+  // Only the authenticated user's own activity becomes a diary signal. The
+  // repo/date search returns every teammate's merged PR, closed issue, and
+  // review on the date, so emitting a signal per item would invent work the
+  // user never did. Author comparison is case-insensitive to survive login
+  // case drift, matching the own-body gate.
   for (const pr of input.fetch.mergedPRs) {
+    if (pr.authorLogin.toLowerCase() !== me) continue;
     signals.push({
       projectId: input.projectId,
       timestamp: pr.mergedAt,
@@ -39,12 +45,13 @@ export function normalizeGitHubFetch(input: NormalizeInput): NormalizedGitHub {
       summary: trim(`PR #${pr.number} merged: ${pr.title}`),
       safetyNotes: []
     });
-    if (pr.authorLogin.toLowerCase() === me && pr.body) {
+    if (pr.body) {
       bodies.push({ source: "pr-body", number: pr.number, visibility, text: pr.body, timestamp: pr.mergedAt });
     }
   }
 
   for (const issue of input.fetch.closedIssues) {
+    if (issue.authorLogin.toLowerCase() !== me) continue;
     signals.push({
       projectId: input.projectId,
       timestamp: issue.closedAt,
@@ -52,12 +59,13 @@ export function normalizeGitHubFetch(input: NormalizeInput): NormalizedGitHub {
       summary: trim(`Issue #${issue.number} closed: ${issue.title}`),
       safetyNotes: []
     });
-    if (issue.authorLogin.toLowerCase() === me && issue.body) {
+    if (issue.body) {
       bodies.push({ source: "issue-body", number: issue.number, visibility, text: issue.body, timestamp: issue.closedAt });
     }
   }
 
   for (const review of input.fetch.reviews) {
+    if (review.authorLogin.toLowerCase() !== me) continue;
     signals.push({
       projectId: input.projectId,
       timestamp: review.submittedAt,
@@ -65,7 +73,7 @@ export function normalizeGitHubFetch(input: NormalizeInput): NormalizedGitHub {
       summary: trim(`Review ${review.state} on PR #${review.prNumber}`),
       safetyNotes: []
     });
-    if (review.authorLogin.toLowerCase() === me && review.body) {
+    if (review.body) {
       bodies.push({
         source: "review-comment",
         number: review.prNumber,

--- a/src/github-event-normalizer.ts
+++ b/src/github-event-normalizer.ts
@@ -1,0 +1,80 @@
+import type { ActivitySignal } from "./event-source.js";
+import type { GitHubFetchResult, RepoVisibility } from "./github-fetcher.js";
+
+export type OwnAuthoredBody = {
+  source: "pr-body" | "issue-body" | "review-comment";
+  number: number;
+  visibility: RepoVisibility;
+  text: string;
+  timestamp: string;
+};
+
+export type NormalizedGitHub = {
+  signals: ActivitySignal[];
+  ownAuthoredBodies: OwnAuthoredBody[];
+};
+
+export type NormalizeInput = {
+  projectId: string;
+  fetch: GitHubFetchResult;
+};
+
+const SUMMARY_LIMIT = 200;
+
+function trim(s: string): string {
+  return s.length > SUMMARY_LIMIT ? s.slice(0, SUMMARY_LIMIT) : s;
+}
+
+export function normalizeGitHubFetch(input: NormalizeInput): NormalizedGitHub {
+  const signals: ActivitySignal[] = [];
+  const bodies: OwnAuthoredBody[] = [];
+  const me = input.fetch.authenticatedLogin;
+  const visibility = input.fetch.visibility;
+
+  for (const pr of input.fetch.mergedPRs) {
+    signals.push({
+      projectId: input.projectId,
+      timestamp: pr.mergedAt,
+      kind: "pr",
+      summary: trim(`PR #${pr.number} merged: ${pr.title}`),
+      safetyNotes: []
+    });
+    if (pr.authorLogin === me && pr.body) {
+      bodies.push({ source: "pr-body", number: pr.number, visibility, text: pr.body, timestamp: pr.mergedAt });
+    }
+  }
+
+  for (const issue of input.fetch.closedIssues) {
+    signals.push({
+      projectId: input.projectId,
+      timestamp: issue.closedAt,
+      kind: "issue",
+      summary: trim(`Issue #${issue.number} closed: ${issue.title}`),
+      safetyNotes: []
+    });
+    if (issue.authorLogin === me && issue.body) {
+      bodies.push({ source: "issue-body", number: issue.number, visibility, text: issue.body, timestamp: issue.closedAt });
+    }
+  }
+
+  for (const review of input.fetch.reviews) {
+    signals.push({
+      projectId: input.projectId,
+      timestamp: review.submittedAt,
+      kind: "review",
+      summary: trim(`Review ${review.state} on PR #${review.prNumber}`),
+      safetyNotes: []
+    });
+    if (review.authorLogin === me && review.body) {
+      bodies.push({
+        source: "review-comment",
+        number: review.prNumber,
+        visibility,
+        text: review.body,
+        timestamp: review.submittedAt
+      });
+    }
+  }
+
+  return { signals, ownAuthoredBodies: bodies };
+}

--- a/src/github-event-redactor.ts
+++ b/src/github-event-redactor.ts
@@ -1,0 +1,95 @@
+import type {
+  NormalizedGitHub,
+  OwnAuthoredBody
+} from "./github-event-normalizer.js";
+import type { ActivitySignal } from "./event-source.js";
+import {
+  REDACTION_CATEGORY_ORDER,
+  sanitizeText,
+  type RedactionCategory
+} from "./redaction.js";
+import {
+  detectSecrets,
+  SECRET_CATEGORY_ORDER,
+  type SecretCategory
+} from "./credential-detector.js";
+
+export type GitHubRedactionCategory = RedactionCategory | SecretCategory;
+
+export type RedactedGitHubEvents = {
+  signals: ActivitySignal[];
+  ownAuthoredBodies: OwnAuthoredBody[];
+  appliedCategories: GitHubRedactionCategory[];
+};
+
+const COMBINED_ORDER: GitHubRedactionCategory[] = [
+  ...SECRET_CATEGORY_ORDER,
+  ...REDACTION_CATEGORY_ORDER
+];
+
+// Mirror the codex adapter: catch SSH-style git URLs before the email
+// regex eats them.
+const SSH_GIT_URL = /\b[\w.-]{1,64}@[\w.-]{1,253}:[^\s]{1,4096}/g;
+
+function sortCategories(
+  set: Set<GitHubRedactionCategory>
+): GitHubRedactionCategory[] {
+  return COMBINED_ORDER.filter((c) => set.has(c));
+}
+
+function redactString(
+  value: string,
+  visibility: "public" | "private"
+): { value: string; categories: GitHubRedactionCategory[] } {
+  const secretPass = detectSecrets(value);
+  let working = secretPass.value;
+
+  const preUrlCategories = new Set<GitHubRedactionCategory>();
+  if (SSH_GIT_URL.test(working)) {
+    preUrlCategories.add("private URLs");
+    SSH_GIT_URL.lastIndex = 0;
+    working = working.replace(SSH_GIT_URL, "[redacted-url]");
+  }
+
+  const textPass = sanitizeText(working);
+  let finalText = textPass.value;
+  const all = new Set<GitHubRedactionCategory>([
+    ...secretPass.categories,
+    ...preUrlCategories,
+    ...textPass.categories
+  ]);
+
+  if (visibility === "private") {
+    const second = detectSecrets(finalText);
+    finalText = second.value;
+    second.categories.forEach((c) => all.add(c));
+  }
+
+  return { value: finalText, categories: sortCategories(all) };
+}
+
+export function redactGitHubEvents(
+  input: NormalizedGitHub
+): RedactedGitHubEvents {
+  const aggregate = new Set<GitHubRedactionCategory>();
+
+  const signals: ActivitySignal[] = input.signals.map((sig) => {
+    const r = redactString(sig.summary, "public");
+    r.categories.forEach((c) => aggregate.add(c));
+    return { ...sig, summary: r.value, safetyNotes: r.categories };
+  });
+
+  const ownAuthoredBodies: OwnAuthoredBody[] = input.ownAuthoredBodies.map(
+    (body) => {
+      const r = redactString(body.text, body.visibility);
+      r.categories.forEach((c) => aggregate.add(c));
+      return { ...body, text: r.value };
+    }
+  );
+
+  return {
+    signals,
+    ownAuthoredBodies,
+    appliedCategories: sortCategories(aggregate)
+  };
+}

--- a/src/github-event-writer.ts
+++ b/src/github-event-writer.ts
@@ -45,8 +45,12 @@ export async function writeGitHubEvents(input: GitHubWriteInput): Promise<GitHub
     ? input.ownAuthoredBodies.map((b) => JSON.stringify(b)).join("\n") + "\n"
     : "";
 
-  await atomicWrite(signalsFile, signalsBody);
+  // Write the raw archive first so the canonical signal file is only replaced
+  // after the raw write (and its chmod) succeed. Otherwise a raw-write failure
+  // could overwrite a previous good signal file while leaving a stale/missing
+  // raw archive, breaking the failure contract for disk/permission errors.
   await atomicWrite(rawArchiveFile, rawBody, 0o600);
+  await atomicWrite(signalsFile, signalsBody);
 
   return {
     signalsFile,

--- a/src/github-event-writer.ts
+++ b/src/github-event-writer.ts
@@ -1,0 +1,57 @@
+import { chmod, mkdir, rename, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { ActivitySignal } from "./event-source.js";
+import type { OwnAuthoredBody } from "./github-event-normalizer.js";
+
+export type GitHubWriteInput = {
+  projectRoot: string;
+  targetDate: string;
+  signals: ActivitySignal[];
+  ownAuthoredBodies: OwnAuthoredBody[];
+};
+
+export type GitHubWriteResult = {
+  signalsFile: string;
+  rawArchiveFile: string;
+  signalCount: number;
+  rawCount: number;
+};
+
+async function atomicWrite(path: string, body: string, mode?: number): Promise<void> {
+  const tmp = `${path}.tmp`;
+  await writeFile(
+    tmp,
+    body,
+    mode === undefined ? { encoding: "utf8" } : { encoding: "utf8", mode }
+  );
+  await rename(tmp, path);
+  // chmod after rename ensures the mode invariant survives even when overwriting an existing file
+  // (the mode option on writeFile only applies when creating a new file).
+  if (mode !== undefined) await chmod(path, mode);
+}
+
+export async function writeGitHubEvents(input: GitHubWriteInput): Promise<GitHubWriteResult> {
+  const baseDir = join(input.projectRoot, ".uncommitted", "events", "github");
+  const rawDir = join(baseDir, "raw");
+  await mkdir(rawDir, { recursive: true });
+
+  const signalsFile = join(baseDir, `${input.targetDate}.jsonl`);
+  const rawArchiveFile = join(rawDir, `${input.targetDate}.jsonl`);
+
+  const signalsBody = input.signals.length
+    ? input.signals.map((s) => JSON.stringify(s)).join("\n") + "\n"
+    : "";
+  const rawBody = input.ownAuthoredBodies.length
+    ? input.ownAuthoredBodies.map((b) => JSON.stringify(b)).join("\n") + "\n"
+    : "";
+
+  await atomicWrite(signalsFile, signalsBody);
+  await atomicWrite(rawArchiveFile, rawBody, 0o600);
+
+  return {
+    signalsFile,
+    rawArchiveFile,
+    signalCount: input.signals.length,
+    rawCount: input.ownAuthoredBodies.length
+  };
+}

--- a/src/github-fetcher.ts
+++ b/src/github-fetcher.ts
@@ -54,6 +54,19 @@ export class RateLimitedError extends Error {
 
 const API = "https://api.github.com";
 
+// GitHub signals rate limiting with 429, or 403 accompanied by an exhausted
+// quota (`x-ratelimit-remaining: 0`) or a `retry-after` header. A bare 403
+// (missing scope, no access to a private repo) is an authorization problem and
+// must surface as a normal HTTP error instead of a misleading rate-limit retry.
+function isRateLimited(res: Response): boolean {
+  if (res.status === 429) return true;
+  if (res.status !== 403) return false;
+  return (
+    res.headers.get("retry-after") !== null ||
+    res.headers.get("x-ratelimit-remaining") === "0"
+  );
+}
+
 export async function fetchGitHubActivity(
   input: FetchGitHubActivityInput
 ): Promise<GitHubFetchResult> {
@@ -69,10 +82,10 @@ export async function fetchGitHubActivity(
       "User-Agent": "uncommitted-collector"
     };
     let res = await http(url, { headers });
-    if (res.status === 403 || res.status === 429) {
+    if (isRateLimited(res)) {
       await sleep(1500);
       res = await http(url, { headers });
-      if (res.status === 403 || res.status === 429) {
+      if (isRateLimited(res)) {
         throw new RateLimitedError();
       }
     }

--- a/src/github-fetcher.ts
+++ b/src/github-fetcher.ts
@@ -1,0 +1,154 @@
+export type HttpClient = (url: string, init?: RequestInit) => Promise<Response>;
+export type Sleep = (ms: number) => Promise<void>;
+
+export type RepoVisibility = "public" | "private";
+
+export type FetchedPR = {
+  number: number;
+  title: string;
+  body: string;
+  authorLogin: string;
+  mergedAt: string;
+};
+
+export type FetchedIssue = {
+  number: number;
+  title: string;
+  body: string;
+  authorLogin: string;
+  closedAt: string;
+};
+
+export type FetchedReview = {
+  id: number;
+  prNumber: number;
+  state: string;
+  submittedAt: string;
+  authorLogin: string;
+  body: string;
+};
+
+export type GitHubFetchResult = {
+  visibility: RepoVisibility;
+  authenticatedLogin: string;
+  mergedPRs: FetchedPR[];
+  closedIssues: FetchedIssue[];
+  reviews: FetchedReview[];
+};
+
+export type FetchGitHubActivityInput = {
+  token: string;
+  owner: string;
+  repo: string;
+  targetDate: string;
+  httpClient?: HttpClient;
+  sleep?: Sleep;
+};
+
+export class RateLimitedError extends Error {
+  constructor(message = "GitHub rate limit hit twice in a row.") {
+    super(message);
+    this.name = "RateLimitedError";
+  }
+}
+
+const API = "https://api.github.com";
+
+export async function fetchGitHubActivity(
+  input: FetchGitHubActivityInput
+): Promise<GitHubFetchResult> {
+  const http = input.httpClient ?? ((url, init) => fetch(url, init));
+  const sleep = input.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
+
+  const get = async <T>(path: string): Promise<T> => {
+    const url = `${API}${path}`;
+    const headers: HeadersInit = {
+      Authorization: `Bearer ${input.token}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "User-Agent": "uncommitted-collector"
+    };
+    let res = await http(url, { headers });
+    if (res.status === 403 || res.status === 429) {
+      await sleep(1500);
+      res = await http(url, { headers });
+      if (res.status === 403 || res.status === 429) {
+        throw new RateLimitedError();
+      }
+    }
+    if (!res.ok) {
+      throw new Error(`GitHub ${path} → ${res.status}`);
+    }
+    return (await res.json()) as T;
+  };
+
+  const me = await get<{ login: string }>("/user");
+  const repoInfo = await get<{ private: boolean }>(`/repos/${input.owner}/${input.repo}`);
+  const visibility: RepoVisibility = repoInfo.private ? "private" : "public";
+
+  const prSearch = await get<{ items: GHIssueLike[] }>(
+    `/search/issues?q=${encodeURIComponent(
+      `repo:${input.owner}/${input.repo} is:pr is:merged merged:${input.targetDate}`
+    )}&per_page=100`
+  );
+  const mergedPRs: FetchedPR[] = prSearch.items
+    .filter((it) => it.pull_request)
+    .map((it) => ({
+      number: it.number,
+      title: it.title ?? "",
+      body: typeof it.body === "string" ? it.body : "",
+      authorLogin: it.user?.login ?? "",
+      mergedAt: it.pull_request?.merged_at ?? it.closed_at ?? ""
+    }));
+
+  const issueSearch = await get<{ items: GHIssueLike[] }>(
+    `/search/issues?q=${encodeURIComponent(
+      `repo:${input.owner}/${input.repo} is:issue is:closed closed:${input.targetDate}`
+    )}&per_page=100`
+  );
+  const closedIssues: FetchedIssue[] = issueSearch.items
+    .filter((it) => !it.pull_request)
+    .map((it) => ({
+      number: it.number,
+      title: it.title ?? "",
+      body: typeof it.body === "string" ? it.body : "",
+      authorLogin: it.user?.login ?? "",
+      closedAt: it.closed_at ?? ""
+    }));
+
+  const reviews: FetchedReview[] = [];
+  for (const pr of mergedPRs) {
+    const list = await get<GHReview[]>(`/repos/${input.owner}/${input.repo}/pulls/${pr.number}/reviews`);
+    for (const r of list) {
+      if (!r.submitted_at || !r.submitted_at.startsWith(input.targetDate)) continue;
+      reviews.push({
+        id: r.id,
+        prNumber: pr.number,
+        state: r.state ?? "",
+        submittedAt: r.submitted_at,
+        authorLogin: r.user?.login ?? "",
+        body: typeof r.body === "string" ? r.body : ""
+      });
+    }
+  }
+
+  return { visibility, authenticatedLogin: me.login, mergedPRs, closedIssues, reviews };
+}
+
+type GHIssueLike = {
+  number: number;
+  title?: string;
+  body?: string | null;
+  state?: string;
+  closed_at?: string;
+  pull_request?: { merged_at?: string };
+  user?: { login?: string };
+};
+
+type GHReview = {
+  id: number;
+  state?: string;
+  submitted_at?: string;
+  body?: string | null;
+  user?: { login?: string };
+};

--- a/src/github-fetcher.ts
+++ b/src/github-fetcher.ts
@@ -164,9 +164,24 @@ export async function fetchGitHubActivity(
     if (it.pull_request) reviewCandidatePRs.add(it.number);
   }
 
+  // The reviews endpoint defaults to 30 per page, so a PR with many reviews
+  // would silently drop the user's review past the first page. Page through it
+  // the same way the search calls do, stopping at the first short page.
+  const listReviews = async (prNumber: number): Promise<GHReview[]> => {
+    const all: GHReview[] = [];
+    for (let page = 1; ; page++) {
+      const batch = await get<GHReview[]>(
+        `/repos/${input.owner}/${input.repo}/pulls/${prNumber}/reviews?per_page=${PER_PAGE}&page=${page}`
+      );
+      all.push(...batch);
+      if (batch.length < PER_PAGE) break;
+    }
+    return all;
+  };
+
   const reviews: FetchedReview[] = [];
   for (const prNumber of reviewCandidatePRs) {
-    const list = await get<GHReview[]>(`/repos/${input.owner}/${input.repo}/pulls/${prNumber}/reviews`);
+    const list = await listReviews(prNumber);
     for (const r of list) {
       if (!r.submitted_at || !r.submitted_at.startsWith(input.targetDate)) continue;
       reviews.push({

--- a/src/github-fetcher.ts
+++ b/src/github-fetcher.ts
@@ -53,6 +53,9 @@ export class RateLimitedError extends Error {
 }
 
 const API = "https://api.github.com";
+const PER_PAGE = 100;
+// GitHub search exposes at most 1000 results (10 pages of 100).
+const SEARCH_PAGE_CAP = 10;
 
 // GitHub signals rate limiting with 429, or 403 accompanied by an exhausted
 // quota (`x-ratelimit-remaining: 0`) or a `retry-after` header. A bare 403
@@ -95,16 +98,28 @@ export async function fetchGitHubActivity(
     return (await res.json()) as T;
   };
 
+  // Search returns at most 100 items per page (1000 results total). Page through
+  // every page so high-activity days are not silently truncated to the first 100.
+  const searchAll = async (query: string): Promise<GHIssueLike[]> => {
+    const items: GHIssueLike[] = [];
+    for (let page = 1; page <= SEARCH_PAGE_CAP; page++) {
+      const res = await get<{ items?: GHIssueLike[] }>(
+        `/search/issues?q=${encodeURIComponent(query)}&per_page=${PER_PAGE}&page=${page}`
+      );
+      const batch = res.items ?? [];
+      items.push(...batch);
+      if (batch.length < PER_PAGE) break;
+    }
+    return items;
+  };
+
   const me = await get<{ login: string }>("/user");
   const repoInfo = await get<{ private: boolean }>(`/repos/${input.owner}/${input.repo}`);
   const visibility: RepoVisibility = repoInfo.private ? "private" : "public";
+  const repoQ = `repo:${input.owner}/${input.repo}`;
 
-  const prSearch = await get<{ items: GHIssueLike[] }>(
-    `/search/issues?q=${encodeURIComponent(
-      `repo:${input.owner}/${input.repo} is:pr is:merged merged:${input.targetDate}`
-    )}&per_page=100`
-  );
-  const mergedPRs: FetchedPR[] = prSearch.items
+  const prItems = await searchAll(`${repoQ} is:pr is:merged merged:${input.targetDate}`);
+  const mergedPRs: FetchedPR[] = prItems
     .filter((it) => it.pull_request)
     .map((it) => ({
       number: it.number,
@@ -114,12 +129,8 @@ export async function fetchGitHubActivity(
       mergedAt: it.pull_request?.merged_at ?? it.closed_at ?? ""
     }));
 
-  const issueSearch = await get<{ items: GHIssueLike[] }>(
-    `/search/issues?q=${encodeURIComponent(
-      `repo:${input.owner}/${input.repo} is:issue is:closed closed:${input.targetDate}`
-    )}&per_page=100`
-  );
-  const closedIssues: FetchedIssue[] = issueSearch.items
+  const issueItems = await searchAll(`${repoQ} is:issue is:closed closed:${input.targetDate}`);
+  const closedIssues: FetchedIssue[] = issueItems
     .filter((it) => !it.pull_request)
     .map((it) => ({
       number: it.number,
@@ -129,14 +140,26 @@ export async function fetchGitHubActivity(
       closedAt: it.closed_at ?? ""
     }));
 
+  // A review submitted on the target date does not imply the PR was merged that
+  // day, so the same-day merged-PR set misses reviews on still-open or
+  // earlier/later-merged PRs. Discover candidate PRs the user reviewed and that
+  // were touched on the date, then union with merged PRs before fetching reviews.
+  const reviewCandidatePRs = new Set<number>(mergedPRs.map((pr) => pr.number));
+  const reviewedItems = await searchAll(
+    `${repoQ} is:pr reviewed-by:${me.login} updated:${input.targetDate}`
+  );
+  for (const it of reviewedItems) {
+    if (it.pull_request) reviewCandidatePRs.add(it.number);
+  }
+
   const reviews: FetchedReview[] = [];
-  for (const pr of mergedPRs) {
-    const list = await get<GHReview[]>(`/repos/${input.owner}/${input.repo}/pulls/${pr.number}/reviews`);
+  for (const prNumber of reviewCandidatePRs) {
+    const list = await get<GHReview[]>(`/repos/${input.owner}/${input.repo}/pulls/${prNumber}/reviews`);
     for (const r of list) {
       if (!r.submitted_at || !r.submitted_at.startsWith(input.targetDate)) continue;
       reviews.push({
         id: r.id,
-        prNumber: pr.number,
+        prNumber,
         state: r.state ?? "",
         submittedAt: r.submitted_at,
         authorLogin: r.user?.login ?? "",

--- a/src/github-fetcher.ts
+++ b/src/github-fetcher.ts
@@ -15,7 +15,10 @@ export type FetchedIssue = {
   number: number;
   title: string;
   body: string;
-  authorLogin: string;
+  // The login of whoever closed the issue (not the opener). Closing is the
+  // activity a diary signal attributes, so the opener's identity would mis-fire
+  // the signal when opener and closer differ. Empty when the closer is unknown.
+  closedByLogin: string;
   closedAt: string;
 };
 
@@ -129,16 +132,25 @@ export async function fetchGitHubActivity(
       mergedAt: it.pull_request?.merged_at ?? it.closed_at ?? ""
     }));
 
-  const issueItems = await searchAll(`${repoQ} is:issue is:closed closed:${input.targetDate}`);
-  const closedIssues: FetchedIssue[] = issueItems
-    .filter((it) => !it.pull_request)
-    .map((it) => ({
+  // Issue search reports the opener (`user`), not who closed it. Fetch each
+  // issue so the closer (`closed_by`) drives signal attribution; otherwise an
+  // issue the user opened but a teammate closed (or vice versa) would invent or
+  // omit a "closed" diary signal. An unknown closer stays empty and is dropped.
+  const issueItems = (await searchAll(`${repoQ} is:issue is:closed closed:${input.targetDate}`))
+    .filter((it) => !it.pull_request);
+  const closedIssues: FetchedIssue[] = [];
+  for (const it of issueItems) {
+    const detail = await get<{ closed_by?: { login?: string } }>(
+      `/repos/${input.owner}/${input.repo}/issues/${it.number}`
+    );
+    closedIssues.push({
       number: it.number,
       title: it.title ?? "",
       body: typeof it.body === "string" ? it.body : "",
-      authorLogin: it.user?.login ?? "",
+      closedByLogin: detail.closed_by?.login ?? "",
       closedAt: it.closed_at ?? ""
-    }));
+    });
+  }
 
   // A review submitted on the target date does not imply the PR was merged that
   // day, so the same-day merged-PR set misses reviews on still-open or

--- a/src/github-repo-inference.ts
+++ b/src/github-repo-inference.ts
@@ -5,7 +5,7 @@ export type InferredRepo = {
   isGitHub: boolean;
 };
 
-const HTTPS = /^https?:\/\/([^/]+)\/([^/]+)\/([^/?#]+?)(?:\.git)?(?:[/?#]|$)/i;
+const HTTPS = /^https?:\/\/(?:[^/@]+@)?([^/]+)\/([^/]+)\/([^/?#]+?)(?:\.git)?(?:[/?#]|$)/i;
 const SSH = /^git@([^:]+):([^/]+)\/([^/?#]+?)(?:\.git)?(?:[/?#]|$)/i;
 const GIT_SSH = /^(?:git\+)?ssh:\/\/git@([^/]+)\/([^/]+)\/([^/?#]+?)(?:\.git)?(?:[/?#]|$)/i;
 
@@ -17,7 +17,7 @@ export function inferGitHubOriginRepo(remoteUrl: string): InferredRepo {
     if (m) {
       const [, host, owner, repo] = m;
       return {
-        host,
+        host: host.toLowerCase(),
         owner,
         repo,
         isGitHub: host.toLowerCase() === "github.com"

--- a/src/github-repo-inference.ts
+++ b/src/github-repo-inference.ts
@@ -1,0 +1,28 @@
+export type InferredRepo = {
+  host: string | null;
+  owner: string | null;
+  repo: string | null;
+  isGitHub: boolean;
+};
+
+const HTTPS = /^https?:\/\/([^/]+)\/([^/]+)\/([^/?#]+?)(?:\.git)?(?:[/?#]|$)/i;
+const SSH = /^git@([^:]+):([^/]+)\/([^/?#]+?)(?:\.git)?(?:[/?#]|$)/i;
+const GIT_SSH = /^(?:git\+)?ssh:\/\/git@([^/]+)\/([^/]+)\/([^/?#]+?)(?:\.git)?(?:[/?#]|$)/i;
+
+export function inferGitHubOriginRepo(remoteUrl: string): InferredRepo {
+  const empty: InferredRepo = { host: null, owner: null, repo: null, isGitHub: false };
+  if (!remoteUrl) return empty;
+  for (const re of [HTTPS, SSH, GIT_SSH]) {
+    const m = re.exec(remoteUrl);
+    if (m) {
+      const [, host, owner, repo] = m;
+      return {
+        host,
+        owner,
+        repo,
+        isGitHub: host.toLowerCase() === "github.com"
+      };
+    }
+  }
+  return empty;
+}

--- a/src/github-token-resolver.ts
+++ b/src/github-token-resolver.ts
@@ -1,0 +1,41 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+export type ResolvedGitHubToken = {
+  token: string | null;
+  source: "env" | "config" | "missing";
+};
+
+export type ResolveGitHubTokenInput = {
+  homeDir: string;
+  env?: Record<string, string | undefined>;
+};
+
+export async function resolveGitHubToken(
+  input: ResolveGitHubTokenInput
+): Promise<ResolvedGitHubToken> {
+  const env = input.env ?? process.env;
+  const envToken = env.GITHUB_TOKEN;
+  if (typeof envToken === "string" && envToken.length > 0) {
+    return { token: envToken, source: "env" };
+  }
+  const configPath = join(input.homeDir, ".uncommitted", "config.json");
+  try {
+    const raw = await readFile(configPath, "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      typeof (parsed as { githubToken?: unknown }).githubToken === "string" &&
+      (parsed as { githubToken: string }).githubToken.length > 0
+    ) {
+      return {
+        token: (parsed as { githubToken: string }).githubToken,
+        source: "config"
+      };
+    }
+  } catch {
+    // Missing / unreadable / invalid JSON → fall through to "missing".
+  }
+  return { token: null, source: "missing" };
+}

--- a/src/safety-report.ts
+++ b/src/safety-report.ts
@@ -86,7 +86,7 @@ const detectionRules: DetectionRule[] = [
     replacement: "[redacted-repo-url]",
     message: "Private repository remote was redacted.",
     pattern:
-      /\bgit@[\w.-]+:[^\s]+|(?:https?|ssh|git):\/\/(?:[^/\s]+@)?(?:github\.com|gitlab\.com|bitbucket\.org|[\w.-]+)[:/][^\s]+\.git\b/gi
+      /\bgit@[\w.-]+:[^\s]+|(?:git\+)?(?:https?|ssh|git):\/\/(?:[^/\s]+@)?(?:github\.com|gitlab\.com|bitbucket\.org|[\w.-]+)[:/][^\s]+\.git\b/gi
   },
   {
     category: "private-url",

--- a/tests/activity-summary.test.ts
+++ b/tests/activity-summary.test.ts
@@ -461,6 +461,34 @@ describe("activity summary — Claude signal wiring (UNC-117)", () => {
     );
   });
 
+  it("seeds a project summary from a GitHub-only project day", () => {
+    const summary = buildActivitySummary(
+      createInput({
+        githubSignals: [
+          {
+            projectId: "cli",
+            timestamp: "2026-05-12T10:00:00.000Z",
+            kind: "pr",
+            summary: "PR #1 merged: add collector",
+            safetyNotes: []
+          },
+          {
+            projectId: "cli",
+            timestamp: "2026-05-12T11:00:00.000Z",
+            kind: "review",
+            summary: "Review APPROVED on PR #2",
+            safetyNotes: []
+          }
+        ]
+      })
+    );
+
+    expect(summary.activityLevel).not.toBe("none");
+    const cli = summary.projects.find((p) => p.projectId === "cli");
+    expect(cli).toBeDefined();
+    expect(cli?.summary).toContain("2 GitHub events");
+  });
+
   it("ignores Claude signals from other dates", () => {
     const summary = buildActivitySummary(
       createInput({

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -65,7 +65,7 @@ describe("cli", () => {
 
     expect(exitCode).toBe(1);
     expect(stdout).toEqual([]);
-    expect(stderr.join("\n")).toContain("Usage: uncommitted collect <git|claude|codex>");
+    expect(stderr.join("\n")).toContain("Usage: uncommitted collect <git|claude|codex|github>");
   });
 
   it("rejects extra arguments for collect git instead of silently ignoring them", async () => {
@@ -106,6 +106,26 @@ describe("cli", () => {
     expect(exitCode).toBe(1);
     expect(stdout).toEqual([]);
     expect(stderr.join("\n")).toContain("Usage: uncommitted collect codex");
+  });
+
+  it("rejects extra args after `collect github`", async () => {
+    const { io, stdout, stderr } = createIo();
+
+    const exitCode = await runCli(["collect", "github", "unexpected"], io);
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toEqual([]);
+    expect(stderr.join("\n")).toContain("Usage: uncommitted collect github");
+  });
+
+  it("rejects collect github --date without a value", async () => {
+    const { io, stdout, stderr } = createIo();
+
+    const exitCode = await runCli(["collect", "github", "--date"], io);
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toEqual([]);
+    expect(stderr.join("\n")).toContain("Usage: uncommitted collect github");
   });
 
   it("reports skip and exits 0 when collect claude finds no session logs", async () => {

--- a/tests/collect-github-command.test.ts
+++ b/tests/collect-github-command.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi } from "vitest";
+import { mkdtemp, mkdir, writeFile, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  collectGitHubForRegisteredProjects,
+  CollectGitHubCommandError
+} from "../src/collect-github-command.js";
+
+async function seedProjects(homeDir: string, projectRoot: string) {
+  await mkdir(join(homeDir, ".uncommitted"), { recursive: true });
+  await writeFile(
+    join(homeDir, ".uncommitted", "projects.json"),
+    JSON.stringify({
+      schemaVersion: 1,
+      projects: [
+        {
+          schemaVersion: 1,
+          id: "p1",
+          name: "demo",
+          root: projectRoot,
+          gitRoot: projectRoot,
+          enabled: true,
+          createdAt: "2026-06-14T00:00:00Z"
+        }
+      ]
+    })
+  );
+}
+
+describe("collectGitHubForRegisteredProjects", () => {
+  it("returns no-token error when neither env nor config has a token", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "gh-cmd-"));
+    const projectRoot = await mkdtemp(join(tmpdir(), "gh-proj-"));
+    await seedProjects(homeDir, projectRoot);
+    await expect(
+      collectGitHubForRegisteredProjects({
+        homeDir,
+        env: {},
+        targetDate: "2026-06-17",
+        remoteUrlReader: async () => "https://github.com/foo/bar.git",
+        httpClient: async () => new Response("{}", { status: 200 })
+      })
+    ).rejects.toMatchObject({ code: "no-token" });
+  });
+
+  it("graceful-skips a project whose origin is not on github.com", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "gh-cmd-"));
+    const projectRoot = await mkdtemp(join(tmpdir(), "gh-proj-"));
+    await seedProjects(homeDir, projectRoot);
+    const result = await collectGitHubForRegisteredProjects({
+      homeDir,
+      env: { GITHUB_TOKEN: "t" },
+      targetDate: "2026-06-17",
+      remoteUrlReader: async () => "git@gitlab.com:foo/bar.git",
+      httpClient: async () => {
+        throw new Error("should not be called");
+      }
+    });
+    expect(result.skippedProjects).toHaveLength(1);
+    expect(result.successes).toHaveLength(0);
+    expect(result.failures).toHaveLength(0);
+  });
+
+  it("writes signal + raw archive when fetcher returns data", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "gh-cmd-"));
+    const projectRoot = await mkdtemp(join(tmpdir(), "gh-proj-"));
+    await seedProjects(homeDir, projectRoot);
+
+    // Handlers ordered most-specific-first (mirroring the fetcher test pattern).
+    const responses: Array<[string, () => Response]> = [
+      ["/pulls/1/reviews", () => new Response(JSON.stringify([]))],
+      [
+        "/search/issues",
+        () =>
+          new Response(
+            JSON.stringify({
+              items: [
+                {
+                  number: 1,
+                  title: "PR1",
+                  body: "my body",
+                  pull_request: { merged_at: "2026-06-17T05:00:00Z" },
+                  closed_at: "2026-06-17T05:00:00Z",
+                  user: { login: "alice" }
+                }
+              ]
+            })
+          )
+      ],
+      ["/repos/foo/bar", () => new Response(JSON.stringify({ private: false }))],
+      ["/user", () => new Response(JSON.stringify({ login: "alice" }))]
+    ];
+    const httpClient = async (url: string) => {
+      const handler = responses.find(([k]) => url.includes(k))?.[1];
+      if (!handler) return new Response("not found", { status: 404 });
+      return handler();
+    };
+
+    const result = await collectGitHubForRegisteredProjects({
+      homeDir,
+      env: { GITHUB_TOKEN: "t" },
+      targetDate: "2026-06-17",
+      remoteUrlReader: async () => "https://github.com/foo/bar.git",
+      httpClient
+    });
+
+    expect(result.successes).toHaveLength(1);
+    const signals = await readFile(result.successes[0].signalsFile, "utf8");
+    expect(signals).toContain('"kind":"pr"');
+    const raw = await readFile(result.successes[0].rawArchiveFile, "utf8");
+    expect(raw).toContain('"source":"pr-body"');
+  });
+
+  it("flushes partial output on per-project failure and returns failure entry", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "gh-cmd-"));
+    const projectRoot = await mkdtemp(join(tmpdir(), "gh-proj-"));
+    await seedProjects(homeDir, projectRoot);
+
+    const httpClient = vi.fn(async () => new Response("nope", { status: 500 }));
+    const result = await collectGitHubForRegisteredProjects({
+      homeDir,
+      env: { GITHUB_TOKEN: "t" },
+      targetDate: "2026-06-17",
+      remoteUrlReader: async () => "https://github.com/foo/bar.git",
+      httpClient
+    });
+    expect(result.successes).toHaveLength(0);
+    expect(result.failures).toHaveLength(1);
+    const empty = await readFile(
+      join(projectRoot, ".uncommitted", "events", "github", "2026-06-17.jsonl"),
+      "utf8"
+    );
+    expect(empty).toBe("");
+  });
+
+  it("rejects an invalid --date (not YYYY-MM-DD)", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "gh-cmd-"));
+    const projectRoot = await mkdtemp(join(tmpdir(), "gh-proj-"));
+    await seedProjects(homeDir, projectRoot);
+    await expect(
+      collectGitHubForRegisteredProjects({
+        homeDir,
+        env: { GITHUB_TOKEN: "t" },
+        targetDate: "not-a-date",
+        remoteUrlReader: async () => "https://github.com/foo/bar.git",
+        httpClient: async () => new Response("{}")
+      })
+    ).rejects.toMatchObject({ code: "invalid-date" });
+  });
+
+  it("exports CollectGitHubCommandError as a constructable class", () => {
+    const err = new CollectGitHubCommandError("x", "no-token");
+    expect(err.code).toBe("no-token");
+  });
+});

--- a/tests/collect-github-command.test.ts
+++ b/tests/collect-github-command.test.ts
@@ -179,6 +179,27 @@ describe("collectGitHubForRegisteredProjects", () => {
     expect(await readFile(rawPath, "utf8")).toBe(priorRaw);
   });
 
+  it("reports a per-project failure when the git remote read fails", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "gh-cmd-"));
+    const projectRoot = await mkdtemp(join(tmpdir(), "gh-proj-"));
+    await seedProjects(homeDir, projectRoot);
+    const result = await collectGitHubForRegisteredProjects({
+      homeDir,
+      env: {}, // no token: a broken project must not be silently skipped
+      targetDate: "2026-06-17",
+      remoteUrlReader: async () => {
+        throw new Error("not a git repository");
+      },
+      httpClient: async () => {
+        throw new Error("should not be called");
+      }
+    });
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0].projectId).toBe("p1");
+    expect(result.skippedProjects).toHaveLength(0);
+    expect(result.successes).toHaveLength(0);
+  });
+
   it("rejects an invalid --date (not YYYY-MM-DD)", async () => {
     const homeDir = await mkdtemp(join(tmpdir(), "gh-cmd-"));
     const projectRoot = await mkdtemp(join(tmpdir(), "gh-proj-"));

--- a/tests/collect-github-command.test.ts
+++ b/tests/collect-github-command.test.ts
@@ -134,6 +134,51 @@ describe("collectGitHubForRegisteredProjects", () => {
     expect(empty).toBe("");
   });
 
+  it("skips GitLab-only/local projects without requiring a GitHub token", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "gh-cmd-"));
+    const projectRoot = await mkdtemp(join(tmpdir(), "gh-proj-"));
+    await seedProjects(homeDir, projectRoot);
+    const result = await collectGitHubForRegisteredProjects({
+      homeDir,
+      env: {}, // no token
+      targetDate: "2026-06-17",
+      remoteUrlReader: async () => "git@gitlab.com:foo/bar.git",
+      httpClient: async () => {
+        throw new Error("should not be called");
+      }
+    });
+    expect(result.skippedProjects).toHaveLength(1);
+    expect(result.successes).toHaveLength(0);
+    expect(result.failures).toHaveLength(0);
+  });
+
+  it("preserves previously collected events when a re-run's fetch fails", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "gh-cmd-"));
+    const projectRoot = await mkdtemp(join(tmpdir(), "gh-proj-"));
+    await seedProjects(homeDir, projectRoot);
+
+    const githubDir = join(projectRoot, ".uncommitted", "events", "github");
+    await mkdir(join(githubDir, "raw"), { recursive: true });
+    const signalsPath = join(githubDir, "2026-06-17.jsonl");
+    const rawPath = join(githubDir, "raw", "2026-06-17.jsonl");
+    const priorSignals = '{"projectId":"p1","timestamp":"2026-06-17T05:00:00Z","kind":"pr","summary":"PR #1 merged: keep me","safetyNotes":[]}\n';
+    const priorRaw = '{"source":"pr-body","number":1,"visibility":"public","text":"keep me","timestamp":"2026-06-17T05:00:00Z"}\n';
+    await writeFile(signalsPath, priorSignals);
+    await writeFile(rawPath, priorRaw);
+
+    const result = await collectGitHubForRegisteredProjects({
+      homeDir,
+      env: { GITHUB_TOKEN: "t" },
+      targetDate: "2026-06-17",
+      remoteUrlReader: async () => "https://github.com/foo/bar.git",
+      httpClient: async () => new Response("nope", { status: 500 })
+    });
+
+    expect(result.failures).toHaveLength(1);
+    expect(await readFile(signalsPath, "utf8")).toBe(priorSignals);
+    expect(await readFile(rawPath, "utf8")).toBe(priorRaw);
+  });
+
   it("rejects an invalid --date (not YYYY-MM-DD)", async () => {
     const homeDir = await mkdtemp(join(tmpdir(), "gh-cmd-"));
     const projectRoot = await mkdtemp(join(tmpdir(), "gh-proj-"));

--- a/tests/generate-command.test.ts
+++ b/tests/generate-command.test.ts
@@ -235,6 +235,39 @@ describe("generate command", () => {
     );
   });
 
+  it("incorporates collected GitHub signals into the activity summary", async () => {
+    const { io, stderr } = createIo();
+    const fixture = await createRegisteredProjectFixture();
+    const provider = new TaskAwareProvider();
+
+    await writeGitEvent(fixture.project, "2026-05-12");
+    await writeGitHubSignals(fixture.project, "2026-05-12", [
+      {
+        projectId: fixture.project.id,
+        timestamp: "2026-05-12T09:00:00.000Z",
+        kind: "pr",
+        summary: "PR #42 merged: add the github collector",
+        safetyNotes: []
+      }
+    ]);
+
+    const exitCode = await runCli(["generate", "today"], io, {
+      homeDir: fixture.homeDir,
+      now: () => "2026-05-12T23:30:00.000Z",
+      aiProvider: provider
+    });
+    const outputDir = join(fixture.draftRoot, "2026-05-12", "rev-001");
+    const activitySummary = (await readJson(
+      join(outputDir, "activity-summary.json")
+    )) as { smallWins: string[] };
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toEqual([]);
+    expect(activitySummary.smallWins).toContain(
+      "PR #42 merged: add the github collector"
+    );
+  });
+
   it("completes warning drafts with a visible safety warning and metadata state", async () => {
     const { io, stdout, stderr } = createIo();
     const fixture = await createRegisteredProjectFixture();
@@ -985,6 +1018,27 @@ async function writeCodexSignals(
   }[]
 ): Promise<void> {
   const eventsDir = join(project.root, ".uncommitted", "events", "codex");
+
+  await mkdir(eventsDir, { recursive: true });
+  await writeFile(
+    join(eventsDir, `${targetDate}.jsonl`),
+    signals.map((signal) => JSON.stringify(signal)).join("\n") + "\n",
+    "utf8"
+  );
+}
+
+async function writeGitHubSignals(
+  project: ProjectRecord,
+  targetDate: string,
+  signals: {
+    projectId: string;
+    timestamp: string;
+    kind: string;
+    summary: string;
+    safetyNotes: string[];
+  }[]
+): Promise<void> {
+  const eventsDir = join(project.root, ".uncommitted", "events", "github");
 
   await mkdir(eventsDir, { recursive: true });
   await writeFile(

--- a/tests/github-event-normalizer.test.ts
+++ b/tests/github-event-normalizer.test.ts
@@ -19,10 +19,20 @@ const base: GitHubFetchResult = {
 };
 
 describe("normalizeGitHubFetch", () => {
-  it("emits one signal per PR/issue/review", () => {
+  it("emits one signal per own PR/issue/review and excludes teammates' activity", () => {
     const r = normalizeGitHubFetch({ projectId: "p1", fetch: base });
     const kinds = r.signals.map((s) => s.kind).sort();
-    expect(kinds).toEqual(["issue", "pr", "pr", "review", "review"]);
+    // PR #2 (bob) and review #101 (carol) must not become this user's activity.
+    expect(kinds).toEqual(["issue", "pr", "review"]);
+  });
+
+  it("never emits a signal for a PR/issue/review authored by someone else", () => {
+    const r = normalizeGitHubFetch({ projectId: "p1", fetch: base });
+    expect(r.signals.some((s) => s.summary.includes("#2"))).toBe(false);
+    const reviewSummaries = r.signals
+      .filter((s) => s.kind === "review")
+      .map((s) => s.summary);
+    expect(reviewSummaries).toEqual(["Review APPROVED on PR #1"]);
   });
 
   it("only collects bodies authored by the authenticated user", () => {

--- a/tests/github-event-normalizer.test.ts
+++ b/tests/github-event-normalizer.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { normalizeGitHubFetch } from "../src/github-event-normalizer.js";
+import type { GitHubFetchResult } from "../src/github-fetcher.js";
+
+const base: GitHubFetchResult = {
+  visibility: "public",
+  authenticatedLogin: "alice",
+  mergedPRs: [
+    { number: 1, title: "Add caching", body: "Implements LRU.", authorLogin: "alice", mergedAt: "2026-06-17T05:00:00Z" },
+    { number: 2, title: "External PR", body: "from someone else", authorLogin: "bob", mergedAt: "2026-06-17T06:00:00Z" }
+  ],
+  closedIssues: [
+    { number: 9, title: "Bug X", body: "I tracked this down", authorLogin: "alice", closedAt: "2026-06-17T07:00:00Z" }
+  ],
+  reviews: [
+    { id: 100, prNumber: 1, state: "APPROVED", submittedAt: "2026-06-17T08:00:00Z", authorLogin: "alice", body: "lgtm" },
+    { id: 101, prNumber: 1, state: "COMMENTED", submittedAt: "2026-06-17T08:30:00Z", authorLogin: "carol", body: "nit pick" }
+  ]
+};
+
+describe("normalizeGitHubFetch", () => {
+  it("emits one signal per PR/issue/review", () => {
+    const r = normalizeGitHubFetch({ projectId: "p1", fetch: base });
+    const kinds = r.signals.map((s) => s.kind).sort();
+    expect(kinds).toEqual(["issue", "pr", "pr", "review", "review"]);
+  });
+
+  it("only collects bodies authored by the authenticated user", () => {
+    const r = normalizeGitHubFetch({ projectId: "p1", fetch: base });
+    const sources = r.ownAuthoredBodies.map((b) => `${b.source}#${b.number}`).sort();
+    expect(sources).toEqual(["issue-body#9", "pr-body#1", "review-comment#1"]);
+  });
+
+  it("uses pr.mergedAt / issue.closedAt / review.submittedAt as the signal timestamp", () => {
+    const r = normalizeGitHubFetch({ projectId: "p1", fetch: base });
+    const pr1 = r.signals.find((s) => s.kind === "pr" && s.summary.includes("#1"));
+    expect(pr1?.timestamp).toBe("2026-06-17T05:00:00Z");
+  });
+
+  it("stamps visibility on every own-authored body", () => {
+    const r = normalizeGitHubFetch({ projectId: "p1", fetch: { ...base, visibility: "private" } });
+    expect(r.ownAuthoredBodies.every((b) => b.visibility === "private")).toBe(true);
+  });
+});

--- a/tests/github-event-normalizer.test.ts
+++ b/tests/github-event-normalizer.test.ts
@@ -10,7 +10,7 @@ const base: GitHubFetchResult = {
     { number: 2, title: "External PR", body: "from someone else", authorLogin: "bob", mergedAt: "2026-06-17T06:00:00Z" }
   ],
   closedIssues: [
-    { number: 9, title: "Bug X", body: "I tracked this down", authorLogin: "alice", closedAt: "2026-06-17T07:00:00Z" }
+    { number: 9, title: "Bug X", body: "I tracked this down", closedByLogin: "alice", closedAt: "2026-06-17T07:00:00Z" }
   ],
   reviews: [
     { id: 100, prNumber: 1, state: "APPROVED", submittedAt: "2026-06-17T08:00:00Z", authorLogin: "alice", body: "lgtm" },
@@ -50,6 +50,24 @@ describe("normalizeGitHubFetch", () => {
   it("stamps visibility on every own-authored body", () => {
     const r = normalizeGitHubFetch({ projectId: "p1", fetch: { ...base, visibility: "private" } });
     expect(r.ownAuthoredBodies.every((b) => b.visibility === "private")).toBe(true);
+  });
+
+  it("attributes closed issues to the closer, not the opener", () => {
+    const fetch: GitHubFetchResult = {
+      visibility: "public",
+      authenticatedLogin: "alice",
+      mergedPRs: [],
+      closedIssues: [
+        // Opened by someone else but closed by alice => her work, keep it.
+        { number: 9, title: "Closed by me", body: "", closedByLogin: "alice", closedAt: "2026-06-17T07:00:00Z" },
+        // Closed by a teammate => not alice's work, drop it.
+        { number: 10, title: "Closed by bob", body: "", closedByLogin: "bob", closedAt: "2026-06-17T07:30:00Z" }
+      ],
+      reviews: []
+    };
+    const r = normalizeGitHubFetch({ projectId: "p", fetch });
+    const issueSummaries = r.signals.filter((s) => s.kind === "issue").map((s) => s.summary);
+    expect(issueSummaries).toEqual(["Issue #9 closed: Closed by me"]);
   });
 
   it("compares author logins case-insensitively so case drift doesn't drop own bodies", () => {

--- a/tests/github-event-normalizer.test.ts
+++ b/tests/github-event-normalizer.test.ts
@@ -41,4 +41,19 @@ describe("normalizeGitHubFetch", () => {
     const r = normalizeGitHubFetch({ projectId: "p1", fetch: { ...base, visibility: "private" } });
     expect(r.ownAuthoredBodies.every((b) => b.visibility === "private")).toBe(true);
   });
+
+  it("compares author logins case-insensitively so case drift doesn't drop own bodies", () => {
+    const fetch: GitHubFetchResult = {
+      visibility: "public",
+      authenticatedLogin: "Alice",
+      mergedPRs: [
+        { number: 42, title: "Mine", body: "this is mine",
+          authorLogin: "alice", mergedAt: "2026-06-17T01:00:00Z" }
+      ],
+      closedIssues: [],
+      reviews: []
+    };
+    const r = normalizeGitHubFetch({ projectId: "p", fetch });
+    expect(r.ownAuthoredBodies.map((b) => b.source)).toEqual(["pr-body"]);
+  });
 });

--- a/tests/github-event-redactor.test.ts
+++ b/tests/github-event-redactor.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { redactGitHubEvents } from "../src/github-event-redactor.js";
+import type { NormalizedGitHub } from "../src/github-event-normalizer.js";
+
+const base: NormalizedGitHub = {
+  signals: [
+    {
+      projectId: "p1",
+      timestamp: "2026-06-17T05:00:00Z",
+      kind: "pr",
+      summary: "PR #1 merged: bump deps",
+      safetyNotes: []
+    }
+  ],
+  ownAuthoredBodies: [
+    {
+      source: "pr-body",
+      number: 1,
+      visibility: "public",
+      timestamp: "2026-06-17T05:00:00Z",
+      text: "Bumped to v2. Email me at me@example.com or via git@github.com:foo/bar.git. token=ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+};
+
+describe("redactGitHubEvents", () => {
+  it("masks secrets, emails, and SSH remotes in own-authored bodies", () => {
+    const r = redactGitHubEvents(base);
+    const text = r.ownAuthoredBodies[0].text;
+    expect(text).not.toContain("me@example.com");
+    expect(text).not.toContain("ghp_");
+    expect(text).not.toContain("git@github.com:foo/bar.git");
+    expect(r.appliedCategories).toContain("emails");
+    expect(r.appliedCategories).toContain("vendor api tokens");
+    expect(r.appliedCategories).toContain("private URLs");
+  });
+
+  it("applies a defensive second secret pass for private-visibility bodies", () => {
+    const privateInput: NormalizedGitHub = {
+      signals: [],
+      ownAuthoredBodies: [
+        {
+          source: "pr-body",
+          number: 1,
+          visibility: "private",
+          timestamp: "2026-06-17T05:00:00Z",
+          text: "internal_url=https://internal.example.com/secret/path AKIAABCDEFGHIJKLMNOP"
+        }
+      ]
+    };
+    const r = redactGitHubEvents(privateInput);
+    const text = r.ownAuthoredBodies[0].text;
+    expect(text).not.toContain("AKIA");
+    expect(text).not.toContain("https://internal.example.com");
+  });
+
+  it("redacts signal summaries too", () => {
+    const sigInput: NormalizedGitHub = {
+      signals: [
+        {
+          projectId: "p",
+          timestamp: "2026-06-17T05:00:00Z",
+          kind: "pr",
+          summary: "PR #1 merged: contact alice@example.com",
+          safetyNotes: []
+        }
+      ],
+      ownAuthoredBodies: []
+    };
+    const r = redactGitHubEvents(sigInput);
+    expect(r.signals[0].summary).not.toContain("alice@example.com");
+    expect(r.signals[0].safetyNotes).toContain("emails");
+  });
+});

--- a/tests/github-event-writer.test.ts
+++ b/tests/github-event-writer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { mkdtemp, readFile, stat, mkdir, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, stat, mkdir, writeFile, chmod } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { writeGitHubEvents } from "../src/github-event-writer.js";
@@ -57,6 +57,38 @@ describe("writeGitHubEvents", () => {
     );
     expect(contents).not.toContain("stale");
     expect(contents).toContain("fresh");
+  });
+
+  it("does not replace an existing good signal file when the raw archive write fails", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "gh-writer-"));
+    const baseDir = join(projectRoot, ".uncommitted", "events", "github");
+    const rawDir = join(baseDir, "raw");
+    await mkdir(rawDir, { recursive: true });
+    // A previous successful collection left a good signal file in place.
+    const signalsFile = join(baseDir, `${targetDate}.jsonl`);
+    await writeFile(signalsFile, "good-prior-signal\n");
+    // Make the raw archive write fail (no write permission on the raw dir).
+    await chmod(rawDir, 0o500);
+
+    try {
+      await expect(
+        writeGitHubEvents({
+          projectRoot,
+          targetDate,
+          signals: [
+            { projectId: "p", timestamp: "x", kind: "pr", summary: "fresh", safetyNotes: [] }
+          ],
+          ownAuthoredBodies: [
+            { source: "pr-body", number: 1, visibility: "private",
+              timestamp: "2026-06-17T05:00:00Z", text: "body" }
+          ]
+        })
+      ).rejects.toBeTruthy();
+      // The canonical signal file must be untouched: raw archive is written first.
+      expect(await readFile(signalsFile, "utf8")).toBe("good-prior-signal\n");
+    } finally {
+      await chmod(rawDir, 0o700);
+    }
   });
 
   it("does not write empty files when no signals or bodies are supplied", async () => {

--- a/tests/github-event-writer.test.ts
+++ b/tests/github-event-writer.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp, readFile, stat, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writeGitHubEvents } from "../src/github-event-writer.js";
+
+const targetDate = "2026-06-17";
+
+describe("writeGitHubEvents", () => {
+  it("writes signal JSONL and raw archive in canonical paths", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "gh-writer-"));
+    const result = await writeGitHubEvents({
+      projectRoot,
+      targetDate,
+      signals: [
+        { projectId: "p", timestamp: "2026-06-17T05:00:00Z", kind: "pr",
+          summary: "PR #1 merged: x", safetyNotes: [] }
+      ],
+      ownAuthoredBodies: [
+        { source: "pr-body", number: 1, visibility: "public",
+          timestamp: "2026-06-17T05:00:00Z", text: "body" }
+      ]
+    });
+    expect(result.signalsFile).toBe(join(projectRoot, ".uncommitted", "events", "github", `${targetDate}.jsonl`));
+    expect(result.rawArchiveFile).toBe(join(projectRoot, ".uncommitted", "events", "github", "raw", `${targetDate}.jsonl`));
+    expect((await readFile(result.signalsFile, "utf8")).trim().split("\n")).toHaveLength(1);
+    expect((await readFile(result.rawArchiveFile, "utf8")).trim().split("\n")).toHaveLength(1);
+  });
+
+  it("writes raw archive with 0600 permissions", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "gh-writer-"));
+    const result = await writeGitHubEvents({
+      projectRoot, targetDate, signals: [],
+      ownAuthoredBodies: [
+        { source: "pr-body", number: 1, visibility: "private",
+          timestamp: "2026-06-17T05:00:00Z", text: "secret-ish" }
+      ]
+    });
+    const s = await stat(result.rawArchiveFile);
+    expect(s.mode & 0o777).toBe(0o600);
+  });
+
+  it("overwrites existing day files (full-rewrite, not append)", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "gh-writer-"));
+    await mkdir(join(projectRoot, ".uncommitted", "events", "github"), { recursive: true });
+    await writeFile(
+      join(projectRoot, ".uncommitted", "events", "github", `${targetDate}.jsonl`),
+      "stale\nstale\n"
+    );
+    await writeGitHubEvents({
+      projectRoot, targetDate,
+      signals: [{ projectId: "p", timestamp: "x", kind: "pr", summary: "fresh", safetyNotes: [] }],
+      ownAuthoredBodies: []
+    });
+    const contents = await readFile(
+      join(projectRoot, ".uncommitted", "events", "github", `${targetDate}.jsonl`), "utf8"
+    );
+    expect(contents).not.toContain("stale");
+    expect(contents).toContain("fresh");
+  });
+
+  it("does not write empty files when no signals or bodies are supplied", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "gh-writer-"));
+    const result = await writeGitHubEvents({
+      projectRoot, targetDate, signals: [], ownAuthoredBodies: []
+    });
+    expect((await readFile(result.signalsFile, "utf8"))).toBe("");
+    expect((await readFile(result.rawArchiveFile, "utf8"))).toBe("");
+  });
+});

--- a/tests/github-fetcher.test.ts
+++ b/tests/github-fetcher.test.ts
@@ -167,6 +167,42 @@ describe("fetchGitHubActivity", () => {
     expect(calls.some((u) => u.includes("page=2") && u.includes("is%3Apr"))).toBe(true);
   });
 
+  it("attributes a closed issue to the closer, not the opener", async () => {
+    const client: HttpClient = async (url) => {
+      if (url.includes("/issues/9")) {
+        // Opened by bob, closed by the authenticated user (alice).
+        return jsonResponse({ number: 9, closed_by: { login: "alice" } });
+      }
+      if (url.includes("/issues/10")) {
+        // Opened by alice, closed by bob.
+        return jsonResponse({ number: 10, closed_by: { login: "bob" } });
+      }
+      if (url.includes("/reviews")) return jsonResponse([]);
+      if (url.includes("/user")) return jsonResponse({ login: "alice" });
+      if (url.endsWith("/repos/foo/bar")) return jsonResponse({ private: false });
+      if (url.includes("/search/issues")) {
+        if (url.includes("is%3Aissue")) {
+          return jsonResponse({ items: [
+            { number: 9, title: "Issue nine", body: "b", closed_at: "2026-06-17T06:00:00Z", user: { login: "bob" } },
+            { number: 10, title: "Issue ten", body: "b", closed_at: "2026-06-17T06:30:00Z", user: { login: "alice" } }
+          ] });
+        }
+        return jsonResponse({ items: [] });
+      }
+      return jsonResponse({}, 404);
+    };
+
+    const result = await fetchGitHubActivity({
+      token: "t", owner: "foo", repo: "bar",
+      targetDate: "2026-06-17", httpClient: client
+    });
+
+    const nine = result.closedIssues.find((i) => i.number === 9);
+    const ten = result.closedIssues.find((i) => i.number === 10);
+    expect(nine?.closedByLogin).toBe("alice");
+    expect(ten?.closedByLogin).toBe("bob");
+  });
+
   it("discovers reviews on PRs that were not merged on the target date", async () => {
     const calls: string[] = [];
     const client: HttpClient = async (url) => {

--- a/tests/github-fetcher.test.ts
+++ b/tests/github-fetcher.test.ts
@@ -127,4 +127,77 @@ describe("fetchGitHubActivity", () => {
     });
     expect(result.visibility).toBe("private");
   });
+
+  it("pages through merged-PR search results beyond the first 100", async () => {
+    const calls: string[] = [];
+    const prItem = (n: number) => ({
+      number: n, title: `PR ${n}`, body: "",
+      pull_request: { merged_at: "2026-06-17T05:00:00Z" },
+      closed_at: "2026-06-17T05:00:00Z", user: { login: "alice" }
+    });
+    const client: HttpClient = async (url) => {
+      calls.push(url);
+      if (url.includes("/reviews")) return jsonResponse([]);
+      if (url.includes("/user")) return jsonResponse({ login: "alice" });
+      if (url.endsWith("/repos/foo/bar")) return jsonResponse({ private: false });
+      if (url.includes("/search/issues")) {
+        const isPrMerged = url.includes("is%3Apr") && url.includes("is%3Amerged");
+        const isReviewedBy = url.includes("reviewed-by");
+        if (isPrMerged && !isReviewedBy) {
+          const page = Number(url.match(/[?&]page=(\d+)/)?.[1] ?? "1");
+          if (page === 1) {
+            return jsonResponse({ items: Array.from({ length: 100 }, (_, i) => prItem(i + 1)) });
+          }
+          if (page === 2) {
+            return jsonResponse({ items: Array.from({ length: 5 }, (_, i) => prItem(i + 101)) });
+          }
+          return jsonResponse({ items: [] });
+        }
+        return jsonResponse({ items: [] });
+      }
+      return jsonResponse({}, 404);
+    };
+
+    const result = await fetchGitHubActivity({
+      token: "t", owner: "foo", repo: "bar",
+      targetDate: "2026-06-17", httpClient: client
+    });
+
+    expect(result.mergedPRs).toHaveLength(105);
+    expect(calls.some((u) => u.includes("page=2") && u.includes("is%3Apr"))).toBe(true);
+  });
+
+  it("discovers reviews on PRs that were not merged on the target date", async () => {
+    const calls: string[] = [];
+    const client: HttpClient = async (url) => {
+      calls.push(url);
+      if (url.includes("/pulls/7/reviews")) {
+        return jsonResponse([
+          { id: 500, state: "APPROVED", submitted_at: "2026-06-17T09:00:00Z",
+            user: { login: "alice" }, body: "ok" }
+        ]);
+      }
+      if (url.includes("/reviews")) return jsonResponse([]);
+      if (url.includes("/user")) return jsonResponse({ login: "alice" });
+      if (url.endsWith("/repos/foo/bar")) return jsonResponse({ private: false });
+      if (url.includes("/search/issues")) {
+        if (url.includes("reviewed-by")) {
+          // PR #7 is open / merged a different day, but the user reviewed it today.
+          return jsonResponse({ items: [{ number: 7, title: "Open PR", pull_request: {}, user: { login: "carol" } }] });
+        }
+        return jsonResponse({ items: [] });
+      }
+      return jsonResponse({}, 404);
+    };
+
+    const result = await fetchGitHubActivity({
+      token: "t", owner: "foo", repo: "bar",
+      targetDate: "2026-06-17", httpClient: client
+    });
+
+    expect(result.mergedPRs).toHaveLength(0);
+    expect(result.reviews.map((r) => r.prNumber)).toContain(7);
+    expect(result.reviews.map((r) => r.id)).toContain(500);
+    expect(calls.some((u) => u.includes("/pulls/7/reviews"))).toBe(true);
+  });
 });

--- a/tests/github-fetcher.test.ts
+++ b/tests/github-fetcher.test.ts
@@ -73,6 +73,48 @@ describe("fetchGitHubActivity", () => {
     expect(calls).toBeGreaterThanOrEqual(2);
   });
 
+  it("treats a 403 without rate-limit headers as a normal HTTP error, not a rate limit", async () => {
+    let calls = 0;
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const client: HttpClient = async () => {
+      calls++;
+      // 403 with quota remaining => authorization/scope problem, not rate limit.
+      return new Response("Forbidden", {
+        status: 403,
+        headers: { "x-ratelimit-remaining": "57" }
+      });
+    };
+    const err = await fetchGitHubActivity({
+      token: "t", owner: "foo", repo: "bar",
+      targetDate: "2026-06-17", httpClient: client, sleep
+    }).catch((e) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect(err).not.toBeInstanceOf(RateLimitedError);
+    expect((err as Error).message).toContain("403");
+    // No retry/backoff for a non-rate-limit 403.
+    expect(calls).toBe(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("treats a 403 with x-ratelimit-remaining: 0 as a rate limit (retries then throws)", async () => {
+    let calls = 0;
+    const client: HttpClient = async () => {
+      calls++;
+      return new Response("rate limited", {
+        status: 403,
+        headers: { "x-ratelimit-remaining": "0" }
+      });
+    };
+    await expect(
+      fetchGitHubActivity({
+        token: "t", owner: "foo", repo: "bar",
+        targetDate: "2026-06-17", httpClient: client,
+        sleep: vi.fn().mockResolvedValue(undefined)
+      })
+    ).rejects.toBeInstanceOf(RateLimitedError);
+    expect(calls).toBeGreaterThanOrEqual(2);
+  });
+
   it("returns private visibility when /repos reports private: true", async () => {
     const client = makeClient({
       "/user": () => jsonResponse({ login: "alice" }),

--- a/tests/github-fetcher.test.ts
+++ b/tests/github-fetcher.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  fetchGitHubActivity,
+  RateLimitedError,
+  type HttpClient
+} from "../src/github-fetcher.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
+}
+
+function makeClient(handlers: Record<string, () => Response>): HttpClient {
+  const calls: string[] = [];
+  const client: HttpClient = async (url) => {
+    calls.push(url);
+    const handler = Object.entries(handlers).find(([k]) => url.includes(k))?.[1];
+    if (!handler) throw new Error(`unexpected url ${url}`);
+    return handler();
+  };
+  (client as HttpClient & { calls: string[] }).calls = calls;
+  return client;
+}
+
+describe("fetchGitHubActivity", () => {
+  it("fetches visibility, merged PRs, closed issues, and reviews for the target date", async () => {
+    const client = makeClient({
+      "/pulls/1/reviews": () => jsonResponse([
+        { id: 100, state: "APPROVED", submitted_at: "2026-06-17T07:00:00Z",
+          user: { login: "alice" }, body: "lgtm" },
+        { id: 101, state: "COMMENTED", submitted_at: "2026-06-17T07:30:00Z",
+          user: { login: "carol" }, body: "nit" }
+      ]),
+      "/search/issues": () => jsonResponse({
+        items: [
+          { number: 1, title: "PR one", body: "auth body", state: "closed",
+            pull_request: { merged_at: "2026-06-17T05:00:00Z" },
+            closed_at: "2026-06-17T05:00:00Z",
+            user: { login: "alice" } },
+          { number: 9, title: "Issue nine", body: "by bob", state: "closed",
+            closed_at: "2026-06-17T06:00:00Z",
+            user: { login: "bob" } }
+        ]
+      }),
+      "/repos/foo/bar": () => jsonResponse({ private: false, full_name: "foo/bar" }),
+      "/user": () => jsonResponse({ login: "alice" })
+    });
+
+    const result = await fetchGitHubActivity({
+      token: "t", owner: "foo", repo: "bar",
+      targetDate: "2026-06-17", httpClient: client
+    });
+
+    expect(result.visibility).toBe("public");
+    expect(result.authenticatedLogin).toBe("alice");
+    expect(result.mergedPRs.map((p) => p.number)).toEqual([1]);
+    expect(result.closedIssues.map((i) => i.number)).toEqual([9]);
+    expect(result.reviews.map((r) => r.id)).toEqual([100, 101]);
+  });
+
+  it("retries 429 once with backoff then throws RateLimitedError on second 429", async () => {
+    let calls = 0;
+    const client: HttpClient = async () => {
+      calls++;
+      return new Response("rate limited", { status: 429 });
+    };
+    await expect(
+      fetchGitHubActivity({
+        token: "t", owner: "foo", repo: "bar",
+        targetDate: "2026-06-17", httpClient: client,
+        sleep: vi.fn().mockResolvedValue(undefined)
+      })
+    ).rejects.toBeInstanceOf(RateLimitedError);
+    expect(calls).toBeGreaterThanOrEqual(2);
+  });
+
+  it("returns private visibility when /repos reports private: true", async () => {
+    const client = makeClient({
+      "/user": () => jsonResponse({ login: "alice" }),
+      "/repos/foo/bar": () => jsonResponse({ private: true, full_name: "foo/bar" }),
+      "/search/issues": () => jsonResponse({ items: [] }),
+    });
+    const result = await fetchGitHubActivity({
+      token: "t", owner: "foo", repo: "bar",
+      targetDate: "2026-06-17", httpClient: client
+    });
+    expect(result.visibility).toBe("private");
+  });
+});

--- a/tests/github-fetcher.test.ts
+++ b/tests/github-fetcher.test.ts
@@ -203,6 +203,53 @@ describe("fetchGitHubActivity", () => {
     expect(ten?.closedByLogin).toBe("bob");
   });
 
+  it("pages through PR reviews beyond the first page", async () => {
+    const calls: string[] = [];
+    const review = (id: number) => ({
+      id, state: "COMMENTED", submitted_at: "2026-06-17T09:00:00Z",
+      user: { login: "alice" }, body: "ok"
+    });
+    const client: HttpClient = async (url) => {
+      calls.push(url);
+      if (url.includes("/pulls/1/reviews")) {
+        const page = Number(url.match(/[?&]page=(\d+)/)?.[1] ?? "1");
+        if (page === 1) {
+          return jsonResponse(Array.from({ length: 100 }, (_, i) => review(i + 1)));
+        }
+        if (page === 2) {
+          return jsonResponse([review(101)]);
+        }
+        return jsonResponse([]);
+      }
+      if (url.includes("/user")) return jsonResponse({ login: "alice" });
+      if (url.endsWith("/repos/foo/bar")) return jsonResponse({ private: false });
+      if (url.includes("/search/issues")) {
+        const isPrMerged = url.includes("is%3Apr") && url.includes("is%3Amerged");
+        if (isPrMerged) {
+          const page = Number(url.match(/[?&]page=(\d+)/)?.[1] ?? "1");
+          if (page === 1) {
+            return jsonResponse({ items: [{
+              number: 1, title: "PR one", pull_request: { merged_at: "2026-06-17T05:00:00Z" },
+              closed_at: "2026-06-17T05:00:00Z", user: { login: "alice" }
+            }] });
+          }
+          return jsonResponse({ items: [] });
+        }
+        return jsonResponse({ items: [] });
+      }
+      return jsonResponse({}, 404);
+    };
+
+    const result = await fetchGitHubActivity({
+      token: "t", owner: "foo", repo: "bar",
+      targetDate: "2026-06-17", httpClient: client
+    });
+
+    expect(result.reviews).toHaveLength(101);
+    expect(result.reviews.map((r) => r.id)).toContain(101);
+    expect(calls.some((u) => u.includes("/pulls/1/reviews") && u.includes("page=2"))).toBe(true);
+  });
+
   it("discovers reviews on PRs that were not merged on the target date", async () => {
     const calls: string[] = [];
     const client: HttpClient = async (url) => {

--- a/tests/github-repo-inference.test.ts
+++ b/tests/github-repo-inference.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { inferGitHubOriginRepo } from "../src/github-repo-inference.js";
+
+describe("inferGitHubOriginRepo", () => {
+  it("parses https github remote", () => {
+    const r = inferGitHubOriginRepo("https://github.com/james20140802/uncommitted.git");
+    expect(r).toEqual({ host: "github.com", owner: "james20140802", repo: "uncommitted", isGitHub: true });
+  });
+
+  it("parses ssh github remote", () => {
+    const r = inferGitHubOriginRepo("git@github.com:james20140802/uncommitted.git");
+    expect(r).toEqual({ host: "github.com", owner: "james20140802", repo: "uncommitted", isGitHub: true });
+  });
+
+  it("parses remote without .git suffix", () => {
+    const r = inferGitHubOriginRepo("https://github.com/foo/bar");
+    expect(r).toEqual({ host: "github.com", owner: "foo", repo: "bar", isGitHub: true });
+  });
+
+  it("returns isGitHub=false for non-github hosts (graceful skip)", () => {
+    const r = inferGitHubOriginRepo("git@gitlab.com:foo/bar.git");
+    expect(r.isGitHub).toBe(false);
+    expect(r.host).toBe("gitlab.com");
+  });
+
+  it("returns isGitHub=false for empty / unparseable remotes", () => {
+    expect(inferGitHubOriginRepo("")).toEqual({ host: null, owner: null, repo: null, isGitHub: false });
+    expect(inferGitHubOriginRepo("not-a-url")).toEqual({ host: null, owner: null, repo: null, isGitHub: false });
+  });
+});

--- a/tests/github-repo-inference.test.ts
+++ b/tests/github-repo-inference.test.ts
@@ -27,4 +27,21 @@ describe("inferGitHubOriginRepo", () => {
     expect(inferGitHubOriginRepo("")).toEqual({ host: null, owner: null, repo: null, isGitHub: false });
     expect(inferGitHubOriginRepo("not-a-url")).toEqual({ host: null, owner: null, repo: null, isGitHub: false });
   });
+
+  it("strips userinfo from HTTPS remotes so credentials don't leak into host", () => {
+    const r = inferGitHubOriginRepo("https://x-access-token:ghs_PLACEHOLDER@github.com/foo/bar.git");
+    expect(r.host).toBe("github.com");
+    expect(r.owner).toBe("foo");
+    expect(r.repo).toBe("bar");
+    expect(r.isGitHub).toBe(true);
+    // Defensive: ensure no part of the returned object contains the credential.
+    expect(JSON.stringify(r)).not.toContain("ghs_PLACEHOLDER");
+    expect(JSON.stringify(r)).not.toContain("x-access-token");
+  });
+
+  it("normalizes the host to lowercase", () => {
+    const r = inferGitHubOriginRepo("https://GitHub.com/foo/bar.git");
+    expect(r.host).toBe("github.com");
+    expect(r.isGitHub).toBe(true);
+  });
 });

--- a/tests/github-token-resolver.test.ts
+++ b/tests/github-token-resolver.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveGitHubToken } from "../src/github-token-resolver.js";
+
+describe("resolveGitHubToken", () => {
+  it("prefers GITHUB_TOKEN env var over config", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "ght-"));
+    await mkdir(join(homeDir, ".uncommitted"), { recursive: true });
+    await writeFile(
+      join(homeDir, ".uncommitted", "config.json"),
+      JSON.stringify({ githubToken: "from-config" })
+    );
+    const result = await resolveGitHubToken({ homeDir, env: { GITHUB_TOKEN: "from-env" } });
+    expect(result).toEqual({ token: "from-env", source: "env" });
+  });
+
+  it("falls back to config when env is unset", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "ght-"));
+    await mkdir(join(homeDir, ".uncommitted"), { recursive: true });
+    await writeFile(
+      join(homeDir, ".uncommitted", "config.json"),
+      JSON.stringify({ githubToken: "from-config" })
+    );
+    const result = await resolveGitHubToken({ homeDir, env: {} });
+    expect(result).toEqual({ token: "from-config", source: "config" });
+  });
+
+  it("returns missing when neither source has a token", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "ght-"));
+    const result = await resolveGitHubToken({ homeDir, env: {} });
+    expect(result).toEqual({ token: null, source: "missing" });
+  });
+
+  it("ignores empty-string env values", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "ght-"));
+    const result = await resolveGitHubToken({ homeDir, env: { GITHUB_TOKEN: "" } });
+    expect(result.source).toBe("missing");
+  });
+});

--- a/tests/safety-report.test.ts
+++ b/tests/safety-report.test.ts
@@ -188,3 +188,22 @@ describe("safety report", () => {
     expect(result.redactedText).not.toContain("git@github.com");
   });
 });
+
+describe("safety-report private-repo-remote (UNC-152)", () => {
+  it("masks SSH-style remote URLs with git+ssh prefix", () => {
+    const r = checkDraftSafety(
+      "see git+ssh://git@github.com/foo/bar.git for details"
+    );
+    expect(r.redactedText).not.toContain(
+      "git+ssh://git@github.com/foo/bar.git"
+    );
+    expect(
+      r.report.risks.some((x) => x.category === "private-repo-remote")
+    ).toBe(true);
+  });
+
+  it("preserves public org/repo references that aren't URLs", () => {
+    const r = checkDraftSafety("our example is github.com/foo/bar in docs");
+    expect(r.redactedText).toContain("github.com/foo/bar");
+  });
+});


### PR DESCRIPTION
🤖 **Auto-generated by Uncommitted Builder (Routine B v2)**

# Goal

Ship `uncommitted collect github` end-to-end — collect day-scoped GitHub PR/issue/review metadata as UNC-116 ActivitySignals, plus the user's own-authored bodies into a redacted, 0600-perm Tier 1 raw archive. Source slice 3/3 of the Source Expansion epic (alongside Claude UNC-117 and Codex UNC-118).

## Related Issue

Closes #UNC-119 (parent) — sub-issues UNC-149 / UNC-150 / UNC-151 / UNC-152 / UNC-153 / UNC-154 covered in the per-commit footers.

Linear: [UNC-119](https://linear.app/sangchu/issue/UNC-119/github-prissue-수집기-collect-github)

## Acceptance Criteria

- [x] Token resolved from `GITHUB_TOKEN` env (preferred) → `~/.uncommitted/config.json.githubToken` (fallback) → exit 2 when missing
- [x] Origin remote parsed; non-GitHub remote → graceful skip (no failure)
- [x] Repo visibility (public / private) detected via `/repos/{owner}/{repo}`
- [x] Merged PRs + closed issues for `targetDate` fetched in one search query each (no listing-and-filtering client-side)
- [x] Per-PR reviews fetched, windowed to `submitted_at.startsWith(targetDate)`
- [x] Own-authored bodies (`authorLogin === authenticatedLogin`) collected; other-authored bodies stay as meta-only signals
- [x] Author-login comparison is case-insensitive (fixup landed in T3)
- [x] Bodies redacted via UNC-155 `detectSecrets` + canonical `sanitizeText` + SSH-URL pre-pass
- [x] Private-visibility bodies get a defensive second `detectSecrets` sweep
- [x] `safety-report.ts` `private-repo-remote` rule widened to accept `git+ssh://` while preserving bare public org/repo mentions
- [x] Signals at `.uncommitted/events/github/YYYY-MM-DD.jsonl`; raw at `.uncommitted/events/github/raw/YYYY-MM-DD.jsonl` with **0600** perms
- [x] Atomic writes (tmp + rename) + full-day overwrite (idempotent retry)
- [x] Per-project failures don't abort the run; empty canonical files flushed to preserve the path contract for downstream readers (UNC-120, UNC-156)
- [x] Exit codes: 0 success (incl. graceful skips), 2 invalid input / missing token / invalid date, 3 collection error
- [x] No new runtime dependencies (uses global `fetch`)
- [x] No auto-publish surface added (collect-only)

## Implementation Notes

Mirrors the Codex collector layering exactly — one orchestrator (`collect-github-command.ts`) plus discrete modules per concern:

| Layer | File | Owns |
|---|---|---|
| Token + repo | `github-token-resolver.ts`, `github-repo-inference.ts` | env/config token resolution; remote URL → `{host, owner, repo, isGitHub}` |
| Network | `github-fetcher.ts` | `/user`, `/repos`, `/search/issues` (PRs + issues), `/pulls/{n}/reviews`, 1× backoff retry on 403/429 → `RateLimitedError` |
| Normalize | `github-event-normalizer.ts` | map fetched records → UNC-116 signals (`kind: "pr" | "issue" | "review"`) + own-authored body stream |
| Redact | `github-event-redactor.ts` | compose UNC-155 + `sanitizeText`; visibility-gated second secret pass for private bodies |
| Persist | `github-event-writer.ts` | atomic tmp+rename; raw archive 0600; full-day overwrite |
| CLI | `collect-github-command.ts`, `cli.ts` | orchestrate; `--date YYYY-MM-DD` parsing; exit code mapping |

Key design decisions reflected in commit footers:
- **Own-authored bodies only.** Other-authored content (reviewer comments, external PRs) becomes meta-only signal. Honors the brainstorm rule (UNC-115 / UNC-119) that we never persist text we didn't write.
- **Visibility gating, not visibility blocking.** Private bodies are still collected, but redacted more aggressively (defensive second secret sweep). Public bodies pass through the standard single-pass redaction.
- **Network surface is one file.** Only `github-fetcher.ts` talks to GitHub; everything else is pure data transformation.

The two follow-up commits (`359d441`, `0ae870f`) addressed code-review findings inline rather than amending:
- `359d441` — HTTPS regex was eating userinfo as host (credential leak risk + GitHub misclassification)
- `0ae870f` — author-login comparison was case-sensitive (could drop user's own bodies if casing drifted)

The third follow-up (`040a54a`) cleaned up an orchestrator/config-paths layout coupling flagged in T6 review.

## Validation

- `pnpm install --frozen-lockfile` — ✓
- `pnpm typecheck` — ✓ clean
- `pnpm lint` — ✓ clean
- `pnpm build` — ✓ clean
- `pnpm test` — ✓ 556/558 pass (1 skipped, 1 flake)
  - Flake: `tests/carousel-renderer-smoke.test.ts > renders a quiet 3-slide fixture …` — Playwright Chromium 5 s timeout. Unrelated to this PR's surface (we do not touch the carousel pipeline). Passes cleanly on retry.

## Remaining Risk

- **Live GitHub call not exercised end-to-end.** All tests use a fake `HttpClient`. A real-token smoke run is a useful follow-up before relying on the scheduler to invoke this command.
- **No `Retry-After` honoring.** Rate-limit backoff is hard-coded 1.5 s, then throws. Fine for current daily-cadence volume (one `/user`, one `/repos`, two `/search`, N PR reviews); the schedule won't hammer the secondary-rate-limit threshold.
- **`safety-report.ts` rule widening is opt-in via the existing detection set.** Public org/repo references that aren't URLs are intentionally preserved (the rule still requires `.git` boundary).
- **Empty-flush silent swallow.** If the partial-output flush itself fails (disk full / EPERM), the original error is still surfaced but downstream readers may see ENOENT instead of an empty file. Low-likelihood edge; logged as a minor in the T6 review.

## Sub-issue progress

- [x] UNC-149 [T1] Token resolver + origin repo + visibility — `eac8827`, fixup `359d441`
- [x] UNC-150 [T2] Day-scoped fetcher + rate-limit retry — `fdcb1a4`
- [x] UNC-151 [T3] Normalizer + own-body stream — `e7917d8`, fixup `0ae870f`
- [x] UNC-152 [T4] Redactor + safety-report private-remote rule — `80560ee`
- [x] UNC-153 [T5] Tier 1 raw archive + Tier 2 signal writer — `e5a9e49`
- [x] UNC-154 [T6] CLI orchestrator + `cli.ts` wiring — `7e68dc3`, fixup `040a54a`

## Review checklist

- [ ] Review each sub-issue's commits separately (per-task TDD trail in commit messages)
- [ ] Verify TDD test coverage (each module has its own test file; orchestrator has integration coverage)
- [ ] Confirm no lockfile changes (none made)
- [ ] Run `pnpm install && pnpm test && pnpm build` locally
- [ ] Confirm no auto-publish code introduced
- [ ] Confirm bodies are persisted only when `authorLogin === authenticatedLogin` (privacy contract)
- [ ] Confirm raw archive lands at `0600`

---

이 PR은 자동 생성되었습니다. 머지 전 사람의 리뷰가 반드시 필요합니다.
