### PR TITLE
🤖 collect all 오케스트레이션 + 소스별 on/off + generate 반영 마감 (UNC-120)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,6 +43,10 @@ import {
 import { resolveConfigPaths } from "./config-paths.js";
 import { loadSourceConfig, type SourceName } from "./source-config.js";
 import {
+  runCollectAll,
+  type CollectInvokerMap
+} from "./collect-all.js";
+import {
   ExportCommandError,
   runExportCommand
 } from "./export-command.js";
@@ -97,6 +101,12 @@ export type CliOptions = {
   schedulerRunner?: LaunchctlRawRunner;
   /** Injectable prompter for feedback command (tests). */
   feedbackPrompter?: FeedbackPrompter;
+  /**
+   * Injectable per-source collect invokers used by `collect all` orchestration.
+   * Tests stub these to force success/failure deterministically without
+   * exercising the live per-source collectors.
+   */
+  collectInvokers?: Partial<CollectInvokerMap>;
 };
 
 const defaultIo: CliIo = {
@@ -767,10 +777,22 @@ async function runCollect(
     (args[0] !== "git" &&
       args[0] !== "claude" &&
       args[0] !== "codex" &&
-      args[0] !== "github")
+      args[0] !== "github" &&
+      args[0] !== "all")
   ) {
-    io.stderr("Usage: uncommitted collect <git|claude|codex|github>");
+    io.stderr("Usage: uncommitted collect <git|claude|codex|github|all>");
     return 1;
+  }
+
+  // `all` orchestrates every enabled source with failure isolation; reject
+  // trailing tokens so a typo (e.g. `collect all --date ...`) can't be
+  // silently ignored.
+  if (args[0] === "all") {
+    if (args.length > 1) {
+      io.stderr("Usage: uncommitted collect all");
+      return 1;
+    }
+    return await runCollectAllCommand(io, options);
   }
 
   // git and claude take no further arguments; reject trailing tokens so an
@@ -967,6 +989,41 @@ async function runCollect(
   }
 
   return 1;
+}
+
+async function runCollectAllCommand(
+  io: CliIo,
+  options: CliOptions
+): Promise<number> {
+  const summary = await runCollectAll({
+    homeDir: options.homeDir,
+    claudeHome: options.claudeHome,
+    codexHome: options.codexHome,
+    now: options.now,
+    collectInvokers: options.collectInvokers
+  });
+
+  const enabledEntries = summary.entries.filter(
+    (entry) => entry.status !== "disabled"
+  );
+
+  if (enabledEntries.length === 0) {
+    io.stdout("collect all: no sources enabled in config; nothing to do.");
+  }
+
+  for (const entry of summary.entries) {
+    if (entry.status === "disabled") {
+      io.stdout(`Source '${entry.source}': disabled`);
+      continue;
+    }
+    if (entry.status === "success") {
+      io.stdout(`Source '${entry.source}': success (${entry.detail})`);
+      continue;
+    }
+    io.stdout(`Source '${entry.source}': failed (${entry.detail})`);
+  }
+
+  return summary.exitCode;
 }
 
 async function runNote(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,6 +41,7 @@ import {
   type ProjectRecord
 } from "./project-registry.js";
 import { resolveConfigPaths } from "./config-paths.js";
+import { loadSourceConfig, type SourceName } from "./source-config.js";
 import {
   ExportCommandError,
   runExportCommand
@@ -778,6 +779,16 @@ async function runCollect(
   if ((args[0] === "git" || args[0] === "claude") && args.length > 1) {
     io.stderr(`Usage: uncommitted collect ${args[0]}`);
     return 1;
+  }
+
+  const source = args[0] as SourceName;
+  const paths = resolveConfigPaths({ homeDir: options.homeDir });
+  const sourceConfig = await loadSourceConfig(paths.configFile);
+  if (!sourceConfig[source].enabled) {
+    io.stdout(
+      `Source '${source}' is disabled in config; skipping collection.`
+    );
+    return 0;
   }
 
   if (args[0] === "git") {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,7 +41,11 @@ import {
   type ProjectRecord
 } from "./project-registry.js";
 import { resolveConfigPaths } from "./config-paths.js";
-import { loadSourceConfig, type SourceName } from "./source-config.js";
+import {
+  loadSourceConfig,
+  SourceConfigError,
+  type SourceName
+} from "./source-config.js";
 import {
   runCollectAll,
   type CollectInvokerMap
@@ -767,6 +771,34 @@ async function runGenerate(
   }
 }
 
+/**
+ * Parse the optional `--date YYYY-MM-DD` argv shared by `collect codex` and
+ * `collect github`. Rejects a dangling `--date` (would otherwise fall back to
+ * today and overwrite events) and any unknown token. Emits the usage error to
+ * stderr and returns `{ error: true }` on failure.
+ */
+function parseCollectDateArgs(
+  args: string[],
+  source: "codex" | "github",
+  io: CliIo
+): { targetDate?: string; error: boolean } {
+  const usage = `Usage: uncommitted collect ${source} [--date YYYY-MM-DD]`;
+  let targetDate: string | undefined;
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--date") {
+      if (i + 1 >= args.length) {
+        io.stderr(usage);
+        return { error: true };
+      }
+      targetDate = args[++i];
+      continue;
+    }
+    io.stderr(usage);
+    return { error: true };
+  }
+  return { targetDate, error: false };
+}
+
 async function runCollect(
   args: string[],
   io: CliIo,
@@ -796,16 +828,42 @@ async function runCollect(
   }
 
   // git and claude take no further arguments; reject trailing tokens so an
-  // unsupported flag can't silently collect/overwrite today's events. codex and
-  // github both accept --date so they validate their own argv below.
+  // unsupported flag can't silently collect/overwrite today's events.
   if ((args[0] === "git" || args[0] === "claude") && args.length > 1) {
     io.stderr(`Usage: uncommitted collect ${args[0]}`);
     return 1;
   }
 
   const source = args[0] as SourceName;
+
+  // codex and github accept `--date`; validate their argv BEFORE consulting
+  // config so a typo (e.g. `collect codex --date`, `collect github --bogus`) is
+  // rejected even when the source is disabled — matching the enabled path.
+  let codexTargetDate: string | undefined;
+  let ghTargetDate: string | undefined;
+  if (source === "codex" || source === "github") {
+    const parsed = parseCollectDateArgs(args.slice(1), source, io);
+    if (parsed.error) {
+      return 1;
+    }
+    if (source === "codex") {
+      codexTargetDate = parsed.targetDate;
+    } else {
+      ghTargetDate = parsed.targetDate;
+    }
+  }
+
   const paths = resolveConfigPaths({ homeDir: options.homeDir });
-  const sourceConfig = await loadSourceConfig(paths.configFile);
+  let sourceConfig;
+  try {
+    sourceConfig = await loadSourceConfig(paths.configFile);
+  } catch (error) {
+    if (error instanceof SourceConfigError) {
+      io.stderr(error.message);
+      return 2;
+    }
+    throw error;
+  }
   if (!sourceConfig[source].enabled) {
     io.stdout(
       `Source '${source}' is disabled in config; skipping collection.`
@@ -877,30 +935,12 @@ async function runCollect(
   }
 
   if (args[0] === "codex") {
-    const codexArgs = args.slice(1);
-    let targetDate: string | undefined;
-    for (let i = 0; i < codexArgs.length; i++) {
-      if (codexArgs[i] === "--date") {
-        // --date must be followed by a value; otherwise the collector would fall
-        // back to today and overwrite today's events on a typo.
-        if (i + 1 >= codexArgs.length) {
-          io.stderr("Usage: uncommitted collect codex [--date YYYY-MM-DD]");
-          return 1;
-        }
-        targetDate = codexArgs[++i];
-        continue;
-      }
-      // Reject unknown/extra tokens rather than silently ignoring them.
-      io.stderr("Usage: uncommitted collect codex [--date YYYY-MM-DD]");
-      return 1;
-    }
-
     try {
       const result = await collectCodexForRegisteredProjects({
         homeDir: options.homeDir,
         codexHome: options.codexHome,
         now: options.now ?? (() => new Date().toISOString()),
-        targetDate
+        targetDate: codexTargetDate
       });
 
       if (result.codexLogsMissing) {
@@ -937,21 +977,6 @@ async function runCollect(
   }
 
   if (args[0] === "github") {
-    const ghArgs = args.slice(1);
-    let ghTargetDate: string | undefined;
-    for (let i = 0; i < ghArgs.length; i++) {
-      if (ghArgs[i] === "--date") {
-        if (i + 1 >= ghArgs.length) {
-          io.stderr("Usage: uncommitted collect github [--date YYYY-MM-DD]");
-          return 1;
-        }
-        ghTargetDate = ghArgs[++i];
-        continue;
-      }
-      io.stderr("Usage: uncommitted collect github [--date YYYY-MM-DD]");
-      return 1;
-    }
-
     try {
       const result = await collectGitHubForRegisteredProjects({
         homeDir: options.homeDir,
@@ -995,13 +1020,22 @@ async function runCollectAllCommand(
   io: CliIo,
   options: CliOptions
 ): Promise<number> {
-  const summary = await runCollectAll({
-    homeDir: options.homeDir,
-    claudeHome: options.claudeHome,
-    codexHome: options.codexHome,
-    now: options.now,
-    collectInvokers: options.collectInvokers
-  });
+  let summary;
+  try {
+    summary = await runCollectAll({
+      homeDir: options.homeDir,
+      claudeHome: options.claudeHome,
+      codexHome: options.codexHome,
+      now: options.now,
+      collectInvokers: options.collectInvokers
+    });
+  } catch (error) {
+    if (error instanceof SourceConfigError) {
+      io.stderr(error.message);
+      return 2;
+    }
+    throw error;
+  }
 
   const enabledEntries = summary.entries.filter(
     (entry) => entry.status !== "disabled"

--- a/src/collect-all.ts
+++ b/src/collect-all.ts
@@ -1,0 +1,210 @@
+import { collectClaudeForRegisteredProjects } from "./collect-claude-command.js";
+import { collectCodexForRegisteredProjects } from "./collect-codex-command.js";
+import { collectGitForRegisteredProjects } from "./collect-git-command.js";
+import { collectGitHubForRegisteredProjects } from "./collect-github-command.js";
+import { resolveConfigPaths } from "./config-paths.js";
+import {
+  loadSourceConfig,
+  SOURCE_NAMES,
+  type SourceName
+} from "./source-config.js";
+
+/**
+ * Normalized per-source invoker return shape used by the `collect all`
+ * orchestrator. Each invoker reports how many per-project collections
+ * succeeded/failed and an optional human-readable detail line.
+ */
+export type CollectInvokerResult = {
+  successCount: number;
+  failureCount: number;
+  detail?: string;
+};
+
+export type CollectInvoker = () => Promise<CollectInvokerResult>;
+
+export type CollectInvokerMap = Record<SourceName, CollectInvoker>;
+
+export type CollectAllOptions = {
+  homeDir?: string;
+  claudeHome?: string;
+  codexHome?: string;
+  now?: () => string;
+  /**
+   * Optional per-source invoker overrides. Any source omitted falls back to
+   * the default per-source command wrapper. Test fixtures use this hook to
+   * stub success/failure without exercising live collectors.
+   */
+  collectInvokers?: Partial<CollectInvokerMap>;
+};
+
+export type CollectAllEntry =
+  | { source: SourceName; status: "success"; detail: string }
+  | { source: SourceName; status: "failed"; detail: string }
+  | { source: SourceName; status: "disabled" };
+
+export type CollectAllSummary = {
+  exitCode: number;
+  entries: CollectAllEntry[];
+};
+
+/**
+ * Iterate every source declared in config:
+ *  - disabled → record a `disabled` entry, do not invoke.
+ *  - enabled  → call the per-source invoker inside a try/catch so one source's
+ *    failure cannot abort the run (failure isolation).
+ *
+ * Exit code rules:
+ *  - 0 if at least one enabled source succeeded.
+ *  - 0 if zero sources are enabled (treated as a no-op, not an error).
+ *  - 3 only when every enabled source failed.
+ */
+export async function runCollectAll(
+  options: CollectAllOptions
+): Promise<CollectAllSummary> {
+  const paths = resolveConfigPaths({ homeDir: options.homeDir });
+  const sourceConfig = await loadSourceConfig(paths.configFile);
+  const invokers = resolveInvokerMap(options);
+
+  const entries: CollectAllEntry[] = [];
+  let enabledCount = 0;
+  let successCount = 0;
+
+  for (const source of SOURCE_NAMES) {
+    if (!sourceConfig[source].enabled) {
+      entries.push({ source, status: "disabled" });
+      continue;
+    }
+
+    enabledCount += 1;
+    const invoke = invokers[source];
+
+    try {
+      const result = await invoke();
+      const detail = formatInvokerDetail(result);
+      entries.push({ source, status: "success", detail });
+      successCount += 1;
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      entries.push({ source, status: "failed", detail });
+    }
+  }
+
+  // No-op exit (zero sources enabled) and partial-success exit both 0. Only
+  // total enabled-source failure escalates to 3 (consistent with per-source
+  // collect exit codes).
+  const exitCode = enabledCount === 0 ? 0 : successCount > 0 ? 0 : 3;
+
+  return { exitCode, entries };
+}
+
+function resolveInvokerMap(options: CollectAllOptions): CollectInvokerMap {
+  const defaults = buildDefaultInvokers(options);
+  const overrides = options.collectInvokers ?? {};
+
+  return {
+    git: overrides.git ?? defaults.git,
+    claude: overrides.claude ?? defaults.claude,
+    codex: overrides.codex ?? defaults.codex,
+    github: overrides.github ?? defaults.github
+  };
+}
+
+function buildDefaultInvokers(options: CollectAllOptions): CollectInvokerMap {
+  const now = options.now ?? (() => new Date().toISOString());
+
+  return {
+    git: async () => {
+      const result = await collectGitForRegisteredProjects({
+        homeDir: options.homeDir,
+        now
+      });
+      const totals = sumActivityTotals(result.successes);
+      return {
+        successCount: result.successes.length,
+        failureCount: result.failures.length,
+        detail: `${formatProjectCount(result.successes.length)}, ${totals.commits} commits`
+      };
+    },
+    claude: async () => {
+      const result = await collectClaudeForRegisteredProjects({
+        homeDir: options.homeDir,
+        claudeHome: options.claudeHome,
+        now
+      });
+      if (result.claudeLogsMissing) {
+        return {
+          successCount: 0,
+          failureCount: 0,
+          detail: "no Claude session logs found"
+        };
+      }
+      const signals = sumSignalCounts(result.successes);
+      return {
+        successCount: result.successes.length,
+        failureCount: result.failures.length,
+        detail: `${formatProjectCount(result.successes.length)}, ${signals} signals`
+      };
+    },
+    codex: async () => {
+      const result = await collectCodexForRegisteredProjects({
+        homeDir: options.homeDir,
+        codexHome: options.codexHome,
+        now
+      });
+      if (result.codexLogsMissing) {
+        return {
+          successCount: 0,
+          failureCount: 0,
+          detail: "no Codex session logs found"
+        };
+      }
+      const signals = sumSignalCounts(result.successes);
+      return {
+        successCount: result.successes.length,
+        failureCount: result.failures.length,
+        detail: `${formatProjectCount(result.successes.length)}, ${signals} signals`
+      };
+    },
+    github: async () => {
+      const result = await collectGitHubForRegisteredProjects({
+        homeDir: options.homeDir,
+        now
+      });
+      const signals = result.successes.reduce(
+        (acc, success) => acc + success.signalCount,
+        0
+      );
+      return {
+        successCount: result.successes.length,
+        failureCount: result.failures.length,
+        detail: `${formatProjectCount(result.successes.length)}, ${signals} signals`
+      };
+    }
+  };
+}
+
+function formatInvokerDetail(result: CollectInvokerResult): string {
+  if (result.detail && result.detail.length > 0) {
+    return result.detail;
+  }
+  return `${result.successCount} ok, ${result.failureCount} failed`;
+}
+
+function sumActivityTotals(
+  successes: ReadonlyArray<{ activity: { totals: { commits: number } } }>
+): { commits: number } {
+  return successes.reduce(
+    (acc, success) => ({ commits: acc.commits + success.activity.totals.commits }),
+    { commits: 0 }
+  );
+}
+
+function sumSignalCounts(
+  successes: ReadonlyArray<{ signalCount: number }>
+): number {
+  return successes.reduce((acc, success) => acc + success.signalCount, 0);
+}
+
+function formatProjectCount(count: number): string {
+  return count === 1 ? "1 project" : `${count} projects`;
+}

--- a/src/collect-all.ts
+++ b/src/collect-all.ts
@@ -81,8 +81,16 @@ export async function runCollectAll(
     try {
       const result = await invoke();
       const detail = formatInvokerDetail(result);
-      entries.push({ source, status: "success", detail });
-      successCount += 1;
+      // A collector that returns per-project failures without throwing (broken
+      // project path, fetch/write error) is still a failed run — mirror the
+      // per-source `collect <source>` exit-3 behavior instead of reporting
+      // success and masking the failure.
+      if (result.failureCount > 0) {
+        entries.push({ source, status: "failed", detail });
+      } else {
+        entries.push({ source, status: "success", detail });
+        successCount += 1;
+      }
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
       entries.push({ source, status: "failed", detail });
@@ -109,8 +117,24 @@ function resolveInvokerMap(options: CollectAllOptions): CollectInvokerMap {
   };
 }
 
+/**
+ * Wrap a clock so the first reading is captured and reused for the rest of the
+ * run. Without this, each per-source collector would call `now()` as it starts,
+ * and a `collect all` run that straddles UTC midnight could write events under
+ * two different dates — splitting one run so `generate today` sees only part.
+ */
+export function createStableNow(now?: () => string): () => string {
+  let cached: string | undefined;
+  return () => {
+    if (cached === undefined) {
+      cached = now ? now() : new Date().toISOString();
+    }
+    return cached;
+  };
+}
+
 function buildDefaultInvokers(options: CollectAllOptions): CollectInvokerMap {
-  const now = options.now ?? (() => new Date().toISOString());
+  const now = createStableNow(options.now);
 
   return {
     git: async () => {
@@ -184,10 +208,16 @@ function buildDefaultInvokers(options: CollectAllOptions): CollectInvokerMap {
 }
 
 function formatInvokerDetail(result: CollectInvokerResult): string {
-  if (result.detail && result.detail.length > 0) {
-    return result.detail;
+  const base =
+    result.detail && result.detail.length > 0
+      ? result.detail
+      : `${result.successCount} ok, ${result.failureCount} failed`;
+  // Surface the failure count on the success-flavored default detail so a
+  // partially failed source does not read as fully clean.
+  if (result.failureCount > 0 && !base.includes("failed")) {
+    return `${base} (${result.failureCount} failed)`;
   }
-  return `${result.successCount} ok, ${result.failureCount} failed`;
+  return base;
 }
 
 function sumActivityTotals(

--- a/src/generate-command.ts
+++ b/src/generate-command.ts
@@ -32,6 +32,7 @@ import {
 } from "./draft-storage.js";
 import type { ManualNoteEvent } from "./note-command.js";
 import type { ProjectRecord, ProjectsFile } from "./project-add.js";
+import { loadSourceConfig } from "./source-config.js";
 import {
   createSafetyReport,
   type SafetyReport,
@@ -195,11 +196,22 @@ export async function runGenerateCommand(
   }
 
   const generatedAt = options.now ? options.now() : new Date().toISOString();
-  const gitEvents = await readGitActivityEvents(projects, targetDate);
+  const sourceConfig = await loadSourceConfig(paths.configFile);
+  const gitEvents = sourceConfig.git.enabled
+    ? await readGitActivityEvents(projects, targetDate)
+    : [];
+  // Manual notes are project-local user input, not a tracked source — they are
+  // loaded unconditionally regardless of per-source enable flags.
   const manualNotes = await readManualNoteEvents(projects, targetDate);
-  const claudeSignals = await readClaudeActivitySignals(projects, targetDate);
-  const codexSignals = await readCodexActivitySignals(projects, targetDate);
-  const githubSignals = await readGitHubActivitySignals(projects, targetDate);
+  const claudeSignals = sourceConfig.claude.enabled
+    ? await readClaudeActivitySignals(projects, targetDate)
+    : [];
+  const codexSignals = sourceConfig.codex.enabled
+    ? await readCodexActivitySignals(projects, targetDate)
+    : [];
+  const githubSignals = sourceConfig.github.enabled
+    ? await readGitHubActivitySignals(projects, targetDate)
+    : [];
   const activitySummary = buildActivitySummary({
     targetDate,
     generatedAt,

--- a/src/init-command.ts
+++ b/src/init-command.ts
@@ -3,6 +3,7 @@ import process from "node:process";
 import { createInterface } from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
 import { ensureConfigDirectories, resolveConfigPaths } from "./config-paths.js";
+import { defaultSourceConfigMap, type SourceConfigMap } from "./source-config.js";
 
 export type InitAnswers = {
   draftRoot?: string;
@@ -30,6 +31,7 @@ export type InitConfig = {
   roastLevel: number;
   rawRetentionDays: number;
   captionProjectionTokenBudget: number;
+  sources: SourceConfigMap;
 };
 
 export type InitCommandResult = {
@@ -94,7 +96,8 @@ export async function runInitCommand(
     persona: answers.persona,
     roastLevel,
     rawRetentionDays,
-    captionProjectionTokenBudget
+    captionProjectionTokenBudget,
+    sources: defaultSourceConfigMap()
   };
 
   await writeJson(paths.configFile, config);

--- a/src/source-config.ts
+++ b/src/source-config.ts
@@ -15,6 +15,18 @@ export type SourceConfigRecord = {
 
 export type SourceConfigMap = Record<SourceName, SourceConfigRecord>;
 
+/**
+ * Raised when `config.json` exists but cannot be read or parsed. A missing
+ * file is NOT an error (it falls back to all-enabled defaults); a malformed or
+ * permission-denied file is, so the opt-out gate cannot be silently bypassed.
+ */
+export class SourceConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SourceConfigError";
+  }
+}
+
 export function isSourceEnabled(config: unknown, source: SourceName): boolean {
   const record = readSourceRecord(config, source);
 
@@ -32,13 +44,30 @@ export function listEnabledSources(config: unknown): SourceName[] {
 export async function loadSourceConfig(
   configFilePath: string
 ): Promise<SourceConfigMap> {
+  let raw: string;
+
+  try {
+    raw = await readFile(configFilePath, "utf8");
+  } catch (error) {
+    // A missing config file is a valid first-run state: default everything on.
+    // Any other read error (permissions, I/O) must surface as a config error
+    // rather than silently enabling all sources.
+    if (isNotFoundError(error)) {
+      return buildSourceConfigMap({});
+    }
+    throw new SourceConfigError(
+      `Unable to read source config at ${configFilePath}.`
+    );
+  }
+
   let parsed: unknown;
 
   try {
-    const raw = await readFile(configFilePath, "utf8");
     parsed = JSON.parse(raw);
   } catch {
-    parsed = {};
+    throw new SourceConfigError(
+      `Malformed source config at ${configFilePath}; fix or remove the file.`
+    );
   }
 
   return buildSourceConfigMap(parsed);
@@ -93,4 +122,8 @@ function readSourceRecord(
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return isRecord(error) && error.code === "ENOENT";
 }

--- a/src/source-config.ts
+++ b/src/source-config.ts
@@ -1,0 +1,96 @@
+import { readFile } from "node:fs/promises";
+
+export type SourceName = "git" | "claude" | "codex" | "github";
+
+export const SOURCE_NAMES: readonly SourceName[] = [
+  "git",
+  "claude",
+  "codex",
+  "github"
+];
+
+export type SourceConfigRecord = {
+  enabled: boolean;
+};
+
+export type SourceConfigMap = Record<SourceName, SourceConfigRecord>;
+
+export function isSourceEnabled(config: unknown, source: SourceName): boolean {
+  const record = readSourceRecord(config, source);
+
+  if (record === undefined) {
+    return true;
+  }
+
+  return record.enabled !== false;
+}
+
+export function listEnabledSources(config: unknown): SourceName[] {
+  return SOURCE_NAMES.filter((name) => isSourceEnabled(config, name));
+}
+
+export async function loadSourceConfig(
+  configFilePath: string
+): Promise<SourceConfigMap> {
+  let parsed: unknown;
+
+  try {
+    const raw = await readFile(configFilePath, "utf8");
+    parsed = JSON.parse(raw);
+  } catch {
+    parsed = {};
+  }
+
+  return buildSourceConfigMap(parsed);
+}
+
+export function buildSourceConfigMap(config: unknown): SourceConfigMap {
+  const map = {} as SourceConfigMap;
+
+  for (const name of SOURCE_NAMES) {
+    const record = readSourceRecord(config, name);
+    map[name] = { enabled: record?.enabled !== false };
+  }
+
+  return map;
+}
+
+export const defaultSourceConfigMap = (): SourceConfigMap => ({
+  git: { enabled: true },
+  claude: { enabled: true },
+  codex: { enabled: true },
+  github: { enabled: true }
+});
+
+function readSourceRecord(
+  config: unknown,
+  source: SourceName
+): SourceConfigRecord | undefined {
+  if (!isRecord(config)) {
+    return undefined;
+  }
+
+  const sources = config.sources;
+
+  if (!isRecord(sources)) {
+    return undefined;
+  }
+
+  const candidate = sources[source];
+
+  if (!isRecord(candidate)) {
+    return undefined;
+  }
+
+  const enabled = candidate.enabled;
+
+  if (typeof enabled !== "boolean") {
+    return undefined;
+  }
+
+  return { enabled };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/tests/cli-collect-all.test.ts
+++ b/tests/cli-collect-all.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { runCli } from "../src/cli.js";
+import { createStableNow } from "../src/collect-all.js";
 import type { SourceName } from "../src/source-config.js";
 
 function createIo() {
@@ -176,6 +177,64 @@ describe("cli collect all orchestration", () => {
     expect(out).toContain("Source 'github': failed");
   });
 
+  it("treats per-project failures as a source failure even when the invoker does not throw", async () => {
+    const { io, stdout } = createIo();
+    const directory = await mkdtemp(
+      join(tmpdir(), "uncommitted-collect-all-project-fail-")
+    );
+    const homeDir = join(directory, "home");
+    await writeConfig(homeDir, configWithSources());
+
+    const collectInvokers = {
+      git: async () => ({ successCount: 0, failureCount: 2, detail: "2 projects" }),
+      claude: async () => ({ successCount: 0, failureCount: 1, detail: "1 project" }),
+      codex: async () => ({ successCount: 0, failureCount: 1 }),
+      github: async () => ({ successCount: 0, failureCount: 1 })
+    };
+
+    const exitCode = await runCli(["collect", "all"], io, {
+      homeDir,
+      collectInvokers
+    });
+
+    // Every enabled source reported only per-project failures → exit 3,
+    // matching the per-source `collect <source>` contract.
+    expect(exitCode).toBe(3);
+    const out = stdout.join("\n");
+    expect(out).toContain("Source 'git': failed");
+    expect(out).toContain("Source 'claude': failed");
+    expect(out).toContain("Source 'codex': failed");
+    expect(out).toContain("Source 'github': failed");
+  });
+
+  it("marks a partially failed source as failed but still exits 0 when another source succeeds", async () => {
+    const { io, stdout } = createIo();
+    const directory = await mkdtemp(
+      join(tmpdir(), "uncommitted-collect-all-partial-fail-")
+    );
+    const homeDir = join(directory, "home");
+    await writeConfig(homeDir, configWithSources());
+
+    const collectInvokers = {
+      git: async () => ({ successCount: 3, failureCount: 0, detail: "3 projects" }),
+      claude: async () => ({ successCount: 1, failureCount: 0, detail: "1 project" }),
+      codex: async () => ({ successCount: 1, failureCount: 0, detail: "1 project" }),
+      github: async () => ({ successCount: 2, failureCount: 1, detail: "2 projects" })
+    };
+
+    const exitCode = await runCli(["collect", "all"], io, {
+      homeDir,
+      collectInvokers
+    });
+
+    expect(exitCode).toBe(0);
+    const out = stdout.join("\n");
+    expect(out).toContain("Source 'git': success");
+    expect(out).toContain("Source 'github': failed");
+    // The success-flavored detail still surfaces the failure count.
+    expect(out).toContain("1 failed");
+  });
+
   it("only invokes enabled sources; disabled ones are reported but not called", async () => {
     const { io, stdout } = createIo();
     const directory = await mkdtemp(
@@ -210,6 +269,21 @@ describe("cli collect all orchestration", () => {
     expect(out).toContain("Source 'claude': disabled");
     expect(out).toContain("Source 'codex': disabled");
     expect(out).toContain("Source 'github': disabled");
+  });
+
+  it("captures a single timestamp for the whole run (createStableNow)", () => {
+    let tick = 0;
+    const stable = createStableNow(() => {
+      tick += 1;
+      return `2026-06-22T0${tick}:00:00.000Z`;
+    });
+
+    // Every collector reads the same instant, even across UTC-midnight runs, so
+    // the run cannot split events across two dates.
+    expect(stable()).toBe("2026-06-22T01:00:00.000Z");
+    expect(stable()).toBe("2026-06-22T01:00:00.000Z");
+    expect(stable()).toBe("2026-06-22T01:00:00.000Z");
+    expect(tick).toBe(1);
   });
 
   it("exits 0 with a no-sources-enabled marker when every source is disabled", async () => {

--- a/tests/cli-collect-all.test.ts
+++ b/tests/cli-collect-all.test.ts
@@ -1,0 +1,244 @@
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { runCli } from "../src/cli.js";
+import type { SourceName } from "../src/source-config.js";
+
+function createIo() {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+
+  return {
+    io: {
+      stdout: (message: string) => stdout.push(message),
+      stderr: (message: string) => stderr.push(message)
+    },
+    stdout,
+    stderr
+  };
+}
+
+async function writeConfig(
+  homeDir: string,
+  config: Record<string, unknown>
+): Promise<void> {
+  await mkdir(join(homeDir, ".uncommitted"), { recursive: true });
+  await writeFile(
+    join(homeDir, ".uncommitted", "config.json"),
+    JSON.stringify(config, null, 2) + "\n",
+    "utf8"
+  );
+}
+
+function configWithSources(
+  overrides: Partial<Record<SourceName, boolean>> = {}
+): Record<string, unknown> {
+  const sources: Record<string, { enabled: boolean }> = {
+    git: { enabled: overrides.git ?? true },
+    claude: { enabled: overrides.claude ?? true },
+    codex: { enabled: overrides.codex ?? true },
+    github: { enabled: overrides.github ?? true }
+  };
+  return {
+    schemaVersion: 1,
+    sources
+  };
+}
+
+type StubResult = {
+  ok: boolean;
+  message: string;
+};
+
+function createStubInvokers(
+  responses: Partial<Record<SourceName, StubResult>>,
+  calls: SourceName[]
+): Record<SourceName, () => Promise<{ successCount: number; failureCount: number; detail?: string }>> {
+  const make = (name: SourceName) => async () => {
+    calls.push(name);
+    const response = responses[name];
+    if (!response) {
+      return { successCount: 1, failureCount: 0, detail: "ok" };
+    }
+    if (!response.ok) {
+      throw new Error(response.message);
+    }
+    return { successCount: 1, failureCount: 0, detail: response.message };
+  };
+  return {
+    git: make("git"),
+    claude: make("claude"),
+    codex: make("codex"),
+    github: make("github")
+  };
+}
+
+describe("cli collect all orchestration", () => {
+  it("invokes every enabled source and exits 0 when all succeed", async () => {
+    const { io, stdout, stderr } = createIo();
+    const directory = await mkdtemp(
+      join(tmpdir(), "uncommitted-collect-all-success-")
+    );
+    const homeDir = join(directory, "home");
+    await writeConfig(homeDir, configWithSources());
+
+    const calls: SourceName[] = [];
+    const collectInvokers = createStubInvokers(
+      {
+        git: { ok: true, message: "git ok" },
+        claude: { ok: true, message: "claude ok" },
+        codex: { ok: true, message: "codex ok" },
+        github: { ok: true, message: "github ok" }
+      },
+      calls
+    );
+
+    const exitCode = await runCli(["collect", "all"], io, {
+      homeDir,
+      collectInvokers
+    });
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toEqual([]);
+    expect(calls.sort()).toEqual(["claude", "codex", "git", "github"]);
+    const out = stdout.join("\n");
+    expect(out).toContain("Source 'git': success");
+    expect(out).toContain("Source 'claude': success");
+    expect(out).toContain("Source 'codex': success");
+    expect(out).toContain("Source 'github': success");
+  });
+
+  it("isolates per-source failures: one throws, others succeed, exit 0", async () => {
+    const { io, stdout } = createIo();
+    const directory = await mkdtemp(
+      join(tmpdir(), "uncommitted-collect-all-isolate-")
+    );
+    const homeDir = join(directory, "home");
+    await writeConfig(homeDir, configWithSources());
+
+    const calls: SourceName[] = [];
+    const collectInvokers = createStubInvokers(
+      {
+        git: { ok: true, message: "git ok" },
+        claude: { ok: true, message: "claude ok" },
+        codex: { ok: true, message: "codex ok" },
+        github: { ok: false, message: "no GitHub token configured" }
+      },
+      calls
+    );
+
+    const exitCode = await runCli(["collect", "all"], io, {
+      homeDir,
+      collectInvokers
+    });
+
+    expect(exitCode).toBe(0);
+    expect(calls.sort()).toEqual(["claude", "codex", "git", "github"]);
+    const out = stdout.join("\n");
+    expect(out).toContain("Source 'git': success");
+    expect(out).toContain("Source 'claude': success");
+    expect(out).toContain("Source 'codex': success");
+    expect(out).toContain("Source 'github': failed");
+    expect(out).toContain("no GitHub token configured");
+  });
+
+  it("returns exit 3 when every enabled source fails", async () => {
+    const { io, stdout } = createIo();
+    const directory = await mkdtemp(
+      join(tmpdir(), "uncommitted-collect-all-all-fail-")
+    );
+    const homeDir = join(directory, "home");
+    await writeConfig(homeDir, configWithSources());
+
+    const calls: SourceName[] = [];
+    const collectInvokers = createStubInvokers(
+      {
+        git: { ok: false, message: "git broke" },
+        claude: { ok: false, message: "claude broke" },
+        codex: { ok: false, message: "codex broke" },
+        github: { ok: false, message: "github broke" }
+      },
+      calls
+    );
+
+    const exitCode = await runCli(["collect", "all"], io, {
+      homeDir,
+      collectInvokers
+    });
+
+    expect(exitCode).toBe(3);
+    expect(calls.sort()).toEqual(["claude", "codex", "git", "github"]);
+    const out = stdout.join("\n");
+    expect(out).toContain("Source 'git': failed");
+    expect(out).toContain("Source 'claude': failed");
+    expect(out).toContain("Source 'codex': failed");
+    expect(out).toContain("Source 'github': failed");
+  });
+
+  it("only invokes enabled sources; disabled ones are reported but not called", async () => {
+    const { io, stdout } = createIo();
+    const directory = await mkdtemp(
+      join(tmpdir(), "uncommitted-collect-all-mostly-disabled-")
+    );
+    const homeDir = join(directory, "home");
+    await writeConfig(
+      homeDir,
+      configWithSources({ claude: false, codex: false, github: false })
+    );
+
+    const calls: SourceName[] = [];
+    const collectInvokers = createStubInvokers(
+      {
+        git: { ok: true, message: "git ok" },
+        claude: { ok: true, message: "should not run" },
+        codex: { ok: true, message: "should not run" },
+        github: { ok: true, message: "should not run" }
+      },
+      calls
+    );
+
+    const exitCode = await runCli(["collect", "all"], io, {
+      homeDir,
+      collectInvokers
+    });
+
+    expect(exitCode).toBe(0);
+    expect(calls).toEqual(["git"]);
+    const out = stdout.join("\n");
+    expect(out).toContain("Source 'git': success");
+    expect(out).toContain("Source 'claude': disabled");
+    expect(out).toContain("Source 'codex': disabled");
+    expect(out).toContain("Source 'github': disabled");
+  });
+
+  it("exits 0 with a no-sources-enabled marker when every source is disabled", async () => {
+    const { io, stdout } = createIo();
+    const directory = await mkdtemp(
+      join(tmpdir(), "uncommitted-collect-all-none-")
+    );
+    const homeDir = join(directory, "home");
+    await writeConfig(
+      homeDir,
+      configWithSources({
+        git: false,
+        claude: false,
+        codex: false,
+        github: false
+      })
+    );
+
+    const calls: SourceName[] = [];
+    const collectInvokers = createStubInvokers({}, calls);
+
+    const exitCode = await runCli(["collect", "all"], io, {
+      homeDir,
+      collectInvokers
+    });
+
+    expect(exitCode).toBe(0);
+    expect(calls).toEqual([]);
+    const out = stdout.join("\n");
+    expect(out).toContain("no sources enabled");
+  });
+});

--- a/tests/cli-collect-source-gating.test.ts
+++ b/tests/cli-collect-source-gating.test.ts
@@ -1,0 +1,141 @@
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { runCli } from "../src/cli.js";
+
+type SourceName = "git" | "claude" | "codex" | "github";
+
+function createIo() {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+
+  return {
+    io: {
+      stdout: (message: string) => stdout.push(message),
+      stderr: (message: string) => stderr.push(message)
+    },
+    stdout,
+    stderr
+  };
+}
+
+async function writeConfig(
+  homeDir: string,
+  config: Record<string, unknown>
+): Promise<void> {
+  await mkdir(join(homeDir, ".uncommitted"), { recursive: true });
+  await writeFile(
+    join(homeDir, ".uncommitted", "config.json"),
+    JSON.stringify(config, null, 2) + "\n",
+    "utf8"
+  );
+}
+
+async function writeProjectsFile(
+  homeDir: string,
+  repoDir: string
+): Promise<void> {
+  await mkdir(join(homeDir, ".uncommitted"), { recursive: true });
+  await writeFile(
+    join(homeDir, ".uncommitted", "projects.json"),
+    JSON.stringify(
+      {
+        schemaVersion: 1,
+        projects: [
+          {
+            schemaVersion: 1,
+            id: "p1",
+            name: "demo",
+            root: repoDir,
+            gitRoot: repoDir,
+            enabled: true,
+            createdAt: "2026-05-01T00:00:00.000Z"
+          }
+        ]
+      },
+      null,
+      2
+    ) + "\n",
+    "utf8"
+  );
+}
+
+function configWith(disabled: SourceName): Record<string, unknown> {
+  const sources: Record<string, { enabled: boolean }> = {
+    git: { enabled: true },
+    claude: { enabled: true },
+    codex: { enabled: true },
+    github: { enabled: true }
+  };
+  sources[disabled] = { enabled: false };
+  return {
+    schemaVersion: 1,
+    sources
+  };
+}
+
+describe("cli collect <source> per-source gating", () => {
+  for (const source of ["git", "claude", "codex", "github"] as const) {
+    it(`exits 0 with a disabled message when sources.${source}.enabled is false`, async () => {
+      const { io, stdout, stderr } = createIo();
+      const directory = await mkdtemp(
+        join(tmpdir(), `uncommitted-cli-collect-gate-${source}-`)
+      );
+      const repoDir = join(directory, "repo");
+      const homeDir = join(directory, "home");
+
+      await mkdir(repoDir, { recursive: true });
+      await writeProjectsFile(homeDir, repoDir);
+      await writeConfig(homeDir, configWith(source));
+
+      const exitCode = await runCli(["collect", source], io, {
+        homeDir,
+        claudeHome: join(directory, "claude-home"),
+        codexHome: join(directory, "codex-home"),
+        now: () => "2026-05-06T13:30:00.000Z"
+      });
+
+      expect(exitCode).toBe(0);
+      expect(stderr).toEqual([]);
+      expect(stdout.join("\n")).toContain(
+        `Source '${source}' is disabled in config; skipping collection.`
+      );
+    });
+  }
+
+  it("invokes the claude collector when sources.claude.enabled is true (sanity)", async () => {
+    const { io, stdout, stderr } = createIo();
+    const directory = await mkdtemp(
+      join(tmpdir(), "uncommitted-cli-collect-gate-enabled-")
+    );
+    const repoDir = join(directory, "repo");
+    const homeDir = join(directory, "home");
+
+    await mkdir(repoDir, { recursive: true });
+    await writeProjectsFile(homeDir, repoDir);
+    await writeConfig(homeDir, {
+      schemaVersion: 1,
+      sources: {
+        git: { enabled: true },
+        claude: { enabled: true },
+        codex: { enabled: true },
+        github: { enabled: true }
+      }
+    });
+
+    const exitCode = await runCli(["collect", "claude"], io, {
+      homeDir,
+      claudeHome: join(directory, "claude-home"),
+      now: () => "2026-05-06T13:30:00.000Z"
+    });
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toEqual([]);
+    // Sanity: the collector runs (claude-home does not exist, so it reports the
+    // "no Claude session logs" path that only the collector can emit). The
+    // disabled-message must NOT appear.
+    expect(stdout.join("\n")).toContain("No Claude session logs found");
+    expect(stdout.join("\n")).not.toContain("disabled in config");
+  });
+});

--- a/tests/cli-collect-source-gating.test.ts
+++ b/tests/cli-collect-source-gating.test.ts
@@ -104,6 +104,64 @@ describe("cli collect <source> per-source gating", () => {
     });
   }
 
+  it("rejects a dangling codex --date even when codex is disabled", async () => {
+    const { io, stdout, stderr } = createIo();
+    const directory = await mkdtemp(
+      join(tmpdir(), "uncommitted-cli-collect-codex-typo-")
+    );
+    const homeDir = join(directory, "home");
+    await writeConfig(homeDir, configWith("codex"));
+
+    const exitCode = await runCli(["collect", "codex", "--date"], io, {
+      homeDir
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stderr.join("\n")).toContain(
+      "Usage: uncommitted collect codex [--date YYYY-MM-DD]"
+    );
+    // The disabled-skip must NOT short-circuit the argument validation.
+    expect(stdout.join("\n")).not.toContain("disabled in config");
+  });
+
+  it("rejects an unknown github flag even when github is disabled", async () => {
+    const { io, stdout, stderr } = createIo();
+    const directory = await mkdtemp(
+      join(tmpdir(), "uncommitted-cli-collect-github-typo-")
+    );
+    const homeDir = join(directory, "home");
+    await writeConfig(homeDir, configWith("github"));
+
+    const exitCode = await runCli(["collect", "github", "--bogus"], io, {
+      homeDir
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stderr.join("\n")).toContain(
+      "Usage: uncommitted collect github [--date YYYY-MM-DD]"
+    );
+    expect(stdout.join("\n")).not.toContain("disabled in config");
+  });
+
+  it("exits 2 (config error) when config.json is malformed", async () => {
+    const { io, stderr } = createIo();
+    const directory = await mkdtemp(
+      join(tmpdir(), "uncommitted-cli-collect-malformed-")
+    );
+    const homeDir = join(directory, "home");
+    await mkdir(join(homeDir, ".uncommitted"), { recursive: true });
+    await writeFile(
+      join(homeDir, ".uncommitted", "config.json"),
+      "{ not valid json",
+      "utf8"
+    );
+
+    const exitCode = await runCli(["collect", "git"], io, { homeDir });
+
+    expect(exitCode).toBe(2);
+    expect(stderr.join("\n")).toContain("Malformed source config");
+  });
+
   it("invokes the claude collector when sources.claude.enabled is true (sanity)", async () => {
     const { io, stdout, stderr } = createIo();
     const directory = await mkdtemp(

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -65,7 +65,7 @@ describe("cli", () => {
 
     expect(exitCode).toBe(1);
     expect(stdout).toEqual([]);
-    expect(stderr.join("\n")).toContain("Usage: uncommitted collect <git|claude|codex|github>");
+    expect(stderr.join("\n")).toContain("Usage: uncommitted collect <git|claude|codex|github|all>");
   });
 
   it("rejects extra arguments for collect git instead of silently ignoring them", async () => {

--- a/tests/collect-all-generate-e2e.test.ts
+++ b/tests/collect-all-generate-e2e.test.ts
@@ -1,0 +1,571 @@
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+import type {
+  AiProvider,
+  AiProviderRawResponse,
+  AiStructuredGenerationRequest
+} from "../src/ai-provider.js";
+import { runCli } from "../src/cli.js";
+import type { GitActivityEvent } from "../src/collect-git-command.js";
+import type { CaptionResult, DiaryDraft } from "../src/diary-generator.js";
+import { addProject, type ProjectRecord } from "../src/project-add.js";
+import type { SourceName } from "../src/source-config.js";
+import type { StoryFormatPlan } from "../src/story-format-plan.js";
+
+const execFileAsync = promisify(execFile);
+
+// End-to-end regression for UNC-120 epic acceptance criterion:
+// `collect all` followed by `generate today` must produce output that is
+// visibly different when non-git sources (claude/codex/github) are enabled
+// and seeded with signal fixtures, compared to a git-only baseline run.
+//
+// Two runs are executed against fully separate tmpdirs (separate fake
+// `~/.uncommitted/` config + projects + separate draft roots) so the runs
+// cannot interfere with each other. The difference is pinned at two layers:
+//   1. The on-disk `activity-summary.json` (`smallWins` field) — non-git
+//      signal summaries appear in the full run but not in the baseline.
+//   2. The AI-provider prompt-context payload (the `input.highlights` array
+//      on the `story-plan` request) — same set-difference, asserted at the
+//      contract boundary between `generate` and the AI provider.
+describe("collect all → generate today end-to-end (UNC-120)", () => {
+  it("baseline (git-only) produces activity-summary without non-git signals", async () => {
+    const targetDate = "2026-06-22";
+    const { artifacts, providerRequests } = await runScenario({
+      targetDate,
+      enabledSources: { git: true, claude: false, codex: false, github: false },
+      seedNonGit: false
+    });
+
+    const summary = artifacts.activitySummary as ActivitySummaryShape;
+    const smallWins = summary.smallWins ?? [];
+    expect(smallWins.some(containsAnyNonGitMarker)).toBe(false);
+
+    const storyPlanRequest = providerRequests.find(
+      (request) => request.task === "story-plan"
+    );
+    expect(storyPlanRequest).toBeDefined();
+    const baselineHighlights = readHighlights(storyPlanRequest!);
+    expect(baselineHighlights.some(containsAnyNonGitMarker)).toBe(false);
+  });
+
+  it("full run (all sources enabled) produces activity-summary with non-git signals that baseline lacks", async () => {
+    const targetDate = "2026-06-22";
+
+    const baseline = await runScenario({
+      targetDate,
+      enabledSources: { git: true, claude: false, codex: false, github: false },
+      seedNonGit: false
+    });
+    const full = await runScenario({
+      targetDate,
+      enabledSources: { git: true, claude: true, codex: true, github: true },
+      seedNonGit: true
+    });
+
+    // Layer 1: on-disk activity summary diff.
+    const baselineWins = new Set(
+      ((baseline.artifacts.activitySummary as ActivitySummaryShape).smallWins ??
+        []) as string[]
+    );
+    const fullWins = ((full.artifacts.activitySummary as ActivitySummaryShape)
+      .smallWins ?? []) as string[];
+    const newWins = fullWins.filter((entry) => !baselineWins.has(entry));
+
+    expect(newWins).toContain(NON_GIT_SIGNAL_SUMMARIES.claude);
+    expect(newWins).toContain(NON_GIT_SIGNAL_SUMMARIES.codex);
+    expect(newWins).toContain(NON_GIT_SIGNAL_SUMMARIES.github);
+
+    // Layer 2: provider prompt-context diff. The story-plan request feeds the
+    // AI with the highlights derived from the activity summary; if non-git
+    // signals reached the provider, the corresponding summaries must appear
+    // there too.
+    const baselinePlan = baseline.providerRequests.find(
+      (request) => request.task === "story-plan"
+    );
+    const fullPlan = full.providerRequests.find(
+      (request) => request.task === "story-plan"
+    );
+    expect(baselinePlan).toBeDefined();
+    expect(fullPlan).toBeDefined();
+
+    const baselineHighlights = new Set(readHighlights(baselinePlan!));
+    const fullHighlights = readHighlights(fullPlan!);
+    const newHighlights = fullHighlights.filter(
+      (entry) => !baselineHighlights.has(entry)
+    );
+
+    expect(newHighlights).toContain(NON_GIT_SIGNAL_SUMMARIES.claude);
+    expect(newHighlights).toContain(NON_GIT_SIGNAL_SUMMARIES.codex);
+    expect(newHighlights).toContain(NON_GIT_SIGNAL_SUMMARIES.github);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario runner
+// ---------------------------------------------------------------------------
+
+type EnabledSources = Record<SourceName, boolean>;
+
+type ScenarioResult = {
+  fixture: RegisteredProjectFixture;
+  artifacts: {
+    activitySummary: unknown;
+    story: unknown;
+    caption: string;
+  };
+  providerRequests: AiStructuredGenerationRequest[];
+};
+
+async function runScenario(options: {
+  targetDate: string;
+  enabledSources: EnabledSources;
+  seedNonGit: boolean;
+}): Promise<ScenarioResult> {
+  const fixture = await createRegisteredProjectFixture({
+    enabledSources: options.enabledSources
+  });
+  const provider = new TaskAwareProvider();
+
+  // Seed git event for the target date — present in both baseline and full
+  // runs so the difference is purely from the non-git sources.
+  await writeGitEvent(fixture.project, options.targetDate);
+
+  // Seed claude/codex/github JSONL signals only for the full run.
+  if (options.seedNonGit) {
+    await writeClaudeSignals(fixture.project, options.targetDate, [
+      {
+        projectId: fixture.project.id,
+        timestamp: `${options.targetDate}T09:00:00.000Z`,
+        kind: "claude-assistant-text",
+        summary: NON_GIT_SIGNAL_SUMMARIES.claude,
+        safetyNotes: []
+      }
+    ]);
+    await writeCodexSignals(fixture.project, options.targetDate, [
+      {
+        projectId: fixture.project.id,
+        timestamp: `${options.targetDate}T10:00:00.000Z`,
+        kind: "codex-assistant-text",
+        summary: NON_GIT_SIGNAL_SUMMARIES.codex,
+        safetyNotes: []
+      }
+    ]);
+    await writeGitHubSignals(fixture.project, options.targetDate, [
+      {
+        projectId: fixture.project.id,
+        timestamp: `${options.targetDate}T11:00:00.000Z`,
+        kind: "pr",
+        summary: NON_GIT_SIGNAL_SUMMARIES.github,
+        safetyNotes: []
+      }
+    ]);
+  }
+
+  const io = createIo();
+  const now = () => `${options.targetDate}T23:30:00.000Z`;
+
+  // Use stub invokers so `collect all` is a deterministic pass-through:
+  // events are already pre-seeded on disk, so generate reads them directly.
+  const stubInvokers = buildStubInvokers();
+  const collectExit = await runCli(["collect", "all"], io.io, {
+    homeDir: fixture.homeDir,
+    now,
+    collectInvokers: stubInvokers
+  });
+  expect(collectExit).toBe(0);
+
+  const generateExit = await runCli(["generate", "today"], io.io, {
+    homeDir: fixture.homeDir,
+    now,
+    aiProvider: provider
+  });
+  expect(generateExit).toBe(0);
+  expect(io.stderr).toEqual([]);
+
+  const outputDir = join(fixture.draftRoot, options.targetDate, "rev-001");
+  const activitySummary = JSON.parse(
+    await readFile(join(outputDir, "activity-summary.json"), "utf8")
+  ) as unknown;
+  const story = JSON.parse(
+    await readFile(join(outputDir, "story.json"), "utf8")
+  ) as unknown;
+  const caption = await readFile(join(outputDir, "caption.txt"), "utf8");
+
+  return {
+    fixture,
+    artifacts: { activitySummary, story, caption },
+    providerRequests: provider.requests
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// Summaries must include a small-win marker (add/built/fixed/implement/
+// implemented/shipped/solved) so the synthesis layer routes them into the
+// `smallWins` field. Without that, the per-source readers would still load
+// them, but they would not surface on the prompt-context highlights.
+const NON_GIT_SIGNAL_SUMMARIES = {
+  claude: "implemented the claude source adapter for the collect-all E2E run",
+  codex: "shipped the codex source dispatcher wiring for the collect-all E2E run",
+  github: "PR #999 merged: add the collect-all github E2E pipeline glue"
+} as const;
+
+type ActivitySummaryShape = {
+  smallWins?: string[];
+};
+
+function containsAnyNonGitMarker(entry: string): boolean {
+  return (
+    entry === NON_GIT_SIGNAL_SUMMARIES.claude ||
+    entry === NON_GIT_SIGNAL_SUMMARIES.codex ||
+    entry === NON_GIT_SIGNAL_SUMMARIES.github
+  );
+}
+
+function readHighlights(request: AiStructuredGenerationRequest): string[] {
+  const input = request.input as { highlights?: unknown } | undefined;
+  if (!input || !Array.isArray(input.highlights)) {
+    return [];
+  }
+  return input.highlights.filter((value): value is string => typeof value === "string");
+}
+
+function buildStubInvokers(): Record<
+  SourceName,
+  () => Promise<{ successCount: number; failureCount: number; detail?: string }>
+> {
+  const stub = async () => ({
+    successCount: 1,
+    failureCount: 0,
+    detail: "1 project, 1 signals (stub)"
+  });
+  return {
+    git: stub,
+    claude: stub,
+    codex: stub,
+    github: stub
+  };
+}
+
+function createIo() {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+
+  return {
+    io: {
+      stdout: (message: string) => stdout.push(message),
+      stderr: (message: string) => stderr.push(message)
+    },
+    stdout,
+    stderr
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fixture + IO helpers (mirror tests/generate-command.test.ts patterns)
+// ---------------------------------------------------------------------------
+
+type RegisteredProjectFixture = {
+  directory: string;
+  repoDir: string;
+  homeDir: string;
+  draftRoot: string;
+  project: ProjectRecord;
+};
+
+async function createRegisteredProjectFixture(options: {
+  enabledSources: EnabledSources;
+}): Promise<RegisteredProjectFixture> {
+  const directory = await mkdtemp(
+    join(tmpdir(), "uncommitted-collect-all-e2e-")
+  );
+  const repoDir = join(directory, "repo");
+  const homeDir = join(directory, "home");
+  const draftRoot = join(directory, "drafts");
+
+  await execFileAsync("git", ["init", repoDir]);
+  await execFileAsync("git", ["-C", repoDir, "config", "user.name", "Fixture Dev"]);
+  await execFileAsync("git", [
+    "-C",
+    repoDir,
+    "config",
+    "user.email",
+    "dev@example.com"
+  ]);
+  await writeConfig(homeDir, draftRoot, options.enabledSources);
+
+  const registered = await addProject(repoDir, {
+    homeDir,
+    now: () => "2026-06-22T00:00:00.000Z"
+  });
+
+  return {
+    directory,
+    repoDir,
+    homeDir,
+    draftRoot,
+    project: registered.project
+  };
+}
+
+async function writeConfig(
+  homeDir: string,
+  draftRoot: string,
+  enabledSources: EnabledSources
+): Promise<void> {
+  const configDir = join(homeDir, ".uncommitted");
+
+  await mkdir(join(configDir, "history"), { recursive: true });
+  await writeFile(
+    join(configDir, "config.json"),
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        draftRoot,
+        scheduleTime: "23:30",
+        aiProvider: "mock",
+        persona: "wry coworker",
+        roastLevel: 2,
+        sources: {
+          git: { enabled: enabledSources.git },
+          claude: { enabled: enabledSources.claude },
+          codex: { enabled: enabledSources.codex },
+          github: { enabled: enabledSources.github }
+        }
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+  await writeFile(
+    join(configDir, "history", "formats.json"),
+    `${JSON.stringify({ schemaVersion: 1, formats: [] })}\n`,
+    "utf8"
+  );
+}
+
+async function writeGitEvent(
+  project: ProjectRecord,
+  targetDate: string
+): Promise<void> {
+  const event: GitActivityEvent = {
+    schemaVersion: 1,
+    source: "git",
+    targetDate,
+    collectedAt: `${targetDate}T23:00:00.000Z`,
+    project: {
+      id: project.id,
+      name: project.name
+    },
+    activity: {
+      schemaVersion: 1,
+      targetDate,
+      repository: {
+        rootName: project.name
+      },
+      commits: [
+        {
+          hash: "deadbee",
+          shortHash: "deadbee",
+          authorName: "Fixture Dev",
+          subject: "wire collect-all orchestration",
+          authoredAt: `${targetDate}T10:00:00.000Z`,
+          stats: {
+            filesChanged: 3,
+            insertions: 60,
+            deletions: 10
+          }
+        }
+      ],
+      dirty: {
+        files: [],
+        totals: {
+          modified: 0,
+          added: 0,
+          deleted: 0,
+          renamed: 0,
+          copied: 0,
+          untracked: 0,
+          other: 0
+        }
+      },
+      totals: {
+        commits: 1,
+        filesChanged: 3,
+        insertions: 60,
+        deletions: 10
+      }
+    }
+  };
+  const eventsDir = join(project.root, ".uncommitted", "events", "git");
+
+  await mkdir(eventsDir, { recursive: true });
+  await writeFile(
+    join(eventsDir, `${targetDate}.json`),
+    `${JSON.stringify(event, null, 2)}\n`,
+    "utf8"
+  );
+}
+
+type SignalSeed = {
+  projectId: string;
+  timestamp: string;
+  kind: string;
+  summary: string;
+  safetyNotes: string[];
+};
+
+async function writeSignals(
+  project: ProjectRecord,
+  source: "claude" | "codex" | "github",
+  targetDate: string,
+  signals: SignalSeed[]
+): Promise<void> {
+  const eventsDir = join(project.root, ".uncommitted", "events", source);
+  await mkdir(eventsDir, { recursive: true });
+  await writeFile(
+    join(eventsDir, `${targetDate}.jsonl`),
+    signals.map((signal) => JSON.stringify(signal)).join("\n") + "\n",
+    "utf8"
+  );
+}
+
+async function writeClaudeSignals(
+  project: ProjectRecord,
+  targetDate: string,
+  signals: SignalSeed[]
+): Promise<void> {
+  await writeSignals(project, "claude", targetDate, signals);
+}
+
+async function writeCodexSignals(
+  project: ProjectRecord,
+  targetDate: string,
+  signals: SignalSeed[]
+): Promise<void> {
+  await writeSignals(project, "codex", targetDate, signals);
+}
+
+async function writeGitHubSignals(
+  project: ProjectRecord,
+  targetDate: string,
+  signals: SignalSeed[]
+): Promise<void> {
+  await writeSignals(project, "github", targetDate, signals);
+}
+
+// ---------------------------------------------------------------------------
+// Provider stub (inlined from tests/generate-command.test.ts to avoid a
+// speculative shared-helper refactor; identical contract).
+// ---------------------------------------------------------------------------
+
+class TaskAwareProvider implements AiProvider {
+  readonly name = "mock";
+  readonly model?: string;
+  readonly requests: AiStructuredGenerationRequest[] = [];
+
+  constructor(
+    private readonly options: {
+      plan?: StoryFormatPlan;
+      draft?: DraftFixture;
+      caption?: CaptionResult;
+      model?: string;
+    } = {}
+  ) {
+    this.model = options.model ?? "fixture-model";
+  }
+
+  async generateStructured(
+    request: AiStructuredGenerationRequest
+  ): Promise<AiProviderRawResponse> {
+    this.requests.push(request);
+
+    if (request.task === "story-plan") {
+      return {
+        responseJson: JSON.stringify(this.options.plan ?? createStoryFormatPlan())
+      };
+    }
+
+    if (request.task === "draft") {
+      return {
+        responseJson: JSON.stringify(this.options.draft ?? createProviderDraft())
+      };
+    }
+
+    if (request.task === "caption") {
+      return {
+        responseJson: JSON.stringify(this.options.caption ?? createProviderCaption())
+      };
+    }
+
+    throw new Error(`Unexpected task: ${request.task}`);
+  }
+}
+
+type DraftFixture = ReturnType<typeof createProviderDraft>;
+
+function createStoryFormatPlan(
+  overrides: Partial<StoryFormatPlan> = {}
+): StoryFormatPlan {
+  return {
+    schemaVersion: 1,
+    formatName: "Implementation Dispatch",
+    voice: "dry coworker",
+    tone: "concise and lightly amused",
+    reason: "Collect-all E2E fixture: enough real signals for a compact update.",
+    structure: [
+      { part: "Signal", purpose: "Name the concrete activity." },
+      { part: "Draft", purpose: "Turn it into a diary beat." },
+      { part: "Close", purpose: "End without inventing extra work." }
+    ],
+    suggestedSlideCount: 3,
+    captionStyle: "short witty caption",
+    doNotMention: ["raw diffs", "private paths"],
+    ...overrides
+  };
+}
+
+function createProviderDraft(
+  overrides: Partial<Omit<DiaryDraft, "schemaVersion" | "targetDate" | "metadata">> = {}
+) {
+  return {
+    title: "Collect-All E2E Day",
+    slides: [
+      {
+        index: 1,
+        title: "Signal",
+        body: "Collected activity from multiple sources was summarized safely.",
+        visualMood: "compact terminal summary"
+      },
+      {
+        index: 2,
+        title: "Draft",
+        body: "Story and caption artifacts were written for the target date.",
+        visualMood: "plain text files"
+      },
+      {
+        index: 3,
+        title: "Close",
+        body: "Pipeline wrapped cleanly without inventing extra work.",
+        visualMood: "checklist with completed items"
+      }
+    ],
+    altText: "Uncommitted text diary draft generated from local activity.",
+    ...overrides
+  };
+}
+
+function createProviderCaption(overrides: Partial<CaptionResult> = {}): CaptionResult {
+  return {
+    caption: "오늘은 collect all 파이프라인을 끝까지 연결했다.",
+    hashtags: ["#Uncommitted", "#개발일기"],
+    ...overrides
+  };
+}

--- a/tests/generate-command-source-gating.test.ts
+++ b/tests/generate-command-source-gating.test.ts
@@ -1,0 +1,509 @@
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+import type {
+  AiProvider,
+  AiProviderRawResponse,
+  AiStructuredGenerationRequest
+} from "../src/ai-provider.js";
+import { runCli } from "../src/cli.js";
+import type { GitActivityEvent } from "../src/collect-git-command.js";
+import type { CaptionResult } from "../src/diary-generator.js";
+import { addProject, type ProjectRecord } from "../src/project-add.js";
+import type { StoryFormatPlan } from "../src/story-format-plan.js";
+
+const execFileAsync = promisify(execFile);
+
+type SourceName = "git" | "claude" | "codex" | "github";
+type SourcesOverride = Partial<Record<SourceName, { enabled: boolean }>>;
+
+function createIo() {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+
+  return {
+    io: {
+      stdout: (message: string) => stdout.push(message),
+      stderr: (message: string) => stderr.push(message)
+    },
+    stdout,
+    stderr
+  };
+}
+
+describe("generate command — per-source gating", () => {
+  it("skips claude/codex/github signals when those sources are disabled", async () => {
+    const { io, stderr } = createIo();
+    const fixture = await createRegisteredProjectFixture({
+      sources: {
+        git: { enabled: true },
+        claude: { enabled: false },
+        codex: { enabled: false },
+        github: { enabled: false }
+      }
+    });
+    const provider = new TaskAwareProvider();
+
+    await writeGitEvent(fixture.project, "2026-05-12");
+    await writeClaudeSignals(fixture.project, "2026-05-12", [
+      {
+        projectId: fixture.project.id,
+        timestamp: "2026-05-12T09:00:00.000Z",
+        kind: "claude-assistant-text",
+        summary: "implement the claude session adapter",
+        safetyNotes: []
+      }
+    ]);
+    await writeCodexSignals(fixture.project, "2026-05-12", [
+      {
+        projectId: fixture.project.id,
+        timestamp: "2026-05-12T09:30:00.000Z",
+        kind: "codex-assistant-text",
+        summary: "implement the codex session adapter",
+        safetyNotes: []
+      }
+    ]);
+    await writeGitHubSignals(fixture.project, "2026-05-12", [
+      {
+        projectId: fixture.project.id,
+        timestamp: "2026-05-12T10:00:00.000Z",
+        kind: "pr",
+        summary: "PR #42 merged: add the github collector",
+        safetyNotes: []
+      }
+    ]);
+
+    const exitCode = await runCli(["generate", "today"], io, {
+      homeDir: fixture.homeDir,
+      now: () => "2026-05-12T23:30:00.000Z",
+      aiProvider: provider
+    });
+    const outputDir = join(fixture.draftRoot, "2026-05-12", "rev-001");
+    const activitySummary = (await readJson(
+      join(outputDir, "activity-summary.json")
+    )) as {
+      smallWins: string[];
+      commitSignals: { totalCommits: number };
+    };
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toEqual([]);
+    // Git signals still present.
+    expect(activitySummary.commitSignals.totalCommits).toBe(1);
+    // Disabled sources contribute nothing — none of their summaries leak in.
+    expect(activitySummary.smallWins).not.toContain(
+      "implement the claude session adapter"
+    );
+    expect(activitySummary.smallWins).not.toContain(
+      "implement the codex session adapter"
+    );
+    expect(activitySummary.smallWins).not.toContain(
+      "PR #42 merged: add the github collector"
+    );
+  });
+
+  it("skips git events when git is disabled in config", async () => {
+    const { io, stderr } = createIo();
+    const fixture = await createRegisteredProjectFixture({
+      sources: {
+        git: { enabled: false },
+        claude: { enabled: true },
+        codex: { enabled: true },
+        github: { enabled: true }
+      }
+    });
+    const provider = new TaskAwareProvider();
+
+    await writeGitEvent(fixture.project, "2026-05-12");
+    // Drop a manual note so projects still have signal — generate should not
+    // throw when git is disabled but other inputs exist.
+    await writeManualNote(fixture.project, "2026-05-12");
+
+    const exitCode = await runCli(["generate", "today"], io, {
+      homeDir: fixture.homeDir,
+      now: () => "2026-05-12T23:30:00.000Z",
+      aiProvider: provider
+    });
+    const outputDir = join(fixture.draftRoot, "2026-05-12", "rev-001");
+    const activitySummary = (await readJson(
+      join(outputDir, "activity-summary.json")
+    )) as {
+      commitSignals: { totalCommits: number; subjects: string[] };
+      manualContext: { noteCount: number };
+    };
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toEqual([]);
+    // Git events were on disk but gating prevented them from loading.
+    expect(activitySummary.commitSignals.totalCommits).toBe(0);
+    expect(activitySummary.commitSignals.subjects).not.toContain(
+      "implement generate command"
+    );
+    // Manual notes are NOT gated by source config.
+    expect(activitySummary.manualContext.noteCount).toBe(1);
+  });
+
+  it("legacy configs without a sources key keep all four sources enabled", async () => {
+    const { io, stderr } = createIo();
+    const fixture = await createRegisteredProjectFixture({
+      omitSources: true
+    });
+    const provider = new TaskAwareProvider();
+
+    await writeGitEvent(fixture.project, "2026-05-12");
+    await writeClaudeSignals(fixture.project, "2026-05-12", [
+      {
+        projectId: fixture.project.id,
+        timestamp: "2026-05-12T09:00:00.000Z",
+        kind: "claude-assistant-text",
+        summary: "implement the claude session adapter",
+        safetyNotes: []
+      }
+    ]);
+    await writeGitHubSignals(fixture.project, "2026-05-12", [
+      {
+        projectId: fixture.project.id,
+        timestamp: "2026-05-12T10:00:00.000Z",
+        kind: "pr",
+        summary: "PR #42 merged: add the github collector",
+        safetyNotes: []
+      }
+    ]);
+
+    const exitCode = await runCli(["generate", "today"], io, {
+      homeDir: fixture.homeDir,
+      now: () => "2026-05-12T23:30:00.000Z",
+      aiProvider: provider
+    });
+    const outputDir = join(fixture.draftRoot, "2026-05-12", "rev-001");
+    const activitySummary = (await readJson(
+      join(outputDir, "activity-summary.json")
+    )) as {
+      smallWins: string[];
+      commitSignals: { totalCommits: number };
+    };
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toEqual([]);
+    // Missing `sources` key ⇒ all enabled; git + claude + github signals load.
+    expect(activitySummary.commitSignals.totalCommits).toBe(1);
+    expect(activitySummary.smallWins).toContain(
+      "implement the claude session adapter"
+    );
+    expect(activitySummary.smallWins).toContain(
+      "PR #42 merged: add the github collector"
+    );
+  });
+});
+
+async function createRegisteredProjectFixture(options: {
+  sources?: SourcesOverride;
+  omitSources?: boolean;
+} = {}): Promise<{
+  directory: string;
+  repoDir: string;
+  homeDir: string;
+  draftRoot: string;
+  project: ProjectRecord;
+}> {
+  const directory = await mkdtemp(
+    join(tmpdir(), "uncommitted-generate-source-gating-")
+  );
+  const repoDir = join(directory, "repo");
+  const homeDir = join(directory, "home");
+  const draftRoot = join(directory, "drafts");
+
+  await execFileAsync("git", ["init", repoDir]);
+  await execFileAsync("git", ["-C", repoDir, "config", "user.name", "Fixture Dev"]);
+  await execFileAsync("git", [
+    "-C",
+    repoDir,
+    "config",
+    "user.email",
+    "dev@example.com"
+  ]);
+  await writeConfig(homeDir, draftRoot, options);
+
+  const registered = await addProject(repoDir, {
+    homeDir,
+    now: () => "2026-05-12T00:00:00.000Z"
+  });
+
+  return {
+    directory,
+    repoDir,
+    homeDir,
+    draftRoot,
+    project: registered.project
+  };
+}
+
+async function writeConfig(
+  homeDir: string,
+  draftRoot: string,
+  options: { sources?: SourcesOverride; omitSources?: boolean }
+): Promise<void> {
+  const configDir = join(homeDir, ".uncommitted");
+
+  await mkdir(join(configDir, "history"), { recursive: true });
+
+  const baseConfig: Record<string, unknown> = {
+    schemaVersion: 1,
+    draftRoot,
+    scheduleTime: "23:30",
+    aiProvider: "mock",
+    persona: "wry coworker",
+    roastLevel: 2
+  };
+
+  if (!options.omitSources) {
+    baseConfig.sources = options.sources ?? {
+      git: { enabled: true },
+      claude: { enabled: true },
+      codex: { enabled: true },
+      github: { enabled: true }
+    };
+  }
+
+  await writeFile(
+    join(configDir, "config.json"),
+    `${JSON.stringify(baseConfig, null, 2)}\n`,
+    "utf8"
+  );
+  await writeFile(
+    join(configDir, "history", "formats.json"),
+    `${JSON.stringify({ schemaVersion: 1, formats: [] })}\n`,
+    "utf8"
+  );
+}
+
+async function writeGitEvent(
+  project: ProjectRecord,
+  targetDate: string
+): Promise<void> {
+  const event: GitActivityEvent = {
+    schemaVersion: 1,
+    source: "git",
+    targetDate,
+    collectedAt: `${targetDate}T23:00:00.000Z`,
+    project: {
+      id: project.id,
+      name: project.name
+    },
+    activity: {
+      schemaVersion: 1,
+      targetDate,
+      repository: {
+        rootName: project.name
+      },
+      commits: [
+        {
+          hash: "abc1234",
+          shortHash: "abc1234",
+          authorName: "Fixture Dev",
+          subject: "implement generate command",
+          authoredAt: `${targetDate}T10:00:00.000Z`,
+          stats: {
+            filesChanged: 2,
+            insertions: 45,
+            deletions: 5
+          }
+        }
+      ],
+      dirty: {
+        files: [
+          {
+            path: "src/generate-command.ts",
+            status: "modified"
+          }
+        ],
+        totals: {
+          modified: 1,
+          added: 0,
+          deleted: 0,
+          renamed: 0,
+          copied: 0,
+          untracked: 0,
+          other: 0
+        }
+      },
+      totals: {
+        commits: 1,
+        filesChanged: 2,
+        insertions: 45,
+        deletions: 5
+      }
+    }
+  };
+  const eventsDir = join(project.root, ".uncommitted", "events", "git");
+
+  await mkdir(eventsDir, { recursive: true });
+  await writeFile(
+    join(eventsDir, `${targetDate}.json`),
+    `${JSON.stringify(event, null, 2)}\n`,
+    "utf8"
+  );
+}
+
+async function writeManualNote(
+  project: ProjectRecord,
+  targetDate: string
+): Promise<void> {
+  const eventsDir = join(project.root, ".uncommitted", "events", "manual");
+
+  await mkdir(eventsDir, { recursive: true });
+  await writeFile(
+    join(eventsDir, `${targetDate}.jsonl`),
+    `${JSON.stringify({
+      schemaVersion: 1,
+      id: "note-1",
+      timestamp: `${targetDate}T15:00:00.000Z`,
+      date: targetDate,
+      projectId: project.id,
+      text: "Manual note that survives git gating.",
+      source: "manual"
+    })}\n`,
+    "utf8"
+  );
+}
+
+async function writeClaudeSignals(
+  project: ProjectRecord,
+  targetDate: string,
+  signals: {
+    projectId: string;
+    timestamp: string;
+    kind: string;
+    summary: string;
+    safetyNotes: string[];
+  }[]
+): Promise<void> {
+  await writeSessionSignals(project, targetDate, "claude", signals);
+}
+
+async function writeCodexSignals(
+  project: ProjectRecord,
+  targetDate: string,
+  signals: {
+    projectId: string;
+    timestamp: string;
+    kind: string;
+    summary: string;
+    safetyNotes: string[];
+  }[]
+): Promise<void> {
+  await writeSessionSignals(project, targetDate, "codex", signals);
+}
+
+async function writeGitHubSignals(
+  project: ProjectRecord,
+  targetDate: string,
+  signals: {
+    projectId: string;
+    timestamp: string;
+    kind: string;
+    summary: string;
+    safetyNotes: string[];
+  }[]
+): Promise<void> {
+  await writeSessionSignals(project, targetDate, "github", signals);
+}
+
+async function writeSessionSignals(
+  project: ProjectRecord,
+  targetDate: string,
+  source: "claude" | "codex" | "github",
+  signals: {
+    projectId: string;
+    timestamp: string;
+    kind: string;
+    summary: string;
+    safetyNotes: string[];
+  }[]
+): Promise<void> {
+  const eventsDir = join(project.root, ".uncommitted", "events", source);
+
+  await mkdir(eventsDir, { recursive: true });
+  await writeFile(
+    join(eventsDir, `${targetDate}.jsonl`),
+    signals.map((signal) => JSON.stringify(signal)).join("\n") + "\n",
+    "utf8"
+  );
+}
+
+class TaskAwareProvider implements AiProvider {
+  readonly name = "mock";
+  readonly model = "fixture-model";
+  readonly requests: AiStructuredGenerationRequest[] = [];
+
+  async generateStructured(
+    request: AiStructuredGenerationRequest
+  ): Promise<AiProviderRawResponse> {
+    this.requests.push(request);
+
+    if (request.task === "story-plan") {
+      const plan: StoryFormatPlan = {
+        schemaVersion: 1,
+        formatName: "Implementation Dispatch",
+        voice: "dry coworker",
+        tone: "concise and lightly amused",
+        reason: "Source-gating test fixture.",
+        structure: [
+          { part: "Signal", purpose: "Name the activity." },
+          { part: "Draft", purpose: "Beat the diary." },
+          { part: "Close", purpose: "End cleanly." }
+        ],
+        suggestedSlideCount: 3,
+        captionStyle: "short witty caption",
+        doNotMention: ["raw diffs", "private paths"]
+      };
+      return { responseJson: JSON.stringify(plan) };
+    }
+
+    if (request.task === "draft") {
+      return {
+        responseJson: JSON.stringify({
+          title: "Source Gating Day",
+          slides: [
+            {
+              index: 1,
+              title: "Signal",
+              body: "Collected enabled-source signals.",
+              visualMood: "compact terminal summary"
+            },
+            {
+              index: 2,
+              title: "Draft",
+              body: "Disabled-source signals stayed off the page.",
+              visualMood: "plain text files"
+            },
+            {
+              index: 3,
+              title: "Close",
+              body: "Ended without inventing extra work.",
+              visualMood: "checklist"
+            }
+          ],
+          altText: "Source-gating draft fixture."
+        })
+      };
+    }
+
+    if (request.task === "caption") {
+      const caption: CaptionResult = {
+        caption: "오늘은 소스 게이팅을 텍스트 draft까지 연결했다.",
+        hashtags: ["#Uncommitted", "#개발일기"]
+      };
+      return { responseJson: JSON.stringify(caption) };
+    }
+
+    throw new Error(`Unexpected task: ${request.task}`);
+  }
+}
+
+async function readJson(path: string): Promise<unknown> {
+  return JSON.parse(await readFile(path, "utf8")) as unknown;
+}

--- a/tests/init-command.test.ts
+++ b/tests/init-command.test.ts
@@ -34,7 +34,13 @@ describe("init command", () => {
         persona: "dry coworker",
         roastLevel: 3,
         rawRetentionDays: 14,
-        captionProjectionTokenBudget: 2048
+        captionProjectionTokenBudget: 2048,
+        sources: {
+          git: { enabled: true },
+          claude: { enabled: true },
+          codex: { enabled: true },
+          github: { enabled: true }
+        }
       });
     expect(JSON.parse(await readFile(join(homeDir, ".uncommitted", "projects.json"), "utf8")))
       .toEqual({ schemaVersion: 1, projects: [] });
@@ -207,6 +213,29 @@ describe("init command", () => {
     ) as { rawRetentionDays: number; captionProjectionTokenBudget: number };
     expect(config.rawRetentionDays).toBe(30);
     expect(config.captionProjectionTokenBudget).toBe(4000);
+  });
+
+  it("writes a default sources map with all four sources enabled", async () => {
+    const homeDir = await mkTestHome("sources-default");
+
+    await runInitCommand([], { homeDir });
+
+    const config = JSON.parse(
+      await readFile(join(homeDir, ".uncommitted", "config.json"), "utf8")
+    ) as {
+      sources: {
+        git: { enabled: boolean };
+        claude: { enabled: boolean };
+        codex: { enabled: boolean };
+        github: { enabled: boolean };
+      };
+    };
+    expect(config.sources).toEqual({
+      git: { enabled: true },
+      claude: { enabled: true },
+      codex: { enabled: true },
+      github: { enabled: true }
+    });
   });
 
   it("accepts explicit Source Expansion values", async () => {

--- a/tests/source-config.test.ts
+++ b/tests/source-config.test.ts
@@ -1,0 +1,81 @@
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  SOURCE_NAMES,
+  isSourceEnabled,
+  listEnabledSources,
+  loadSourceConfig
+} from "../src/source-config.js";
+
+describe("isSourceEnabled", () => {
+  it("returns true for every source when the config object has no sources key", () => {
+    const config = { schemaVersion: 1 };
+    for (const name of SOURCE_NAMES) {
+      expect(isSourceEnabled(config, name)).toBe(true);
+    }
+  });
+
+  it("returns true when sources.<name> is absent but other sources are listed", () => {
+    const config = { sources: { git: { enabled: false } } };
+    expect(isSourceEnabled(config, "claude")).toBe(true);
+    expect(isSourceEnabled(config, "codex")).toBe(true);
+    expect(isSourceEnabled(config, "github")).toBe(true);
+  });
+
+  it("returns false when sources.<name>.enabled === false", () => {
+    const config = { sources: { claude: { enabled: false } } };
+    expect(isSourceEnabled(config, "claude")).toBe(false);
+  });
+
+  it("returns true when sources.<name>.enabled === true", () => {
+    const config = { sources: { github: { enabled: true } } };
+    expect(isSourceEnabled(config, "github")).toBe(true);
+  });
+});
+
+describe("listEnabledSources", () => {
+  it("returns all four canonical names when no sources key is present", () => {
+    const config = { schemaVersion: 1 };
+    expect(listEnabledSources(config)).toEqual(["git", "claude", "codex", "github"]);
+  });
+
+  it("returns only the enabled names when some are explicitly disabled", () => {
+    const config = {
+      sources: {
+        git: { enabled: true },
+        claude: { enabled: false },
+        codex: { enabled: false },
+        github: { enabled: true }
+      }
+    };
+    expect(listEnabledSources(config)).toEqual(["git", "github"]);
+  });
+});
+
+describe("loadSourceConfig", () => {
+  it("reads a config JSON file and fills missing sources with enabled=true", async () => {
+    const home = await mkdtemp(join(tmpdir(), "uncommitted-source-config-"));
+    const configDir = join(home, ".uncommitted");
+    await mkdir(configDir, { recursive: true });
+    const configFile = join(configDir, "config.json");
+    await writeFile(
+      configFile,
+      JSON.stringify({
+        schemaVersion: 1,
+        sources: {
+          claude: { enabled: false }
+        }
+      })
+    );
+
+    const sources = await loadSourceConfig(configFile);
+    expect(sources).toEqual({
+      git: { enabled: true },
+      claude: { enabled: false },
+      codex: { enabled: true },
+      github: { enabled: true }
+    });
+  });
+});

--- a/tests/source-config.test.ts
+++ b/tests/source-config.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   SOURCE_NAMES,
+  SourceConfigError,
   isSourceEnabled,
   listEnabledSources,
   loadSourceConfig
@@ -77,5 +78,30 @@ describe("loadSourceConfig", () => {
       codex: { enabled: true },
       github: { enabled: true }
     });
+  });
+
+  it("falls back to all-enabled defaults when the config file is missing", async () => {
+    const home = await mkdtemp(join(tmpdir(), "uncommitted-source-config-"));
+    const configFile = join(home, ".uncommitted", "config.json");
+
+    const sources = await loadSourceConfig(configFile);
+    expect(sources).toEqual({
+      git: { enabled: true },
+      claude: { enabled: true },
+      codex: { enabled: true },
+      github: { enabled: true }
+    });
+  });
+
+  it("rejects a malformed config instead of silently enabling every source", async () => {
+    const home = await mkdtemp(join(tmpdir(), "uncommitted-source-config-"));
+    const configDir = join(home, ".uncommitted");
+    await mkdir(configDir, { recursive: true });
+    const configFile = join(configDir, "config.json");
+    await writeFile(configFile, "{ this is not valid json", "utf8");
+
+    await expect(loadSourceConfig(configFile)).rejects.toBeInstanceOf(
+      SourceConfigError
+    );
   });
 });


### PR DESCRIPTION
# Goal

🤖 **Auto-generated by Uncommitted Builder (Routine B v2)**

Finish the Source Expansion epic ([UNC-115](https://linear.app/sangchu/issue/UNC-115)) closing slice: orchestrate every registered source through a single `uncommitted collect all`, expose per-source on/off config, and wire `generate` so its output is visibly different when non-git sources are enabled.

Parent: [UNC-120](https://linear.app/sangchu/issue/UNC-120/collect-all-오케스트레이션-소스별-onoff-설정-generate-반영-마감)

## Related Issue

Closes #UNC-120 *(Linear)* — composed of:
- [UNC-165](https://linear.app/sangchu/issue/UNC-165) — T1: per-source enable/disable config schema + accessor
- [UNC-166](https://linear.app/sangchu/issue/UNC-166) — T2: gate individual `collect <source>` commands on config
- [UNC-167](https://linear.app/sangchu/issue/UNC-167) — T4: wire non-git source signals into `generate` with per-source gating
- [UNC-168](https://linear.app/sangchu/issue/UNC-168) — T3: `uncommitted collect all` orchestration with failure isolation + aggregate exit code
- [UNC-169](https://linear.app/sangchu/issue/UNC-169) — T5: end-to-end regression test (visible difference from git-only baseline)

## Sub-issues progress

- [x] UNC-165 — `✨ feat(config): add per-source enable/disable schema` (af4d519)
- [x] UNC-166 — `🚧 feat(cli): gate per-source collect commands on config` (8bda485)
- [x] UNC-167 — `✨ feat(generate): gate source loading on per-source config` (6728f6d)
- [x] UNC-168 — `✨ feat(cli): add 'collect all' orchestration with failure isolation` (1e07a39)
- [x] UNC-169 — `✅ test(e2e): non-git sources produce visibly different generate output` (7d60df6)

## Acceptance Criteria

- [x] Per-source on/off config respected by both `collect` and `generate` (symmetric gating via shared `isSourceEnabled` accessor)
- [x] `uncommitted collect all` orchestrates every enabled source; one source's failure does not abort the rest (per-source try/catch + status summary)
- [x] Aggregate exit code: `0` if any enabled source succeeds, `3` only if every enabled source fails, `0` if no sources are enabled
- [x] `generate` output visibly differs from git-only baseline when claude/codex/github sources contribute signals (pinned by regression test `tests/collect-all-generate-e2e.test.ts`)
- [x] Backward-compatible: missing `sources` key in config treated as all-enabled (no migration prompt)
- [x] Unit + integration test coverage (TDD, all RED → GREEN per task)

## Implementation Notes

**Config layer (T1, UNC-165)**
- New `src/source-config.ts` with `SourceName`, `SOURCE_NAMES`, `isSourceEnabled`, `listEnabledSources`, `loadSourceConfig`. Missing keys default to enabled.
- `InitConfig.sources` field added at `src/init-command.ts`; defaulted to all-enabled on `uncommitted init`.

**Per-source `collect` gating (T2, UNC-166)**
- `runCollect` in `src/cli.ts` consults `loadSourceConfig` after argv validation and short-circuits disabled sources with `Source '<name>' is disabled in config; skipping collection.` + exit 0.
- No change to the per-source command modules themselves; gating happens at the CLI boundary.

**Generate gating (T4, UNC-167)**
- `runGenerateCommand` reads the source config and skips disabled sources at the reader call sites. Manual notes remain unconditional (they're user input, not a tracked source).
- No prompt contract change; `buildActivitySummary` already handles empty signal arrays.

**`collect all` orchestration (T3, UNC-168)**
- New `src/collect-all.ts` with `runCollectAll` and per-source invoker wrappers. Each enabled source runs inside its own try/catch — failure isolation.
- CLI surface: `uncommitted collect all`. Stdout: one line per source (`success` / `failed (...)` / `disabled`).
- Test injection point: `CliOptions.collectInvokers` (same pattern as `aiProvider`) — lets the E2E test drive the orchestrator without touching live collectors.

**End-to-end regression (T5, UNC-169)**
- `tests/collect-all-generate-e2e.test.ts` runs two fully-isolated tmpdir scenarios: git-only baseline vs all-sources-enabled with seeded claude/codex/github JSONL fixtures. Asserts visible difference at two layers: on-disk `activity-summary.json` `smallWins` AND the AI provider's `story-plan` request `input.highlights` payload.
- Test-only; no production code changes in this commit.

**Notable design choices captured here for review:**
- Per-source command gating message is stable (`Source '<name>' is disabled in config; skipping collection.`) — chosen so users can grep for it in logs.
- `collect all` exit code 3 reserved for "every enabled source failed"; mixing partial success returns 0 deliberately.
- Disabled sources do NOT appear as explicit entries in `activity-summary.json` — their absence is the signal (per UNC-167 key decision).
- Manual notes intentionally excluded from the source gating system — they're project-local user input, treated like project-registry data not like a tracked source.

## Validation

- ✅ `pnpm install --frozen-lockfile` (no lockfile changes)
- ✅ `pnpm test` — **597 passed**, 2 skipped, **+22 new tests** vs main
- ✅ `pnpm typecheck` — clean
- ✅ `pnpm lint` — clean
- ✅ `pnpm build` — clean
- ⚠️ `tests/carousel-renderer-smoke.test.ts > renders a quiet 3-slide fixture into non-empty 1080x1350 PNGs` — pre-existing Playwright Chromium 5s-timeout flake on this dev environment; confirmed same failure on `main` before any UNC-120 changes. Unrelated to this PR.

**TDD trail** (each task RED → GREEN → commit):
- UNC-165: 6 RED `source-config` + 1 RED `init-command` defaults → GREEN
- UNC-166: 5 RED `cli-collect-source-gating` → GREEN
- UNC-167: 3 RED `generate-command-source-gating` (incl. legacy back-compat assertion) → GREEN
- UNC-168: 5 RED `cli-collect-all` (all-success, single-failure, all-fail, partial-disabled, no-sources-enabled) → GREEN
- UNC-169: 2 GREEN regression tests (1 baseline sanity + 1 visible-difference)

## Remaining Risk

- The carousel renderer smoke failure noted above is pre-existing infrastructure (Playwright Chromium not initializing within 5s on this machine). Not introduced by this PR; should be addressed separately if it persists in CI.
- `collect all` does not (yet) emit a separate JSON report file — per key decision in UNC-168, stdout + existing per-source logs are sufficient observability for MVP. Revisit if dashboard/digest needs change.
- `generate` gating relies on the same `isSourceEnabled` accessor as `collect` — if a user manually disables a source AFTER events have been collected, those stale events on disk will NOT appear in the next `generate` (intended symmetric behavior per UNC-167 key decision).
- Build is a per-task commit per Routine B v2; for clean review consider walking the 5 commits in order rather than reading the squash diff.

## Review checklist

- [ ] Walk the 5 sub-issue commits in order (af4d519 → 8bda485 → 6728f6d → 1e07a39 → 7d60df6)
- [ ] Confirm `loadSourceConfig` back-compat defaults (missing keys ⇒ enabled) behaves as expected on legacy `~/.uncommitted/config.json` files
- [ ] Spot-check `runCollectAll` exit-code logic vs the 5 specified scenarios
- [ ] Verify `tests/collect-all-generate-e2e.test.ts` assertions hold without flake (run 2-3× locally)
- [ ] Confirm no auto-publish code, no lockfile changes, no network access added
- [ ] `pnpm install && pnpm test && pnpm typecheck && pnpm lint && pnpm build` locally

---

🤖 이 PR은 Uncommitted Builder Routine B v2가 자동 생성했습니다. 머지 전 사람의 리뷰가 반드시 필요합니다.
