### PR TITLE
🤖 Tier 1 원문 아카이브 보존 만료 prune 구현 (UNC-170) — single-issue

### DIFF
--- a/src/collect-claude-command.ts
+++ b/src/collect-claude-command.ts
@@ -90,6 +90,17 @@ export async function collectClaudeForRegisteredProjects(
     claudeHome: options.claudeHome
   });
   if (logs.length === 0) {
+    // No new logs to collect, but retention must still be enforced so raw
+    // archives age out on quiet days instead of lingering until the next
+    // session appears.
+    for (const project of projects) {
+      await pruneRawArchives({
+        projectRoot: project.root,
+        source: "claude",
+        today: targetDate,
+        retentionDays
+      });
+    }
     return {
       targetDate,
       successes: [],

--- a/src/collect-claude-command.ts
+++ b/src/collect-claude-command.ts
@@ -13,6 +13,10 @@ import {
 } from "./claude-session-parser.js";
 import { redactClaudeSession } from "./claude-session-redactor.js";
 import { writeClaudeSessionOutputs } from "./claude-session-writer.js";
+import {
+  pruneRawArchives,
+  readRawRetentionDays
+} from "./raw-archive-prune.js";
 
 export type CollectClaudeCommandOptions = {
   homeDir?: string;
@@ -80,6 +84,7 @@ export async function collectClaudeForRegisteredProjects(
 
   const now = options.now ? options.now() : new Date().toISOString();
   const targetDate = now.slice(0, 10);
+  const retentionDays = await readRawRetentionDays(paths.configFile);
 
   const logs = await discoverClaudeSessionLogs({
     claudeHome: options.claudeHome
@@ -166,6 +171,12 @@ export async function collectClaudeForRegisteredProjects(
         signalCount: written.signalCount,
         conversationCount: written.conversationCount,
         toolFactCount: written.toolFactCount
+      });
+      await pruneRawArchives({
+        projectRoot: project.root,
+        source: "claude",
+        today: targetDate,
+        retentionDays
       });
     } catch (error) {
       failures.push({

--- a/src/collect-codex-command.ts
+++ b/src/collect-codex-command.ts
@@ -16,6 +16,10 @@ import {
 } from "./codex-session-parser.js";
 import { redactCodexSession } from "./codex-session-redactor.js";
 import { writeCodexSessionOutputs } from "./codex-session-writer.js";
+import {
+  pruneRawArchives,
+  readRawRetentionDays
+} from "./raw-archive-prune.js";
 
 export type CollectCodexCommandOptions = {
   homeDir?: string;
@@ -98,6 +102,8 @@ export async function collectCodexForRegisteredProjects(
     const now = options.now ? options.now() : new Date().toISOString();
     targetDate = now.slice(0, 10);
   }
+
+  const retentionDays = await readRawRetentionDays(paths.configFile);
 
   // A Codex session that starts before midnight stays under its start day's
   // `sessions/YYYY/MM/DD` directory even when work continues into the next day.
@@ -197,6 +203,12 @@ export async function collectCodexForRegisteredProjects(
         signalCount: written.signalCount,
         conversationCount: written.conversationCount,
         toolFactCount: written.toolFactCount
+      });
+      await pruneRawArchives({
+        projectRoot: project.root,
+        source: "codex",
+        today: targetDate,
+        retentionDays
       });
     } catch (error) {
       failures.push({

--- a/src/collect-codex-command.ts
+++ b/src/collect-codex-command.ts
@@ -126,6 +126,17 @@ export async function collectCodexForRegisteredProjects(
     return true;
   });
   if (logs.length === 0) {
+    // No new logs to collect, but retention must still be enforced so raw
+    // archives age out on quiet days instead of lingering until the next
+    // session appears.
+    for (const project of projects) {
+      await pruneRawArchives({
+        projectRoot: project.root,
+        source: "codex",
+        today: targetDate,
+        retentionDays
+      });
+    }
     return {
       targetDate,
       successes: [],

--- a/src/collect-github-command.ts
+++ b/src/collect-github-command.ts
@@ -15,6 +15,10 @@ import {
 import { normalizeGitHubFetch } from "./github-event-normalizer.js";
 import { redactGitHubEvents } from "./github-event-redactor.js";
 import { writeGitHubEvents } from "./github-event-writer.js";
+import {
+  pruneRawArchives,
+  readRawRetentionDays
+} from "./raw-archive-prune.js";
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 const execFileP = promisify(execFile);
@@ -130,6 +134,7 @@ export async function collectGitHubForRegisteredProjects(
     targetDate = now.slice(0, 10);
   }
 
+  const retentionDays = await readRawRetentionDays(paths.configFile);
   const remoteUrlReader = input.remoteUrlReader ?? defaultRemoteUrlReader;
   const successes: CollectGitHubSuccess[] = [];
   const failures: CollectGitHubFailure[] = [];
@@ -215,6 +220,12 @@ export async function collectGitHubForRegisteredProjects(
         rawArchiveFile: written.rawArchiveFile,
         signalCount: written.signalCount,
         rawCount: written.rawCount
+      });
+      await pruneRawArchives({
+        projectRoot: project.root,
+        source: "github",
+        today: targetDate,
+        retentionDays
       });
     } catch (error) {
       // On failure, never destroy a prior successful collection: if the

--- a/src/collect-github-command.ts
+++ b/src/collect-github-command.ts
@@ -135,6 +135,21 @@ export async function collectGitHubForRegisteredProjects(
   }
 
   const retentionDays = await readRawRetentionDays(paths.configFile);
+
+  // Enforce retention for every enabled project independently of fetch
+  // success or remote classification. A project whose remote was removed or
+  // changed away from GitHub takes the skipped path and never reaches a
+  // per-success prune, so archives from earlier GitHub collections would
+  // otherwise outlive rawRetentionDays.
+  for (const project of projects) {
+    await pruneRawArchives({
+      projectRoot: project.root,
+      source: "github",
+      today: targetDate,
+      retentionDays
+    });
+  }
+
   const remoteUrlReader = input.remoteUrlReader ?? defaultRemoteUrlReader;
   const successes: CollectGitHubSuccess[] = [];
   const failures: CollectGitHubFailure[] = [];
@@ -220,12 +235,6 @@ export async function collectGitHubForRegisteredProjects(
         rawArchiveFile: written.rawArchiveFile,
         signalCount: written.signalCount,
         rawCount: written.rawCount
-      });
-      await pruneRawArchives({
-        projectRoot: project.root,
-        source: "github",
-        today: targetDate,
-        retentionDays
       });
     } catch (error) {
       // On failure, never destroy a prior successful collection: if the

--- a/src/raw-archive-prune.ts
+++ b/src/raw-archive-prune.ts
@@ -1,0 +1,157 @@
+import { readdir, readFile, stat, unlink } from "node:fs/promises";
+import { join } from "node:path";
+
+export type RawArchiveSource = "claude" | "codex" | "github";
+
+export type PruneRawArchivesInput = {
+  projectRoot: string;
+  source: RawArchiveSource;
+  today: string;
+  retentionDays: number;
+};
+
+export type PruneRawArchivesResult = {
+  deletedFiles: string[];
+  errors: Array<{ file: string; message: string }>;
+};
+
+const DATE_FILENAME_RE = /^(\d{4}-\d{2}-\d{2})\.jsonl(?:\.gz)?$/;
+
+export async function pruneRawArchives(
+  input: PruneRawArchivesInput
+): Promise<PruneRawArchivesResult> {
+  const { projectRoot, source, today, retentionDays } = input;
+
+  if (!Number.isFinite(retentionDays) || retentionDays <= 0) {
+    return { deletedFiles: [], errors: [] };
+  }
+
+  const rawDir = join(projectRoot, ".uncommitted", "events", source, "raw");
+
+  let entries: string[];
+  try {
+    entries = await readdir(rawDir);
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return { deletedFiles: [], errors: [] };
+    }
+    return {
+      deletedFiles: [],
+      errors: [{ file: rawDir, message: errorMessage(error) }]
+    };
+  }
+
+  const cutoff = computeCutoff(today, retentionDays);
+  if (cutoff === null) {
+    return { deletedFiles: [], errors: [] };
+  }
+
+  const deletedFiles: string[] = [];
+  const errors: Array<{ file: string; message: string }> = [];
+
+  for (const entry of entries) {
+    const match = entry.match(DATE_FILENAME_RE);
+    if (!match) {
+      continue;
+    }
+    const fileDate = match[1];
+    if (!isValidYyyyMmDd(fileDate)) {
+      continue;
+    }
+    if (fileDate >= cutoff) {
+      continue;
+    }
+    const full = join(rawDir, entry);
+    try {
+      const s = await stat(full);
+      if (!s.isFile()) {
+        continue;
+      }
+      await unlink(full);
+      deletedFiles.push(full);
+    } catch (error) {
+      if (isNotFoundError(error)) {
+        continue;
+      }
+      errors.push({ file: full, message: errorMessage(error) });
+    }
+  }
+
+  return { deletedFiles, errors };
+}
+
+export async function readRawRetentionDays(
+  configFilePath: string
+): Promise<number> {
+  let raw: string;
+  try {
+    raw = await readFile(configFilePath, "utf8");
+  } catch {
+    return 0;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return 0;
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    return 0;
+  }
+  const value = (parsed as Record<string, unknown>).rawRetentionDays;
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return 0;
+  }
+  return Math.floor(value);
+}
+
+function computeCutoff(today: string, retentionDays: number): string | null {
+  if (!isValidYyyyMmDd(today)) {
+    return null;
+  }
+  const days = Math.floor(retentionDays);
+  // Keep the most recent `days` days INCLUDING today. So cutoff is the
+  // smallest YYYY-MM-DD that is kept; anything strictly less is deleted.
+  // cutoff = today - (days - 1) days.
+  const t = Date.UTC(
+    Number(today.slice(0, 4)),
+    Number(today.slice(5, 7)) - 1,
+    Number(today.slice(8, 10))
+  );
+  const cutoffMs = t - (days - 1) * 86_400_000;
+  const d = new Date(cutoffMs);
+  const yyyy = d.getUTCFullYear().toString().padStart(4, "0");
+  const mm = (d.getUTCMonth() + 1).toString().padStart(2, "0");
+  const dd = d.getUTCDate().toString().padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+function isValidYyyyMmDd(value: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return false;
+  }
+  const year = Number(value.slice(0, 4));
+  const month = Number(value.slice(5, 7));
+  const day = Number(value.slice(8, 10));
+  if (month < 1 || month > 12) return false;
+  if (day < 1 || day > 31) return false;
+  const dt = new Date(Date.UTC(year, month - 1, day));
+  return (
+    dt.getUTCFullYear() === year &&
+    dt.getUTCMonth() === month - 1 &&
+    dt.getUTCDate() === day
+  );
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as { code?: string }).code === "ENOENT"
+  );
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}

--- a/tests/collect-claude-command.test.ts
+++ b/tests/collect-claude-command.test.ts
@@ -67,6 +67,44 @@ describe("collectClaudeForRegisteredProjects", () => {
     ).rejects.toBeInstanceOf(CollectClaudeCommandError);
   });
 
+  it("prunes expired raw archives on a no-log day", async () => {
+    await writeProjectsFile(homeDir, [
+      {
+        schemaVersion: 1,
+        id: "p1",
+        name: "demo",
+        root: projectRoot,
+        gitRoot: projectRoot,
+        enabled: true,
+        createdAt: "2026-06-01T00:00:00.000Z"
+      }
+    ]);
+    // rawRetentionDays=7 with today 2026-06-13 → cutoff 2026-06-07; anything
+    // strictly older must be pruned even when no session logs are collected.
+    await writeFile(
+      join(homeDir, ".uncommitted", "config.json"),
+      JSON.stringify({ rawRetentionDays: 7 })
+    );
+    const rawDir = join(projectRoot, ".uncommitted", "events", "claude", "raw");
+    await mkdir(rawDir, { recursive: true });
+    const expired = join(rawDir, "2026-06-01.jsonl");
+    const recent = join(rawDir, "2026-06-13.jsonl");
+    await writeFile(expired, "{}\n");
+    await writeFile(recent, "{}\n");
+
+    const result = await collectClaudeForRegisteredProjects({
+      homeDir,
+      claudeHome,
+      now: NOW
+    });
+
+    expect(result.claudeLogsMissing).toBe(true);
+    await expect(readFile(expired, "utf8")).rejects.toMatchObject({
+      code: "ENOENT"
+    });
+    await expect(readFile(recent, "utf8")).resolves.toBe("{}\n");
+  });
+
   it("end-to-end: parses, redacts, persists signals + Tier 1 archive for one project", async () => {
     await writeProjectsFile(homeDir, [
       {

--- a/tests/collect-codex-command.test.ts
+++ b/tests/collect-codex-command.test.ts
@@ -176,6 +176,54 @@ describe("collectCodexForRegisteredProjects", () => {
     expect(result.failures).toEqual([]);
   });
 
+  it("prunes expired raw archives on a no-log day", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "codex-cmd-"));
+    const codexHome = join(homeDir, ".codex");
+    const projectRoot = await mkdtemp(join(tmpdir(), "codex-proj-"));
+    await mkdir(join(homeDir, ".uncommitted"), { recursive: true });
+    await writeFile(
+      join(homeDir, ".uncommitted", "projects.json"),
+      JSON.stringify({
+        schemaVersion: 1,
+        projects: [
+          {
+            schemaVersion: 1,
+            id: "p1",
+            name: "demo",
+            root: projectRoot,
+            gitRoot: projectRoot,
+            enabled: true,
+            createdAt: "2026-06-14T00:00:00Z"
+          }
+        ]
+      })
+    );
+    // rawRetentionDays=7 with today 2026-06-14 → cutoff 2026-06-08; the older
+    // archive must be pruned even though no rollout files exist today.
+    await writeFile(
+      join(homeDir, ".uncommitted", "config.json"),
+      JSON.stringify({ rawRetentionDays: 7 })
+    );
+    const rawDir = join(projectRoot, ".uncommitted", "events", "codex", "raw");
+    await mkdir(rawDir, { recursive: true });
+    const expired = join(rawDir, "2026-06-01.jsonl");
+    const recent = join(rawDir, "2026-06-14.jsonl");
+    await writeFile(expired, "{}\n");
+    await writeFile(recent, "{}\n");
+
+    const result = await collectCodexForRegisteredProjects({
+      homeDir,
+      codexHome,
+      now: () => "2026-06-14T05:00:00Z"
+    });
+
+    expect(result.codexLogsMissing).toBe(true);
+    await expect(readFile(expired, "utf8")).rejects.toMatchObject({
+      code: "ENOENT"
+    });
+    await expect(readFile(recent, "utf8")).resolves.toBe("{}\n");
+  });
+
   it("throws no-projects error when registry is empty", async () => {
     const homeDir = await mkdtemp(join(tmpdir(), "codex-cmd-"));
     await mkdir(join(homeDir, ".uncommitted"), { recursive: true });

--- a/tests/collect-github-command.test.ts
+++ b/tests/collect-github-command.test.ts
@@ -152,6 +152,42 @@ describe("collectGitHubForRegisteredProjects", () => {
     expect(result.failures).toHaveLength(0);
   });
 
+  it("prunes expired github raw archives for a project whose remote is no longer github", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "gh-cmd-"));
+    const projectRoot = await mkdtemp(join(tmpdir(), "gh-proj-"));
+    await seedProjects(homeDir, projectRoot);
+    // The project once collected GitHub activity but its remote has since
+    // changed away from GitHub. retention must still age out the archives it
+    // accumulated, even though the project now takes the skipped path.
+    await writeFile(
+      join(homeDir, ".uncommitted", "config.json"),
+      JSON.stringify({ rawRetentionDays: 7 })
+    );
+    const rawDir = join(projectRoot, ".uncommitted", "events", "github", "raw");
+    await mkdir(rawDir, { recursive: true });
+    // today 2026-06-17 with retention 7 → cutoff 2026-06-11.
+    const expired = join(rawDir, "2026-06-01.jsonl");
+    const recent = join(rawDir, "2026-06-17.jsonl");
+    await writeFile(expired, "{}\n");
+    await writeFile(recent, "{}\n");
+
+    const result = await collectGitHubForRegisteredProjects({
+      homeDir,
+      env: { GITHUB_TOKEN: "t" },
+      targetDate: "2026-06-17",
+      remoteUrlReader: async () => "git@gitlab.com:foo/bar.git",
+      httpClient: async () => {
+        throw new Error("should not be called");
+      }
+    });
+
+    expect(result.skippedProjects).toHaveLength(1);
+    await expect(readFile(expired, "utf8")).rejects.toMatchObject({
+      code: "ENOENT"
+    });
+    await expect(readFile(recent, "utf8")).resolves.toBe("{}\n");
+  });
+
   it("preserves previously collected events when a re-run's fetch fails", async () => {
     const homeDir = await mkdtemp(join(tmpdir(), "gh-cmd-"));
     const projectRoot = await mkdtemp(join(tmpdir(), "gh-proj-"));

--- a/tests/raw-archive-prune.test.ts
+++ b/tests/raw-archive-prune.test.ts
@@ -1,0 +1,298 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdir, mkdtemp, rm, writeFile, readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  pruneRawArchives,
+  readRawRetentionDays,
+  type RawArchiveSource
+} from "../src/raw-archive-prune.js";
+
+async function makeProjectRoot(): Promise<string> {
+  return await mkdtemp(join(tmpdir(), "unc-170-"));
+}
+
+async function seedRawFile(
+  projectRoot: string,
+  source: RawArchiveSource,
+  name: string,
+  body = "{}\n"
+): Promise<string> {
+  const rawDir = join(projectRoot, ".uncommitted", "events", source, "raw");
+  await mkdir(rawDir, { recursive: true });
+  const file = join(rawDir, name);
+  await writeFile(file, body, "utf8");
+  return file;
+}
+
+describe("pruneRawArchives", () => {
+  let projectRoot: string;
+
+  beforeEach(async () => {
+    projectRoot = await makeProjectRoot();
+  });
+
+  afterEach(async () => {
+    await rm(projectRoot, { recursive: true, force: true });
+  });
+
+  it("deletes files strictly older than today minus retentionDays and keeps the rest", async () => {
+    await seedRawFile(projectRoot, "claude", "2026-06-20.jsonl");
+    await seedRawFile(projectRoot, "claude", "2026-06-21.jsonl");
+    await seedRawFile(projectRoot, "claude", "2026-06-22.jsonl");
+    await seedRawFile(projectRoot, "claude", "2026-06-23.jsonl");
+    await seedRawFile(projectRoot, "claude", "2026-06-24.jsonl");
+
+    const result = await pruneRawArchives({
+      projectRoot,
+      source: "claude",
+      today: "2026-06-24",
+      retentionDays: 3
+    });
+
+    const remaining = await readdir(
+      join(projectRoot, ".uncommitted", "events", "claude", "raw")
+    );
+    expect(remaining.sort()).toEqual([
+      "2026-06-22.jsonl",
+      "2026-06-23.jsonl",
+      "2026-06-24.jsonl"
+    ]);
+    expect(result.deletedFiles.map((f) => f.split("/").pop()!).sort()).toEqual([
+      "2026-06-20.jsonl",
+      "2026-06-21.jsonl"
+    ]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("treats retentionDays of 0 as unlimited and deletes nothing", async () => {
+    await seedRawFile(projectRoot, "codex", "2020-01-01.jsonl");
+    await seedRawFile(projectRoot, "codex", "2026-06-24.jsonl");
+
+    const result = await pruneRawArchives({
+      projectRoot,
+      source: "codex",
+      today: "2026-06-24",
+      retentionDays: 0
+    });
+
+    const remaining = await readdir(
+      join(projectRoot, ".uncommitted", "events", "codex", "raw")
+    );
+    expect(remaining.sort()).toEqual(["2020-01-01.jsonl", "2026-06-24.jsonl"]);
+    expect(result.deletedFiles).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("treats negative retentionDays as unlimited and deletes nothing", async () => {
+    await seedRawFile(projectRoot, "github", "2020-01-01.jsonl");
+
+    const result = await pruneRawArchives({
+      projectRoot,
+      source: "github",
+      today: "2026-06-24",
+      retentionDays: -5
+    });
+
+    const remaining = await readdir(
+      join(projectRoot, ".uncommitted", "events", "github", "raw")
+    );
+    expect(remaining).toEqual(["2020-01-01.jsonl"]);
+    expect(result.deletedFiles).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("returns no-op when the raw directory does not exist", async () => {
+    const result = await pruneRawArchives({
+      projectRoot,
+      source: "claude",
+      today: "2026-06-24",
+      retentionDays: 7
+    });
+
+    expect(result.deletedFiles).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("returns no-op when the raw directory exists but is empty", async () => {
+    const rawDir = join(projectRoot, ".uncommitted", "events", "claude", "raw");
+    await mkdir(rawDir, { recursive: true });
+
+    const result = await pruneRawArchives({
+      projectRoot,
+      source: "claude",
+      today: "2026-06-24",
+      retentionDays: 7
+    });
+
+    expect(result.deletedFiles).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("skips files whose name is not a valid YYYY-MM-DD date and never deletes them", async () => {
+    await seedRawFile(projectRoot, "claude", "notes.txt");
+    await seedRawFile(projectRoot, "claude", "2026.jsonl");
+    await seedRawFile(projectRoot, "claude", "2026-13-01.jsonl");
+    await seedRawFile(projectRoot, "claude", "2026-06-32.jsonl");
+    await seedRawFile(projectRoot, "claude", "2026-06-20.jsonl");
+
+    const result = await pruneRawArchives({
+      projectRoot,
+      source: "claude",
+      today: "2026-06-24",
+      retentionDays: 3
+    });
+
+    const remaining = await readdir(
+      join(projectRoot, ".uncommitted", "events", "claude", "raw")
+    );
+    expect(remaining.sort()).toEqual([
+      "2026-06-32.jsonl",
+      "2026-13-01.jsonl",
+      "2026.jsonl",
+      "notes.txt"
+    ]);
+    expect(result.deletedFiles.map((f) => f.split("/").pop()!)).toEqual([
+      "2026-06-20.jsonl"
+    ]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("deletes both .jsonl and .jsonl.gz variants by filename date", async () => {
+    await seedRawFile(projectRoot, "codex", "2026-06-20.jsonl");
+    await seedRawFile(projectRoot, "codex", "2026-06-20.jsonl.gz");
+    await seedRawFile(projectRoot, "codex", "2026-06-23.jsonl.gz");
+
+    const result = await pruneRawArchives({
+      projectRoot,
+      source: "codex",
+      today: "2026-06-24",
+      retentionDays: 2
+    });
+
+    const remaining = await readdir(
+      join(projectRoot, ".uncommitted", "events", "codex", "raw")
+    );
+    expect(remaining.sort()).toEqual(["2026-06-23.jsonl.gz"]);
+    expect(result.deletedFiles.map((f) => f.split("/").pop()!).sort()).toEqual([
+      "2026-06-20.jsonl",
+      "2026-06-20.jsonl.gz"
+    ]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("keeps today's file and yesterday's file when retentionDays=1", async () => {
+    // retentionDays=1 means "keep files within the last 1 day window including
+    // today" => cutoff = today - 0 days = today; keep today and newer, delete
+    // strictly older. Spec consensus: a positive N keeps the most recent N
+    // days INCLUDING today, so N=1 keeps only today and deletes yesterday.
+    await seedRawFile(projectRoot, "claude", "2026-06-23.jsonl");
+    await seedRawFile(projectRoot, "claude", "2026-06-24.jsonl");
+
+    const result = await pruneRawArchives({
+      projectRoot,
+      source: "claude",
+      today: "2026-06-24",
+      retentionDays: 1
+    });
+
+    const remaining = await readdir(
+      join(projectRoot, ".uncommitted", "events", "claude", "raw")
+    );
+    expect(remaining).toEqual(["2026-06-24.jsonl"]);
+    expect(result.deletedFiles.map((f) => f.split("/").pop()!)).toEqual([
+      "2026-06-23.jsonl"
+    ]);
+  });
+
+  it("touches only the specified source's raw directory", async () => {
+    await seedRawFile(projectRoot, "claude", "2020-01-01.jsonl");
+    await seedRawFile(projectRoot, "codex", "2020-01-01.jsonl");
+    await seedRawFile(projectRoot, "github", "2020-01-01.jsonl");
+
+    await pruneRawArchives({
+      projectRoot,
+      source: "claude",
+      today: "2026-06-24",
+      retentionDays: 7
+    });
+
+    expect(
+      await readdir(join(projectRoot, ".uncommitted", "events", "codex", "raw"))
+    ).toEqual(["2020-01-01.jsonl"]);
+    expect(
+      await readdir(join(projectRoot, ".uncommitted", "events", "github", "raw"))
+    ).toEqual(["2020-01-01.jsonl"]);
+  });
+
+  it("does not touch sibling canonical signal files outside raw/", async () => {
+    const eventsDir = join(projectRoot, ".uncommitted", "events", "claude");
+    await mkdir(eventsDir, { recursive: true });
+    const canonical = join(eventsDir, "2020-01-01.jsonl");
+    await writeFile(canonical, "{}\n", "utf8");
+    await seedRawFile(projectRoot, "claude", "2020-01-01.jsonl");
+
+    await pruneRawArchives({
+      projectRoot,
+      source: "claude",
+      today: "2026-06-24",
+      retentionDays: 7
+    });
+
+    expect(await readdir(eventsDir)).toEqual(
+      expect.arrayContaining(["2020-01-01.jsonl", "raw"])
+    );
+  });
+});
+
+describe("readRawRetentionDays", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "unc-170-cfg-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("returns 0 when the config file is missing", async () => {
+    expect(await readRawRetentionDays(join(dir, "missing.json"))).toBe(0);
+  });
+
+  it("returns 0 when the config file is malformed JSON", async () => {
+    const file = join(dir, "config.json");
+    await writeFile(file, "{not json", "utf8");
+    expect(await readRawRetentionDays(file)).toBe(0);
+  });
+
+  it("returns 0 when the field is absent", async () => {
+    const file = join(dir, "config.json");
+    await writeFile(file, JSON.stringify({ other: 1 }), "utf8");
+    expect(await readRawRetentionDays(file)).toBe(0);
+  });
+
+  it("returns 0 when the field is non-numeric", async () => {
+    const file = join(dir, "config.json");
+    await writeFile(file, JSON.stringify({ rawRetentionDays: "thirty" }), "utf8");
+    expect(await readRawRetentionDays(file)).toBe(0);
+  });
+
+  it("returns 0 when the field is negative", async () => {
+    const file = join(dir, "config.json");
+    await writeFile(file, JSON.stringify({ rawRetentionDays: -5 }), "utf8");
+    expect(await readRawRetentionDays(file)).toBe(0);
+  });
+
+  it("returns the integer value when the field is a positive integer", async () => {
+    const file = join(dir, "config.json");
+    await writeFile(file, JSON.stringify({ rawRetentionDays: 30 }), "utf8");
+    expect(await readRawRetentionDays(file)).toBe(30);
+  });
+
+  it("floors a positive non-integer to an integer", async () => {
+    const file = join(dir, "config.json");
+    await writeFile(file, JSON.stringify({ rawRetentionDays: 7.9 }), "utf8");
+    expect(await readRawRetentionDays(file)).toBe(7);
+  });
+});

--- a/tests/raw-archive-prune.test.ts
+++ b/tests/raw-archive-prune.test.ts
@@ -181,7 +181,7 @@ describe("pruneRawArchives", () => {
     expect(result.errors).toEqual([]);
   });
 
-  it("keeps today's file and yesterday's file when retentionDays=1", async () => {
+  it("keeps only today's file and deletes yesterday's file when retentionDays=1", async () => {
     // retentionDays=1 means "keep files within the last 1 day window including
     // today" => cutoff = today - 0 days = today; keep today and newer, delete
     // strictly older. Spec consensus: a positive N keeps the most recent N


### PR DESCRIPTION
🤖 **Auto-generated by Uncommitted Builder (Routine B v2 — single-issue path)**

## Issue
[UNC-170: Tier 1 원문 아카이브 보존 만료 prune 구현 (rawRetentionDays 소비)](https://linear.app/sangchu/issue/UNC-170/tier-1-원문-아카이브-보존-만료-prune-구현-rawretentiondays-소비)

Routine A가 분해 불필요(single-issue)로 판정하여 sub-issue 없이 이 이슈를 그대로 단일 작업으로 처리했습니다.

## Summary
UNC-157이 `rawRetentionDays` config 값을 정의·노출했지만 실제 prune 실행 로직이 누락되어 있던 **dead config** 상태를 해결합니다. 각 `collect` 실행에서 프로젝트별·소스별 `events/{claude,codex,github}/raw/YYYY-MM-DD.jsonl[.gz]` 아카이브 중 보존 기간이 만료된 파일을 삭제합니다.

핵심 동작:
- **파일명 기반**: `YYYY-MM-DD` 파일명이 권위 — fs mtime은 무시(백필/재실행 안전).
- **컷오프 의미**: `retentionDays=N` ⇒ 오늘 포함 최근 N일치 보존, 그 이전은 삭제.
- **0 / 음수 / unlimited**: prune 비활성.
- **graceful**: 디렉터리 부재·빈 디렉터리·잘못된 파일명·개별 unlink 실패 모두 collect 본 흐름을 막지 않음 (partial-output 보존).
- **소스 격리**: 호출된 소스의 `raw/` 만 만지며, sibling 정규 신호 파일(`events/<source>/<date>.jsonl`)은 절대 건드리지 않음.
- **gzip 변형**: `.jsonl`, `.jsonl.gz` 모두 동일 컷오프로 삭제.

## Status
- Branch: `claude/UNC-170-tier-1-prune`
- Tests: ⚠️ 623/625 pass + 1 skipped + 1 flake (see TDD trail).
- Build: ✅
- Type check: ✅
- Lint: ✅

## TDD trail
- TDD: 단위 테스트 17개 신규 (`tests/raw-archive-prune.test.ts`) — RED → GREEN.
- Commit 1 (`84657ed`): 본체 구현 + 테스트 + 3개 collect 명령 통합.
- Commit 2 (`b4ad34b`): code-review에서 지적된 misleading test title 수정 (`keeps today's file and yesterday's file` → `keeps only today's file and deletes yesterday's file`).
- **Flake (environment-bound, not from this PR)**: `tests/carousel-renderer-smoke.test.ts > renders a quiet 3-slide fixture into non-empty 1080x1350 PNGs`는 Playwright Chromium의 cold-init이 5s timeout보다 오래 걸리면 timeout으로 실패. 단독 실행 시 ~580ms로 통과, 전체 suite 병렬 실행 시 종종 5s 초과. **이 PR의 diff와 무관** — 본 routine 환경에서 `origin/main` checkout으로 동일 파일을 재확인했을 때도 같은 양상이 재현됨. 한 번은 그린 패스 관찰됨 (`Tests 624 passed | 1 skipped`).
- Per Routine B v2 정책 ("테스트 실패 상태에서 PR Ready 전환 금지"), Draft 상태 유지. 사람이 (a) flake 무시하고 Ready 전환, 또는 (b) 별도 후속으로 carousel-renderer-smoke timeout 조정 — 둘 중 선택 요망.

## Files changed
| 파일 | 변경 |
|---|---|
| `src/raw-archive-prune.ts` | new (157 LOC) — `pruneRawArchives`, `readRawRetentionDays`, helpers |
| `tests/raw-archive-prune.test.ts` | new (298 LOC) — 17 단위 테스트 |
| `src/collect-claude-command.ts` | +11 — prune 통합 |
| `src/collect-codex-command.ts` | +12 — prune 통합 |
| `src/collect-github-command.ts` | +11 — prune 통합 |

## Notes
- 새 dependency 없음. `node:fs/promises`만 사용.
- Lockfile/`.env*`/`AGENTS.md` 미수정.
- Auto-publish 코드 미도입.

## Review checklist
- [ ] `pnpm install && pnpm test && pnpm build` 로컬 실행 (flake 1건은 위 TDD trail 참조)
- [ ] Cutoff 의미 ("retentionDays=N ⇒ 오늘 포함 최근 N일치 보존") 합의 확인
- [ ] `retentionDays=0`이 "unlimited"라는 의미 — `readRawRetentionDays`가 0 반환, `pruneRawArchives`가 `retentionDays <= 0`에서 no-op 처리
- [ ] 정규 신호 파일(`events/<source>/<date>.jsonl`)은 절대 prune 대상이 아님 (테스트 1건 + 코드에서 경로 분리로 강제)
- [ ] **single-issue 판정이 적절했는지 확인** — 사후에 분해가 필요했다 판단되면 PR 닫고 `single-issue` 라벨 제거 후 Decomposer 재실행 권장
- [ ] Confirm no auto-publish code introduced

---
이 PR은 자동 생성되었습니다. 머지 전 사람의 리뷰가 반드시 필요합니다.
