### PR TITLE
🤖 Tier 2 caption projection: 토큰 예산 + 규칙 선택으로 원문 → caption writer (UNC-156)

### DIFF
--- a/src/diary-generator.ts
+++ b/src/diary-generator.ts
@@ -65,6 +65,7 @@ export type GenerateCaptionOptions = {
   provider: AiProvider;
   persona: string;
   roastLevel: number;
+  rawNarrativeProjection?: RawNarrativeProjection;
 };
 
 type DiaryDraftProviderData = JsonObject & {
@@ -293,6 +294,7 @@ export function buildCaptionInstructions(options: { quiet: boolean }): string {
     "4 to 8 short lines. Blank lines are allowed. Add 2 to 5 hashtags (each starting with #).",
     "Mild roast is allowed toward situations, workflow, bugs, TODOs, vague requirements, or developer habits. Never insult ability, worth, personality, identity, mental health, or real life.",
     quietInstruction,
+    "If rawNarrativeProjection is present, you may use its turns as concrete anchors for what actually happened today; it is already safety-filtered. Never copy it verbatim and never invent work it does not support.",
     "",
     "=== GOOD EXAMPLES ===",
     "",
@@ -398,11 +400,12 @@ function buildSafeCaptionInput(options: {
   activitySummary: ActivitySummary;
   persona: string;
   roastLevel: number;
+  rawNarrativeProjection?: RawNarrativeProjection;
 }): SafeActivitySummary {
   const summary = options.activitySummary;
   const quiet = summary.activityLevel === "none";
 
-  return {
+  const safeInput: SafeActivitySummary = {
     schemaVersion: 1,
     targetDate: summary.targetDate,
     quiet,
@@ -429,6 +432,17 @@ function buildSafeCaptionInput(options: {
       activityLevel: summary.activityLevel
     }
   };
+
+  // Tier 2 raw-narrative projection: concrete, already-safety-filtered anchors
+  // for days where the raw archive holds the only specific detail. The caption
+  // writer needs this just as much as the story writer (UNC-156 review).
+  if (options.rawNarrativeProjection !== undefined) {
+    safeInput.rawNarrativeProjection = toJsonValue(
+      options.rawNarrativeProjection
+    );
+  }
+
+  return safeInput;
 }
 
 function buildCaptionHighlights(summary: ActivitySummary): string[] {
@@ -461,7 +475,8 @@ export async function generateCaption(
     summary: buildSafeCaptionInput({
       activitySummary: options.activitySummary,
       persona: options.persona,
-      roastLevel: options.roastLevel
+      roastLevel: options.roastLevel,
+      rawNarrativeProjection: options.rawNarrativeProjection
     })
   });
 

--- a/src/diary-generator.ts
+++ b/src/diary-generator.ts
@@ -14,6 +14,7 @@ import type {
   ProjectPersonaHint,
   StoryFormatPlan
 } from "./story-format-plan.js";
+import type { RawNarrativeProjection } from "./raw-narrative-projection.js";
 
 export type DiarySlide = {
   index: number;
@@ -51,6 +52,7 @@ export type DiaryGeneratorOptions = {
   roastLevel: number;
   projectPersonaHints?: ProjectPersonaHint[];
   entryMode?: "daily_global";
+  rawNarrativeProjection?: RawNarrativeProjection;
 };
 
 export type CaptionResult = {
@@ -113,7 +115,8 @@ export async function generateDiaryDraft(
       storyFormatPlan: options.storyFormatPlan,
       persona: options.persona,
       roastLevel: options.roastLevel,
-      projectPersonaHints: options.projectPersonaHints ?? []
+      projectPersonaHints: options.projectPersonaHints ?? [],
+      rawNarrativeProjection: options.rawNarrativeProjection
     })
   });
   const response = await generateStructured<DiaryDraftProviderData>(
@@ -144,11 +147,12 @@ function buildSafeDiaryInput(options: {
   persona: string;
   roastLevel: number;
   projectPersonaHints: ProjectPersonaHint[];
+  rawNarrativeProjection?: RawNarrativeProjection;
 }): SafeActivitySummary {
   const summary = options.activitySummary;
   const quiet = summary.activityLevel === "none";
 
-  return {
+  const safeInput: SafeActivitySummary = {
     schemaVersion: 1,
     targetDate: summary.targetDate,
     quiet,
@@ -200,6 +204,28 @@ function buildSafeDiaryInput(options: {
       privateItemsToAvoid: summary.privateItemsToAvoid,
       uncertaintyNotes: summary.uncertaintyNotes
     }
+  };
+
+  if (options.rawNarrativeProjection !== undefined) {
+    safeInput.rawNarrativeProjection = toJsonValue(
+      options.rawNarrativeProjection
+    );
+  }
+
+  return safeInput;
+}
+
+function toJsonValue(projection: RawNarrativeProjection): JsonValue {
+  return {
+    turns: projection.turns.map((turn) => ({
+      source: turn.source,
+      text: turn.text,
+      tokenEstimate: turn.tokenEstimate
+    })),
+    totalTokens: projection.totalTokens,
+    droppedTurns: projection.droppedTurns,
+    droppedTokens: projection.droppedTokens,
+    budget: projection.budget
   };
 }
 

--- a/src/generate-command.ts
+++ b/src/generate-command.ts
@@ -33,6 +33,11 @@ import {
 import type { ManualNoteEvent } from "./note-command.js";
 import type { ProjectRecord, ProjectsFile } from "./project-add.js";
 import { loadSourceConfig } from "./source-config.js";
+import { buildRawNarrativeProjection } from "./raw-narrative-archive.js";
+import {
+  emptyRawNarrativeProjection,
+  readCaptionProjectionTokenBudget
+} from "./raw-narrative-projection.js";
 import {
   createSafetyReport,
   type SafetyReport,
@@ -197,6 +202,25 @@ export async function runGenerateCommand(
 
   const generatedAt = options.now ? options.now() : new Date().toISOString();
   const sourceConfig = await loadSourceConfig(paths.configFile);
+  // Tier 2 raw-narrative projection. A projection failure must never break
+  // generation — absent archives are already handled gracefully inside, so on
+  // any unexpected error we fall back to an empty projection.
+  let rawNarrativeProjection;
+  try {
+    rawNarrativeProjection = await buildRawNarrativeProjection({
+      projects: projects.map((project) => ({
+        id: project.id,
+        root: project.root
+      })),
+      config: sourceConfig,
+      configFilePath: paths.configFile,
+      targetDate
+    });
+  } catch {
+    rawNarrativeProjection = emptyRawNarrativeProjection(
+      await readCaptionProjectionTokenBudget(paths.configFile)
+    );
+  }
   const gitEvents = sourceConfig.git.enabled
     ? await readGitActivityEvents(projects, targetDate)
     : [];
@@ -248,7 +272,8 @@ export async function runGenerateCommand(
     storyFormatPlan,
     provider,
     persona: config.persona,
-    roastLevel: config.roastLevel
+    roastLevel: config.roastLevel,
+    rawNarrativeProjection
   });
   const captionResult = await generateCaption({
     activitySummary,

--- a/src/generate-command.ts
+++ b/src/generate-command.ts
@@ -212,7 +212,7 @@ export async function runGenerateCommand(
         id: project.id,
         root: project.root
       })),
-      config: sourceConfig,
+      sourceConfig,
       configFilePath: paths.configFile,
       targetDate
     });

--- a/src/generate-command.ts
+++ b/src/generate-command.ts
@@ -279,7 +279,8 @@ export async function runGenerateCommand(
     activitySummary,
     provider,
     persona: config.persona,
-    roastLevel: config.roastLevel
+    roastLevel: config.roastLevel,
+    rawNarrativeProjection
   });
   const caption = deriveCaptionText(captionResult);
   const baseMetadata: DraftMetadataBase = {

--- a/src/raw-narrative-archive.ts
+++ b/src/raw-narrative-archive.ts
@@ -127,7 +127,10 @@ function normalizeEntry(
       text,
       timestamp: typeof entry.timestamp === "string" ? entry.timestamp : "",
       sessionId,
-      hasCodeOrToolMarker: hasCodeOrToolMarker(text)
+      hasCodeOrToolMarker: hasCodeOrToolMarker(text),
+      // Carry the role so the projection can drop user requests/plans, which are
+      // not evidence of completed work (UNC-156 review).
+      role: typeof entry.role === "string" ? entry.role : undefined
     };
   }
 
@@ -154,6 +157,14 @@ function normalizeEntry(
   // lives in `text` (see OwnAuthoredBody in github-event-normalizer.ts); the
   // timestamp field is `timestamp`.
   if (source === "github") {
+    // `issue-body` is attributed on the CLOSER, not the author (see
+    // github-event-normalizer.ts "Attribute on the closer"). Closing a
+    // teammate's issue would otherwise project their description as the user's
+    // own raw narrative, so skip it — only `pr-body`/`review-comment` are
+    // genuinely user-authored (UNC-156 review).
+    if (entry.source === "issue-body") {
+      return undefined;
+    }
     const text = firstString(entry.text);
     if (text.length === 0) {
       return undefined;
@@ -273,9 +284,16 @@ export type BuildRawNarrativeProjectionInput = {
 
 /**
  * Orchestrate the full Tier 2 pipeline over the day's Tier 1 archives:
- *   read archives -> selectTurns (budgeted) -> egress revalidation ->
- *   assemble projection. Egress drops are FOLDED (summed) into the final
- *   projection counters so dropped secret turns remain visible to callers.
+ *   read archives -> drop user-role requests -> egress safety filter
+ *   (secrets + raw code) -> selectTurns (budgeted) -> assemble projection.
+ *
+ * The egress safety filter runs BEFORE selection on purpose: selection/assembly
+ * only subset turns (they never add or mutate text), so filtering first means
+ * unsafe turns can neither egress nor consume the budget that clean narrative
+ * needs — fixing the "selected-then-egress-dropped, no backfill" thinning
+ * (UNC-156 review). Drops from EVERY stage (role, safety, selection, assembly)
+ * are FOLDED into the final projection counters so truncation stays visible to
+ * callers and metadata.
  *
  * When there are no turns at all (absent or all-disabled), returns an empty
  * projection echoing the resolved budget — a faithful no-op.
@@ -297,16 +315,42 @@ export async function buildRawNarrativeProjection(
     return emptyRawNarrativeProjection(budget);
   }
 
-  const selected = selectTurns(turns, { budget, tokenCounter });
-  const reval = revalidateTurnsForEgress(selected, tokenCounter);
-  const projection = assembleRawNarrativeProjection(reval.kept, {
+  // Drop user-role turns: requests/plans are not evidence of completed work.
+  const relevant = turns.filter((turn) => turn.role !== "user");
+  let droppedTurns = 0;
+  let droppedTokens = 0;
+  for (const turn of turns) {
+    if (turn.role === "user") {
+      droppedTurns += 1;
+      droppedTokens += tokenCounter.estimate(turn.text);
+    }
+  }
+
+  // Egress safety filter (secrets + raw code) BEFORE budgeted selection.
+  const safe = revalidateTurnsForEgress(relevant, tokenCounter);
+  droppedTurns += safe.droppedTurns;
+  droppedTokens += safe.droppedTokens;
+
+  const selected = selectTurns(safe.kept, { budget, tokenCounter });
+
+  // Turns selectTurns omitted under budget pressure must be counted too,
+  // otherwise an over-budget day can report droppedTurns: 0 (UNC-156 review).
+  const selectedSet = new Set<NarrativeTurn>(selected);
+  for (const turn of safe.kept) {
+    if (!selectedSet.has(turn)) {
+      droppedTurns += 1;
+      droppedTokens += tokenCounter.estimate(turn.text);
+    }
+  }
+
+  const projection = assembleRawNarrativeProjection(selected, {
     budget,
     tokenCounter
   });
 
   return {
     ...projection,
-    droppedTurns: projection.droppedTurns + reval.droppedTurns,
-    droppedTokens: projection.droppedTokens + reval.droppedTokens
+    droppedTurns: projection.droppedTurns + droppedTurns,
+    droppedTokens: projection.droppedTokens + droppedTokens
   };
 }

--- a/src/raw-narrative-archive.ts
+++ b/src/raw-narrative-archive.ts
@@ -1,0 +1,308 @@
+// Tier 1 raw archive reader + Tier 2 projection orchestration (UNC-164).
+//
+// This module is READ-ONLY over the Tier 1 `raw/` archives written by the
+// session/github collectors. It never collects or mutates source data; it only
+// projects the day's raw narrative material into a budgeted projection for the
+// downstream caption writer.
+//
+// Per-source gating honors the UNC-120 opt-out config: a disabled source
+// contributes ZERO turns and is recorded distinctly from an absent archive, so
+// callers can tell "user turned this off" apart from "nothing happened here".
+//
+// Raw archives are SUPPLEMENTARY, already-redacted input: a malformed line or a
+// missing file must never throw or block diary generation. We mirror
+// `readSessionActivitySignals` in generate-command.ts — skip bad lines silently
+// and treat ENOENT as an empty (no-archive) source.
+
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  assembleRawNarrativeProjection,
+  defaultTokenCounter,
+  emptyRawNarrativeProjection,
+  readCaptionProjectionTokenBudget,
+  type NarrativeSource,
+  type NarrativeTurn,
+  type RawNarrativeProjection,
+  type TokenCounter
+} from "./raw-narrative-projection.js";
+import { selectTurns } from "./raw-narrative-selection.js";
+import { revalidateTurnsForEgress } from "./raw-narrative-egress.js";
+import { isSourceEnabled } from "./source-config.js";
+
+// Sources whose Tier 1 raw archives this reader projects. Git is excluded — it
+// has no conversational raw archive (its events are structured commit data).
+const RAW_NARRATIVE_SOURCES: readonly NarrativeSource[] = [
+  "claude",
+  "codex",
+  "github"
+];
+
+export type Tier1DiscoveryStatus = "disabled" | "no-archive" | "read";
+
+export type Tier1Discovery = {
+  projectId: string;
+  source: NarrativeSource;
+  status: Tier1DiscoveryStatus;
+  turnCount: number;
+};
+
+export type ProjectInput = {
+  id: string;
+  root: string;
+};
+
+export type ReadTier1ArchivesInput = {
+  projects: ProjectInput[];
+  config: unknown;
+  targetDate: string;
+};
+
+export type ReadTier1ArchivesResult = {
+  turns: NarrativeTurn[];
+  discoveries: Tier1Discovery[];
+};
+
+/**
+ * Lightweight, deterministic marker check: does the text look like it carries
+ * code or a tool/command reference? Cheap regex over common, stable markers —
+ * code fences (```), inline backticks, and a handful of language/CLI tokens.
+ * Conservative on purpose: a false positive only nudges selection density, it
+ * never mutates text or egresses anything.
+ */
+export function hasCodeOrToolMarker(text: string): boolean {
+  if (text.length === 0) {
+    return false;
+  }
+  if (text.includes("```") || text.includes("`")) {
+    return true;
+  }
+  return /\b(function|const|=>|import |class |def |\$ |npm |git )/.test(text);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return isRecord(error) && error.code === "ENOENT";
+}
+
+function firstString(...values: unknown[]): string {
+  for (const value of values) {
+    if (typeof value === "string" && value.length > 0) {
+      return value;
+    }
+  }
+  return "";
+}
+
+/**
+ * Normalize a single parsed JSONL entry into a NarrativeTurn, or undefined when
+ * the entry carries no usable text (skip it silently).
+ */
+function normalizeEntry(
+  entry: unknown,
+  source: NarrativeSource,
+  sessionId: string
+): NarrativeTurn | undefined {
+  if (!isRecord(entry)) {
+    return undefined;
+  }
+
+  const kind = entry.kind;
+
+  if (kind === "turn") {
+    // claude/codex conversation turn.
+    if (typeof entry.text !== "string" || entry.text.length === 0) {
+      return undefined;
+    }
+    const text = entry.text;
+    return {
+      source,
+      text,
+      timestamp: typeof entry.timestamp === "string" ? entry.timestamp : "",
+      sessionId,
+      hasCodeOrToolMarker: hasCodeOrToolMarker(text)
+    };
+  }
+
+  if (kind === "tool") {
+    // claude/codex tool fact. Combine `tool` + optional `target`.
+    if (typeof entry.tool !== "string" || entry.tool.length === 0) {
+      return undefined;
+    }
+    const target = typeof entry.target === "string" ? entry.target : "";
+    const text = `${entry.tool}${target ? " " + target : ""}`.trim();
+    if (text.length === 0) {
+      return undefined;
+    }
+    return {
+      source,
+      text,
+      timestamp: typeof entry.timestamp === "string" ? entry.timestamp : "",
+      sessionId,
+      hasCodeOrToolMarker: true
+    };
+  }
+
+  // GitHub own-authored body entries have NO `kind`. The human-authored text
+  // lives in `text` (see OwnAuthoredBody in github-event-normalizer.ts); the
+  // timestamp field is `timestamp`.
+  if (source === "github") {
+    const text = firstString(entry.text);
+    if (text.length === 0) {
+      return undefined;
+    }
+    return {
+      source: "github",
+      text,
+      timestamp: typeof entry.timestamp === "string" ? entry.timestamp : "",
+      sessionId,
+      hasCodeOrToolMarker: hasCodeOrToolMarker(text)
+    };
+  }
+
+  return undefined;
+}
+
+/**
+ * Read the day's Tier 1 raw archives across all projects and sources,
+ * normalizing each entry into a NarrativeTurn. Source gating, absence, and read
+ * are all recorded as distinct discovery statuses.
+ *
+ * One archive FILE is treated as one session (we lack explicit session markers
+ * in the raw archive), keyed `${source}:${projectId}:${targetDate}`.
+ */
+export async function readTier1Archives(
+  input: ReadTier1ArchivesInput
+): Promise<ReadTier1ArchivesResult> {
+  const turns: NarrativeTurn[] = [];
+  const discoveries: Tier1Discovery[] = [];
+
+  for (const project of input.projects) {
+    for (const source of RAW_NARRATIVE_SOURCES) {
+      if (!isSourceEnabled(input.config, source)) {
+        discoveries.push({
+          projectId: project.id,
+          source,
+          status: "disabled",
+          turnCount: 0
+        });
+        continue;
+      }
+
+      const file = join(
+        project.root,
+        ".uncommitted",
+        "events",
+        source,
+        "raw",
+        `${input.targetDate}.jsonl`
+      );
+
+      let content: string;
+      try {
+        content = await readFile(file, "utf8");
+      } catch (error) {
+        if (isNotFoundError(error)) {
+          discoveries.push({
+            projectId: project.id,
+            source,
+            status: "no-archive",
+            turnCount: 0
+          });
+          continue;
+        }
+        // Any other read error (permissions/IO): treat as no-archive rather
+        // than blocking generation. Raw archives are supplementary input.
+        discoveries.push({
+          projectId: project.id,
+          source,
+          status: "no-archive",
+          turnCount: 0
+        });
+        continue;
+      }
+
+      const sessionId = `${source}:${project.id}:${input.targetDate}`;
+      let turnCount = 0;
+
+      for (const line of content.split("\n")) {
+        if (!line.trim()) {
+          continue;
+        }
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(line);
+        } catch {
+          // Malformed line: skip silently, never throw.
+          continue;
+        }
+        const turn = normalizeEntry(parsed, source, sessionId);
+        if (turn !== undefined) {
+          turns.push(turn);
+          turnCount += 1;
+        }
+      }
+
+      discoveries.push({
+        projectId: project.id,
+        source,
+        status: "read",
+        turnCount
+      });
+    }
+  }
+
+  return { turns, discoveries };
+}
+
+export type BuildRawNarrativeProjectionInput = {
+  projects: ProjectInput[];
+  config: unknown;
+  configFilePath: string;
+  targetDate: string;
+  budget?: number;
+  tokenCounter?: TokenCounter;
+};
+
+/**
+ * Orchestrate the full Tier 2 pipeline over the day's Tier 1 archives:
+ *   read archives -> selectTurns (budgeted) -> egress revalidation ->
+ *   assemble projection. Egress drops are FOLDED (summed) into the final
+ *   projection counters so dropped secret turns remain visible to callers.
+ *
+ * When there are no turns at all (absent or all-disabled), returns an empty
+ * projection echoing the resolved budget — a faithful no-op.
+ */
+export async function buildRawNarrativeProjection(
+  input: BuildRawNarrativeProjectionInput
+): Promise<RawNarrativeProjection> {
+  const tokenCounter = input.tokenCounter ?? defaultTokenCounter;
+  const budget =
+    input.budget ?? (await readCaptionProjectionTokenBudget(input.configFilePath));
+
+  const { turns } = await readTier1Archives({
+    projects: input.projects,
+    config: input.config,
+    targetDate: input.targetDate
+  });
+
+  if (turns.length === 0) {
+    return emptyRawNarrativeProjection(budget);
+  }
+
+  const selected = selectTurns(turns, { budget, tokenCounter });
+  const reval = revalidateTurnsForEgress(selected, tokenCounter);
+  const projection = assembleRawNarrativeProjection(reval.kept, {
+    budget,
+    tokenCounter
+  });
+
+  return {
+    ...projection,
+    droppedTurns: projection.droppedTurns + reval.droppedTurns,
+    droppedTokens: projection.droppedTokens + reval.droppedTokens
+  };
+}

--- a/src/raw-narrative-archive.ts
+++ b/src/raw-narrative-archive.ts
@@ -28,7 +28,7 @@ import {
 } from "./raw-narrative-projection.js";
 import { selectTurns } from "./raw-narrative-selection.js";
 import { revalidateTurnsForEgress } from "./raw-narrative-egress.js";
-import { isSourceEnabled } from "./source-config.js";
+import type { SourceConfigMap } from "./source-config.js";
 
 // Sources whose Tier 1 raw archives this reader projects. Git is excluded — it
 // has no conversational raw archive (its events are structured commit data).
@@ -54,7 +54,11 @@ export type ProjectInput = {
 
 export type ReadTier1ArchivesInput = {
   projects: ProjectInput[];
-  config: unknown;
+  // Normalized per-source toggle map from loadSourceConfig (UNC-120). Typed
+  // (not `unknown`) so the gate below is compile-checked against the actual
+  // shape callers pass — a `SourceConfigMap` keyed by source, NOT the raw
+  // config object with a `.sources` wrapper.
+  sourceConfig: SourceConfigMap;
   targetDate: string;
 };
 
@@ -182,7 +186,7 @@ export async function readTier1Archives(
 
   for (const project of input.projects) {
     for (const source of RAW_NARRATIVE_SOURCES) {
-      if (!isSourceEnabled(input.config, source)) {
+      if (input.sourceConfig[source].enabled === false) {
         discoveries.push({
           projectId: project.id,
           source,
@@ -260,7 +264,7 @@ export async function readTier1Archives(
 
 export type BuildRawNarrativeProjectionInput = {
   projects: ProjectInput[];
-  config: unknown;
+  sourceConfig: SourceConfigMap;
   configFilePath: string;
   targetDate: string;
   budget?: number;
@@ -285,7 +289,7 @@ export async function buildRawNarrativeProjection(
 
   const { turns } = await readTier1Archives({
     projects: input.projects,
-    config: input.config,
+    sourceConfig: input.sourceConfig,
     targetDate: input.targetDate
   });
 

--- a/src/raw-narrative-egress.ts
+++ b/src/raw-narrative-egress.ts
@@ -18,9 +18,13 @@ export type EgressRevalidationResult = {
  * selected turn aggressively and over-redact on purpose.
  *
  * For each turn we run {@link detectSecrets}. If any signature fires
- * (`categories.length > 0`) the ENTIRE turn is dropped — we do not attempt to
+ * (`categories.length > 0`) OR the detector mutated the text at all
+ * (`value !== turn.text`) the ENTIRE turn is dropped — we do not attempt to
  * salvage the redacted value, because a turn that trips any signature is
- * terminal. Clean turns are kept UNCHANGED (same object reference and text),
+ * terminal. The `value !== text` check is belt-and-suspenders: it removes this
+ * gate's dependency on the detector's implicit "mutate ⟹ category" invariant,
+ * so a future detector that ever redacts without firing a category still cannot
+ * leak here. Clean turns are kept UNCHANGED (same object reference and text),
  * preserving input order. Dropped turns are counted toward `droppedTurns` and
  * their token estimates summed into `droppedTokens` so callers (T4) can fold
  * them into the final projection counters.
@@ -34,8 +38,8 @@ export function revalidateTurnsForEgress(
   let droppedTokens = 0;
 
   for (const turn of turns) {
-    const { categories } = detectSecrets(turn.text);
-    if (categories.length > 0) {
+    const { categories, value } = detectSecrets(turn.text);
+    if (categories.length > 0 || value !== turn.text) {
       droppedTurns += 1;
       droppedTokens += tokenCounter.estimate(turn.text);
       continue;

--- a/src/raw-narrative-egress.ts
+++ b/src/raw-narrative-egress.ts
@@ -1,0 +1,47 @@
+import { detectSecrets } from "./credential-detector.js";
+import {
+  defaultTokenCounter,
+  type NarrativeTurn,
+  type TokenCounter
+} from "./raw-narrative-projection.js";
+
+export type EgressRevalidationResult = {
+  kept: NarrativeTurn[];
+  droppedTurns: number;
+  droppedTokens: number;
+};
+
+/**
+ * Final pre-egress secret re-validation for the raw conversation turns that
+ * are about to leave the machine for the external caption-writer LLM. This is
+ * the only point where raw narrative text egresses, so we re-validate every
+ * selected turn aggressively and over-redact on purpose.
+ *
+ * For each turn we run {@link detectSecrets}. If any signature fires
+ * (`categories.length > 0`) the ENTIRE turn is dropped — we do not attempt to
+ * salvage the redacted value, because a turn that trips any signature is
+ * terminal. Clean turns are kept UNCHANGED (same object reference and text),
+ * preserving input order. Dropped turns are counted toward `droppedTurns` and
+ * their token estimates summed into `droppedTokens` so callers (T4) can fold
+ * them into the final projection counters.
+ */
+export function revalidateTurnsForEgress(
+  turns: NarrativeTurn[],
+  tokenCounter: TokenCounter = defaultTokenCounter
+): EgressRevalidationResult {
+  const kept: NarrativeTurn[] = [];
+  let droppedTurns = 0;
+  let droppedTokens = 0;
+
+  for (const turn of turns) {
+    const { categories } = detectSecrets(turn.text);
+    if (categories.length > 0) {
+      droppedTurns += 1;
+      droppedTokens += tokenCounter.estimate(turn.text);
+      continue;
+    }
+    kept.push(turn);
+  }
+
+  return { kept, droppedTurns, droppedTokens };
+}

--- a/src/raw-narrative-egress.ts
+++ b/src/raw-narrative-egress.ts
@@ -12,22 +12,25 @@ export type EgressRevalidationResult = {
 };
 
 /**
- * Final pre-egress secret re-validation for the raw conversation turns that
- * are about to leave the machine for the external caption-writer LLM. This is
- * the only point where raw narrative text egresses, so we re-validate every
- * selected turn aggressively and over-redact on purpose.
+ * Egress safety filter for the raw conversation turns that are about to leave
+ * the machine for the external caption-writer LLM. The pipeline applies this
+ * BEFORE selection/assembly (which only subset turns, never add or mutate
+ * text), so no unsafe text can reach the provider. We over-redact on purpose.
  *
- * For each turn we run {@link detectSecrets}. If any signature fires
- * (`categories.length > 0`) OR the detector mutated the text at all
- * (`value !== turn.text`) the ENTIRE turn is dropped — we do not attempt to
- * salvage the redacted value, because a turn that trips any signature is
- * terminal. The `value !== text` check is belt-and-suspenders: it removes this
- * gate's dependency on the detector's implicit "mutate ⟹ category" invariant,
- * so a future detector that ever redacts without firing a category still cannot
- * leak here. Clean turns are kept UNCHANGED (same object reference and text),
- * preserving input order. Dropped turns are counted toward `droppedTurns` and
- * their token estimates summed into `droppedTokens` so callers (T4) can fold
- * them into the final projection counters.
+ * A turn is DROPPED ENTIRELY (never salvaged) when any of:
+ *   - {@link detectSecrets} fires a signature (`categories.length > 0`), or
+ *   - the detector mutated the text at all (`value !== turn.text`), or
+ *   - the turn carries a raw code / tool marker (`hasCodeOrToolMarker`).
+ *
+ * The first two are the secret gate; the `value !== text` check is
+ * belt-and-suspenders so a future detector that redacts without firing a
+ * category still cannot leak. The third enforces the project rule "do not send
+ * raw code/diffs to AI providers": plain code that trips no secret signature
+ * (e.g. `function renderCard() { ... }`, an unbackticked `import ...`) must not
+ * egress either (UNC-156 review). Clean prose turns are kept UNCHANGED (same
+ * object reference and text), preserving input order. Dropped turns are counted
+ * toward `droppedTurns` and their token estimates summed into `droppedTokens` so
+ * callers can fold them into the final projection counters.
  */
 export function revalidateTurnsForEgress(
   turns: NarrativeTurn[],
@@ -39,7 +42,11 @@ export function revalidateTurnsForEgress(
 
   for (const turn of turns) {
     const { categories, value } = detectSecrets(turn.text);
-    if (categories.length > 0 || value !== turn.text) {
+    if (
+      categories.length > 0 ||
+      value !== turn.text ||
+      turn.hasCodeOrToolMarker
+    ) {
       droppedTurns += 1;
       droppedTokens += tokenCounter.estimate(turn.text);
       continue;

--- a/src/raw-narrative-projection.ts
+++ b/src/raw-narrative-projection.ts
@@ -1,0 +1,118 @@
+import { readFile } from "node:fs/promises";
+
+export type NarrativeSource = "claude" | "codex" | "github";
+
+export type NarrativeTurn = {
+  source: NarrativeSource;
+  text: string;
+  timestamp: string; // ISO-8601; "" when none
+  sessionId: string; // grouping key
+  hasCodeOrToolMarker: boolean;
+};
+
+export type ProjectionTurn = {
+  source: NarrativeSource;
+  text: string;
+  tokenEstimate: number;
+};
+
+export type RawNarrativeProjection = {
+  turns: ProjectionTurn[];
+  totalTokens: number;
+  droppedTurns: number;
+  droppedTokens: number;
+  budget: number;
+};
+
+export interface TokenCounter {
+  estimate(text: string): number;
+}
+
+export const defaultTokenCounter: TokenCounter = {
+  estimate(text: string): number {
+    if (text.length === 0) {
+      return 0;
+    }
+    return Math.ceil(text.length / 4);
+  }
+};
+
+export const DEFAULT_CAPTION_PROJECTION_TOKEN_BUDGET = 4000;
+
+export function emptyRawNarrativeProjection(
+  budget: number
+): RawNarrativeProjection {
+  return {
+    turns: [],
+    totalTokens: 0,
+    droppedTurns: 0,
+    droppedTokens: 0,
+    budget
+  };
+}
+
+export function assembleRawNarrativeProjection(
+  orderedTurns: NarrativeTurn[],
+  options: { budget: number; tokenCounter?: TokenCounter }
+): RawNarrativeProjection {
+  const { budget } = options;
+  const tokenCounter = options.tokenCounter ?? defaultTokenCounter;
+
+  if (orderedTurns.length === 0 || budget <= 0) {
+    return emptyRawNarrativeProjection(budget);
+  }
+
+  const turns: ProjectionTurn[] = [];
+  let totalTokens = 0;
+  let droppedTurns = 0;
+  let droppedTokens = 0;
+
+  for (const turn of orderedTurns) {
+    const tokenEstimate = tokenCounter.estimate(turn.text);
+    if (totalTokens + tokenEstimate <= budget) {
+      turns.push({
+        source: turn.source,
+        text: turn.text,
+        tokenEstimate
+      });
+      totalTokens += tokenEstimate;
+    } else {
+      droppedTurns += 1;
+      droppedTokens += tokenEstimate;
+    }
+  }
+
+  return {
+    turns,
+    totalTokens,
+    droppedTurns,
+    droppedTokens,
+    budget
+  };
+}
+
+export async function readCaptionProjectionTokenBudget(
+  configFilePath: string
+): Promise<number> {
+  let raw: string;
+  try {
+    raw = await readFile(configFilePath, "utf8");
+  } catch {
+    return DEFAULT_CAPTION_PROJECTION_TOKEN_BUDGET;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return DEFAULT_CAPTION_PROJECTION_TOKEN_BUDGET;
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    return DEFAULT_CAPTION_PROJECTION_TOKEN_BUDGET;
+  }
+  const value = (parsed as Record<string, unknown>)
+    .captionProjectionTokenBudget;
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return DEFAULT_CAPTION_PROJECTION_TOKEN_BUDGET;
+  }
+  return Math.floor(value);
+}

--- a/src/raw-narrative-projection.ts
+++ b/src/raw-narrative-projection.ts
@@ -8,6 +8,11 @@ export type NarrativeTurn = {
   timestamp: string; // ISO-8601; "" when none
   sessionId: string; // grouping key
   hasCodeOrToolMarker: boolean;
+  // Conversation role for claude/codex turns ("user" | "assistant" | ...).
+  // Absent for tool facts and github bodies. A "user" turn is a request/plan,
+  // NOT evidence of completed work, so the projection pipeline drops it to avoid
+  // narrating requested-but-not-done work (UNC-156 review).
+  role?: string;
 };
 
 export type ProjectionTurn = {

--- a/src/raw-narrative-selection.ts
+++ b/src/raw-narrative-selection.ts
@@ -24,9 +24,10 @@
 //          original index (keep earlier-arriving turns).
 //          Kept turns are emitted in chronological (timestamp) order, with
 //          original index as a stable tie-break.
-//        - Once a session is partially evicted (budget pressure reached), later
-//          (older) sessions get no budget; the walk stops adding new sessions
-//          after the budget is exhausted.
+//        - After a partial eviction the budget is usually exhausted, but the
+//          walk continues while `remaining > 0`: any leftover slack flows to
+//          strictly-older sessions (which may be kept whole or partially), so
+//          newer sessions are always served first.
 //   4. Output is concatenated session-by-session in keep-priority (recency)
 //      order, ready for `assembleRawNarrativeProjection` (which re-applies a
 //      hard cap as a safety net).
@@ -222,8 +223,9 @@ export function selectTurns(
     }
     remaining -= kept;
 
-    // Budget is now exhausted (or nearly); subsequent older sessions get
-    // nothing further. Stop to keep the policy crisp and deterministic.
+    // If any budget slack remains after this partial eviction, continue to
+    // strictly-older sessions and backfill them into the leftover slack.
+    // Stop only once the budget is fully exhausted.
     if (remaining <= 0) {
       break;
     }

--- a/src/raw-narrative-selection.ts
+++ b/src/raw-narrative-selection.ts
@@ -178,58 +178,89 @@ export function selectTurns(
     return a.firstIndex - b.firstIndex;
   });
 
-  // 4. Greedy fill, session by session, in recency order.
-  const result: NarrativeTurn[] = [];
+  // 4. Two-phase fill honoring completeness > recency.
+  //
+  //   Phase 1: walk sessions most-recent-first and keep every session that fits
+  //            WHOLE in the remaining budget. A session that does not fit whole
+  //            is skipped here; the FIRST (most-recent) such session is the sole
+  //            candidate for a partial fill, all older non-fitting sessions are
+  //            dropped.
+  //   Phase 2: partial-fill that candidate into any leftover slack.
+  //
+  // Doing whole-session keeps first means a budget that cannot fit the newest
+  // session but CAN fit an older session completely emits the complete older
+  // session instead of a fragment of the newer one — the documented
+  // completeness-outranks-recency rule (UNC-156 review).
+  const keptBySession = new Map<string, NarrativeTurn[]>();
   let remaining = budget;
+  let partialCandidate: SessionGroup | undefined;
 
   for (const session of orderedSessions) {
     const sessionTokens = session.turns.reduce((sum, t) => sum + t.tokens, 0);
-
     if (sessionTokens <= remaining) {
-      // Whole-session keep (completeness preference). Emit in chronological
-      // (original input) order.
-      for (const item of session.turns) {
-        result.push(item.turn);
-      }
+      keptBySession.set(
+        session.sessionId,
+        session.turns.map((item) => item.turn)
+      );
       remaining -= sessionTokens;
       continue;
     }
-
-    // Intra-session budget pressure: evict lowest-density turns first until the
-    // rest fit `remaining`. Eviction order is ascending density; ties broken by
-    // earlier original index (keep earlier turns when density is equal).
-    const evictionOrder = [...session.turns].sort((a, b) => {
-      if (a.density !== b.density) {
-        return a.density - b.density; // lowest density first to drop
-      }
-      return b.originalIndex - a.originalIndex; // drop later turns on ties
-    });
-
-    const dropped = new Set<number>();
-    let kept = sessionTokens;
-    for (const item of evictionOrder) {
-      if (kept <= remaining) {
-        break;
-      }
-      dropped.add(item.originalIndex);
-      kept -= item.tokens;
+    if (partialCandidate === undefined) {
+      partialCandidate = session;
     }
+  }
 
-    // Emit survivors in original chronological order.
-    for (const item of session.turns) {
-      if (!dropped.has(item.originalIndex)) {
-        result.push(item.turn);
-      }
+  if (partialCandidate !== undefined && remaining > 0) {
+    const survivors = evictToFit(partialCandidate, remaining);
+    if (survivors.length > 0) {
+      keptBySession.set(partialCandidate.sessionId, survivors);
     }
-    remaining -= kept;
+  }
 
-    // If any budget slack remains after this partial eviction, continue to
-    // strictly-older sessions and backfill them into the leftover slack.
-    // Stop only once the budget is fully exhausted.
-    if (remaining <= 0) {
-      break;
+  // 5. Emit in keep-priority (recency) order.
+  const result: NarrativeTurn[] = [];
+  for (const session of orderedSessions) {
+    const kept = keptBySession.get(session.sessionId);
+    if (kept !== undefined) {
+      result.push(...kept);
     }
   }
 
   return result;
+}
+
+/**
+ * Intra-session budget pressure: evict a session's lowest-density turns first
+ * until the rest fit `remaining`. Eviction order is ascending density; ties
+ * broken by LATER original index (drop later turns, keep earlier ones).
+ * Survivors are returned in chronological (original input) order.
+ */
+function evictToFit(
+  session: SessionGroup,
+  remaining: number
+): NarrativeTurn[] {
+  const evictionOrder = [...session.turns].sort((a, b) => {
+    if (a.density !== b.density) {
+      return a.density - b.density; // lowest density first to drop
+    }
+    return b.originalIndex - a.originalIndex; // drop later turns on ties
+  });
+
+  const dropped = new Set<number>();
+  let kept = session.turns.reduce((sum, t) => sum + t.tokens, 0);
+  for (const item of evictionOrder) {
+    if (kept <= remaining) {
+      break;
+    }
+    dropped.add(item.originalIndex);
+    kept -= item.tokens;
+  }
+
+  const survivors: NarrativeTurn[] = [];
+  for (const item of session.turns) {
+    if (!dropped.has(item.originalIndex)) {
+      survivors.push(item.turn);
+    }
+  }
+  return survivors;
 }

--- a/src/raw-narrative-selection.ts
+++ b/src/raw-narrative-selection.ts
@@ -1,0 +1,233 @@
+// Tier 2 deterministic turn selection (UNC-162).
+//
+// This module is PURE, RULE-BASED, and contains NO LLM. The only LLM in the
+// pipeline is the downstream caption writer; selection here is a fixed-rule
+// reducer so the same input always yields the same output.
+//
+// We pick which raw narrative turns to hand to
+// `assembleRawNarrativeProjection` under a token budget. Precedence is FIXED:
+//
+//   (1) session-boundary completeness  >  (2) recency  >  (3) signal density
+//
+// Algorithm:
+//   1. Group turns by `sessionId`, preserving each turn's original index so we
+//      can break every tie deterministically.
+//   2. Order sessions by recency: a session's recency = its newest turn
+//      timestamp. Sessions with only empty timestamps sort oldest. Ties on
+//      recency are broken by sessionId, then first original index.
+//   3. Walk sessions most-recent-first, greedily filling the budget:
+//        - If the WHOLE session fits the remaining budget, keep it whole
+//          (completeness preference).
+//        - If it does not fully fit, apply intra-session budget pressure:
+//          evict that session's LOWEST-signal-density turns first (drop lowest
+//          density until the remaining turns fit). Density ties are broken by
+//          original index (keep earlier-arriving turns).
+//          Kept turns are emitted in chronological (timestamp) order, with
+//          original index as a stable tie-break.
+//        - Once a session is partially evicted (budget pressure reached), later
+//          (older) sessions get no budget; the walk stops adding new sessions
+//          after the budget is exhausted.
+//   4. Output is concatenated session-by-session in keep-priority (recency)
+//      order, ready for `assembleRawNarrativeProjection` (which re-applies a
+//      hard cap as a safety net).
+//
+// Density is only used to decide WHICH turns survive intra-session pressure; it
+// never overrides completeness or recency. Density does NOT mutate text — T3
+// owns actual secret egress dropping.
+
+import {
+  defaultTokenCounter,
+  type NarrativeTurn,
+  type TokenCounter
+} from "./raw-narrative-projection.js";
+import { detectSecrets } from "./credential-detector.js";
+
+// --- Documented, tunable density weights -----------------------------------
+
+// Weight applied to the length proxy (tokenEstimate). Kept at 1 so a turn's
+// baseline density tracks its information volume one-for-one; the two boolean
+// boosts below are expressed relative to roughly one token of length each.
+export const DENSITY_WEIGHT_LENGTH = 1;
+
+// Boost for turns carrying a code/tool marker. Concrete diffs, commands, and
+// tool calls are the highest-signal narrative material, so they should survive
+// intra-session eviction ahead of equal-length prose.
+export const DENSITY_WEIGHT_CODE_OR_TOOL = 50;
+
+// Boost for turns whose text trips the secret detector. Such turns describe
+// real credential/config work (high narrative signal even though the secret
+// itself is redacted later), so we bias toward keeping them rather than
+// silently dropping the context. (Text is NOT mutated here.)
+export const DENSITY_WEIGHT_SECRET_TRIGGER = 25;
+
+/**
+ * Lightweight presence check for a redaction/secret-trigger marker in text.
+ * Uses the shared detector so density agrees with the egress policy.
+ */
+export function hasSecretTriggerMarker(text: string): boolean {
+  if (text.length === 0) {
+    return false;
+  }
+  return detectSecrets(text).categories.length > 0;
+}
+
+/**
+ * Weighted-sum signal density for a single turn:
+ *   length-proxy + (code/tool boost) + (secret-trigger boost)
+ */
+export function signalDensity(
+  turn: NarrativeTurn,
+  tokenCounter: TokenCounter = defaultTokenCounter
+): number {
+  const lengthProxy = tokenCounter.estimate(turn.text);
+  return (
+    DENSITY_WEIGHT_LENGTH * lengthProxy +
+    (turn.hasCodeOrToolMarker ? DENSITY_WEIGHT_CODE_OR_TOOL : 0) +
+    (hasSecretTriggerMarker(turn.text) ? DENSITY_WEIGHT_SECRET_TRIGGER : 0)
+  );
+}
+
+type IndexedTurn = {
+  turn: NarrativeTurn;
+  originalIndex: number;
+  tokens: number;
+  density: number;
+};
+
+type SessionGroup = {
+  sessionId: string;
+  turns: IndexedTurn[]; // sorted chronologically (timestamp, then index)
+  recency: string; // newest timestamp in the session; "" => oldest
+  firstIndex: number; // first original index, for stable tie-breaks
+};
+
+/**
+ * Deterministic chronological order within a session: by timestamp, then by
+ * original index for stable ties. Empty timestamps sort earliest (oldest).
+ */
+function chronological(a: IndexedTurn, b: IndexedTurn): number {
+  const ta = a.turn.timestamp;
+  const tb = b.turn.timestamp;
+  if (ta !== tb) {
+    return ta < tb ? -1 : 1;
+  }
+  return a.originalIndex - b.originalIndex;
+}
+
+/**
+ * Select an ordered subset of turns that fits `budget`, in keep-priority
+ * (recency) order, applying the fixed completeness > recency > density policy.
+ */
+export function selectTurns(
+  turns: NarrativeTurn[],
+  options: { budget: number; tokenCounter?: TokenCounter }
+): NarrativeTurn[] {
+  const { budget } = options;
+  const tokenCounter = options.tokenCounter ?? defaultTokenCounter;
+
+  if (turns.length === 0 || budget <= 0) {
+    return [];
+  }
+
+  // 1. Index + score every turn.
+  const indexed: IndexedTurn[] = turns.map((turn, originalIndex) => ({
+    turn,
+    originalIndex,
+    tokens: tokenCounter.estimate(turn.text),
+    density: signalDensity(turn, tokenCounter)
+  }));
+
+  // 2. Group by sessionId, preserving input order within each group.
+  const groups = new Map<string, SessionGroup>();
+  for (const item of indexed) {
+    const id = item.turn.sessionId;
+    let group = groups.get(id);
+    if (group === undefined) {
+      group = {
+        sessionId: id,
+        turns: [],
+        recency: item.turn.timestamp,
+        firstIndex: item.originalIndex
+      };
+      groups.set(id, group);
+    }
+    group.turns.push(item);
+    // recency = newest (max) timestamp; empty timestamps never raise it.
+    if (item.turn.timestamp > group.recency) {
+      group.recency = item.turn.timestamp;
+    }
+  }
+
+  // Sort each session's turns chronologically for deterministic emission
+  // independent of input arrival order.
+  for (const group of groups.values()) {
+    group.turns.sort(chronological);
+  }
+
+  // 3. Order sessions most-recent-first. Empty recency sorts oldest. Ties:
+  //    sessionId, then firstIndex — all stable + deterministic.
+  const orderedSessions = [...groups.values()].sort((a, b) => {
+    if (a.recency !== b.recency) {
+      // Empty string is lexicographically smallest -> treat as oldest (last).
+      return a.recency < b.recency ? 1 : -1;
+    }
+    if (a.sessionId !== b.sessionId) {
+      return a.sessionId < b.sessionId ? -1 : 1;
+    }
+    return a.firstIndex - b.firstIndex;
+  });
+
+  // 4. Greedy fill, session by session, in recency order.
+  const result: NarrativeTurn[] = [];
+  let remaining = budget;
+
+  for (const session of orderedSessions) {
+    const sessionTokens = session.turns.reduce((sum, t) => sum + t.tokens, 0);
+
+    if (sessionTokens <= remaining) {
+      // Whole-session keep (completeness preference). Emit in chronological
+      // (original input) order.
+      for (const item of session.turns) {
+        result.push(item.turn);
+      }
+      remaining -= sessionTokens;
+      continue;
+    }
+
+    // Intra-session budget pressure: evict lowest-density turns first until the
+    // rest fit `remaining`. Eviction order is ascending density; ties broken by
+    // earlier original index (keep earlier turns when density is equal).
+    const evictionOrder = [...session.turns].sort((a, b) => {
+      if (a.density !== b.density) {
+        return a.density - b.density; // lowest density first to drop
+      }
+      return b.originalIndex - a.originalIndex; // drop later turns on ties
+    });
+
+    const dropped = new Set<number>();
+    let kept = sessionTokens;
+    for (const item of evictionOrder) {
+      if (kept <= remaining) {
+        break;
+      }
+      dropped.add(item.originalIndex);
+      kept -= item.tokens;
+    }
+
+    // Emit survivors in original chronological order.
+    for (const item of session.turns) {
+      if (!dropped.has(item.originalIndex)) {
+        result.push(item.turn);
+      }
+    }
+    remaining -= kept;
+
+    // Budget is now exhausted (or nearly); subsequent older sessions get
+    // nothing further. Stop to keep the policy crisp and deterministic.
+    if (remaining <= 0) {
+      break;
+    }
+  }
+
+  return result;
+}

--- a/tests/diary-generator.test.ts
+++ b/tests/diary-generator.test.ts
@@ -411,6 +411,41 @@ describe("caption generator", () => {
     expect(inputJson).toContain("fix rendering bug");
   });
 
+  it("generateCaption forwards the raw narrative projection to the caption prompt input", async () => {
+    const provider = new MockAiProvider({
+      response: {
+        caption: "오늘은 원문에 적힌 그 순간을 가져왔습니다",
+        hashtags: ["#Uncommitted", "#AI동료일지"]
+      }
+    });
+
+    await generateCaption({
+      activitySummary: createActivitySummary(),
+      provider,
+      persona: "wry coworker",
+      roastLevel: 2,
+      rawNarrativeProjection: {
+        turns: [
+          {
+            source: "claude",
+            text: "Untangled the selection policy and landed a clean fix.",
+            tokenEstimate: 13
+          }
+        ],
+        totalTokens: 13,
+        droppedTurns: 0,
+        droppedTokens: 0,
+        budget: 4000
+      }
+    });
+
+    const request = provider.requests[0]!;
+    const inputJson = JSON.stringify(request.input);
+    expect(inputJson).toContain(
+      "Untangled the selection policy and landed a clean fix."
+    );
+  });
+
   it("generateCaption returns validated { caption, hashtags[] } from mocked provider", async () => {
     const provider = new MockAiProvider({
       response: {

--- a/tests/generate-command-source-gating.test.ts
+++ b/tests/generate-command-source-gating.test.ts
@@ -214,7 +214,7 @@ describe("generate command — per-source gating", () => {
     const disabledProvider = new TaskAwareProvider();
     await writeGitEvent(disabledFixture.project, "2026-05-12");
     await writeClaudeRawArchive(disabledFixture.project, "2026-05-12", [
-      { role: "user", text: SEED_TEXT, timestamp: "2026-05-12T09:00:00.000Z" }
+      { role: "assistant", text: SEED_TEXT, timestamp: "2026-05-12T09:00:00.000Z" }
     ]);
 
     const disabledExit = await runCli(["generate", "today"], disabledRun.io, {
@@ -248,7 +248,7 @@ describe("generate command — per-source gating", () => {
     const enabledProvider = new TaskAwareProvider();
     await writeGitEvent(enabledFixture.project, "2026-05-12");
     await writeClaudeRawArchive(enabledFixture.project, "2026-05-12", [
-      { role: "user", text: SEED_TEXT, timestamp: "2026-05-12T09:00:00.000Z" }
+      { role: "assistant", text: SEED_TEXT, timestamp: "2026-05-12T09:00:00.000Z" }
     ]);
 
     const enabledExit = await runCli(["generate", "today"], enabledRun.io, {

--- a/tests/generate-command-source-gating.test.ts
+++ b/tests/generate-command-source-gating.test.ts
@@ -197,6 +197,79 @@ describe("generate command — per-source gating", () => {
       "PR #42 merged: add the github collector"
     );
   });
+
+  it("gates the Tier 2 raw-narrative projection by source: a disabled source's raw archive is not projected, an enabled one is", async () => {
+    const SEED_TEXT = "raw narrative projection seed turn unique-marker";
+
+    // Disabled run: claude raw archive present on disk, but claude is off.
+    const disabledRun = createIo();
+    const disabledFixture = await createRegisteredProjectFixture({
+      sources: {
+        git: { enabled: true },
+        claude: { enabled: false },
+        codex: { enabled: true },
+        github: { enabled: true }
+      }
+    });
+    const disabledProvider = new TaskAwareProvider();
+    await writeGitEvent(disabledFixture.project, "2026-05-12");
+    await writeClaudeRawArchive(disabledFixture.project, "2026-05-12", [
+      { role: "user", text: SEED_TEXT, timestamp: "2026-05-12T09:00:00.000Z" }
+    ]);
+
+    const disabledExit = await runCli(["generate", "today"], disabledRun.io, {
+      homeDir: disabledFixture.homeDir,
+      now: () => "2026-05-12T23:30:00.000Z",
+      aiProvider: disabledProvider
+    });
+
+    expect(disabledExit).toBe(0);
+    const disabledDraft = disabledProvider.requests.find(
+      (request) => request.task === "draft"
+    );
+    const disabledProjection = (
+      disabledDraft?.input as {
+        rawNarrativeProjection?: { turns: { text: string }[] };
+      }
+    ).rawNarrativeProjection;
+    // Source gating must keep the disabled source's raw turns out of egress.
+    expect(disabledProjection?.turns ?? []).toEqual([]);
+
+    // Enabled run: identical archive, claude on — the turn is projected.
+    const enabledRun = createIo();
+    const enabledFixture = await createRegisteredProjectFixture({
+      sources: {
+        git: { enabled: true },
+        claude: { enabled: true },
+        codex: { enabled: true },
+        github: { enabled: true }
+      }
+    });
+    const enabledProvider = new TaskAwareProvider();
+    await writeGitEvent(enabledFixture.project, "2026-05-12");
+    await writeClaudeRawArchive(enabledFixture.project, "2026-05-12", [
+      { role: "user", text: SEED_TEXT, timestamp: "2026-05-12T09:00:00.000Z" }
+    ]);
+
+    const enabledExit = await runCli(["generate", "today"], enabledRun.io, {
+      homeDir: enabledFixture.homeDir,
+      now: () => "2026-05-12T23:30:00.000Z",
+      aiProvider: enabledProvider
+    });
+
+    expect(enabledExit).toBe(0);
+    const enabledDraft = enabledProvider.requests.find(
+      (request) => request.task === "draft"
+    );
+    const enabledProjection = (
+      enabledDraft?.input as {
+        rawNarrativeProjection?: { turns: { text: string }[] };
+      }
+    ).rawNarrativeProjection;
+    expect(enabledProjection?.turns.map((turn) => turn.text)).toContain(
+      SEED_TEXT
+    );
+  });
 });
 
 async function createRegisteredProjectFixture(options: {
@@ -410,6 +483,29 @@ async function writeGitHubSignals(
   }[]
 ): Promise<void> {
   await writeSessionSignals(project, targetDate, "github", signals);
+}
+
+async function writeClaudeRawArchive(
+  project: ProjectRecord,
+  targetDate: string,
+  turns: { role: string; text: string; timestamp: string }[]
+): Promise<void> {
+  const rawDir = join(
+    project.root,
+    ".uncommitted",
+    "events",
+    "claude",
+    "raw"
+  );
+
+  await mkdir(rawDir, { recursive: true });
+  await writeFile(
+    join(rawDir, `${targetDate}.jsonl`),
+    turns
+      .map((turn) => JSON.stringify({ kind: "turn", ...turn }))
+      .join("\n") + "\n",
+    "utf8"
+  );
 }
 
 async function writeSessionSignals(

--- a/tests/raw-narrative-archive.test.ts
+++ b/tests/raw-narrative-archive.test.ts
@@ -149,6 +149,53 @@ describe("readTier1Archives", () => {
     });
   });
 
+  it("skips a github issue-body (attributed on closer, not author) but keeps pr-body", async () => {
+    await seedRawArchive(projectRoot, "github", [
+      JSON.stringify({
+        source: "issue-body",
+        number: 7,
+        visibility: "public",
+        text: "A teammate's issue description the user merely closed.",
+        timestamp: "2026-06-29T09:00:00.000Z"
+      }),
+      JSON.stringify({
+        source: "pr-body",
+        number: 8,
+        visibility: "public",
+        text: "The user's own PR description.",
+        timestamp: "2026-06-29T09:05:00.000Z"
+      })
+    ]);
+
+    const { turns } = await readTier1Archives({
+      projects: [{ id: "proj-a", root: projectRoot }],
+      sourceConfig: allEnabled(),
+      targetDate: TARGET_DATE
+    });
+
+    expect(turns.map((t) => t.text)).toEqual(["The user's own PR description."]);
+  });
+
+  it("carries the conversation role through onto the narrative turn", async () => {
+    await seedRawArchive(projectRoot, "claude", [
+      JSON.stringify({
+        kind: "turn",
+        role: "user",
+        text: "Please add a prune step.",
+        timestamp: "2026-06-29T10:00:00.000Z"
+      })
+    ]);
+
+    const { turns } = await readTier1Archives({
+      projects: [{ id: "proj-a", root: projectRoot }],
+      sourceConfig: allEnabled(),
+      targetDate: TARGET_DATE
+    });
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0].role).toBe("user");
+  });
+
   it("gates a disabled source to zero turns with status 'disabled', distinct from 'no-archive'", async () => {
     await seedRawArchive(projectRoot, "claude", [
       JSON.stringify({
@@ -374,5 +421,99 @@ describe("buildRawNarrativeProjection", () => {
     for (const turn of projection.turns) {
       expect(turn.text).not.toContain("ghp_");
     }
+  });
+
+  it("drops user-role request turns and keeps assistant evidence", async () => {
+    await seedRawArchive(projectRoot, "claude", [
+      JSON.stringify({
+        kind: "turn",
+        role: "user",
+        text: "Please rewrite the whole renderer from scratch tomorrow.",
+        timestamp: "2026-06-29T10:00:00.000Z"
+      }),
+      JSON.stringify({
+        kind: "turn",
+        role: "assistant",
+        text: "Fixed the flaky carousel test and tidied the summary.",
+        timestamp: "2026-06-29T10:01:00.000Z"
+      })
+    ]);
+
+    const projection = await buildRawNarrativeProjection({
+      projects: [{ id: "proj-a", root: projectRoot }],
+      sourceConfig: allEnabled(),
+      configFilePath: join(projectRoot, "config.json"),
+      targetDate: TARGET_DATE,
+      budget: 1000
+    });
+
+    const texts = projection.turns.map((t) => t.text);
+    expect(texts).toContain("Fixed the flaky carousel test and tidied the summary.");
+    expect(texts).not.toContain(
+      "Please rewrite the whole renderer from scratch tomorrow."
+    );
+    // The dropped user turn is still accounted for.
+    expect(projection.droppedTurns).toBeGreaterThanOrEqual(1);
+  });
+
+  it("drops a raw-code turn before egress and keeps clean prose", async () => {
+    await seedRawArchive(projectRoot, "claude", [
+      JSON.stringify({
+        kind: "turn",
+        role: "assistant",
+        text: "function renderCard() { return draw(slides); }",
+        timestamp: "2026-06-29T10:00:00.000Z"
+      }),
+      JSON.stringify({
+        kind: "turn",
+        role: "assistant",
+        text: "Walked through the failure and landed a clean fix.",
+        timestamp: "2026-06-29T10:01:00.000Z"
+      })
+    ]);
+
+    const projection = await buildRawNarrativeProjection({
+      projects: [{ id: "proj-a", root: projectRoot }],
+      sourceConfig: allEnabled(),
+      configFilePath: join(projectRoot, "config.json"),
+      targetDate: TARGET_DATE,
+      budget: 1000
+    });
+
+    const texts = projection.turns.map((t) => t.text);
+    expect(texts).toEqual(["Walked through the failure and landed a clean fix."]);
+    expect(texts.join(" ")).not.toContain("function renderCard");
+    expect(projection.droppedTurns).toBeGreaterThanOrEqual(1);
+  });
+
+  it("counts turns selection omits under a tight token budget", async () => {
+    // Two clean prose turns in the same session, each ~12 tokens. A budget of
+    // 12 fits only one, so selection must omit the other AND report it dropped.
+    await seedRawArchive(projectRoot, "claude", [
+      JSON.stringify({
+        kind: "turn",
+        role: "assistant",
+        text: "a".repeat(48),
+        timestamp: "2026-06-29T10:00:00.000Z"
+      }),
+      JSON.stringify({
+        kind: "turn",
+        role: "assistant",
+        text: "b".repeat(48),
+        timestamp: "2026-06-29T10:01:00.000Z"
+      })
+    ]);
+
+    const projection = await buildRawNarrativeProjection({
+      projects: [{ id: "proj-a", root: projectRoot }],
+      sourceConfig: allEnabled(),
+      configFilePath: join(projectRoot, "config.json"),
+      targetDate: TARGET_DATE,
+      budget: 12
+    });
+
+    expect(projection.turns.length).toBe(1);
+    expect(projection.droppedTurns).toBe(1);
+    expect(projection.droppedTokens).toBeGreaterThan(0);
   });
 });

--- a/tests/raw-narrative-archive.test.ts
+++ b/tests/raw-narrative-archive.test.ts
@@ -6,10 +6,25 @@ import {
   readTier1Archives,
   buildRawNarrativeProjection
 } from "../src/raw-narrative-archive.js";
+import {
+  defaultSourceConfigMap,
+  type SourceConfigMap,
+  type SourceName
+} from "../src/source-config.js";
 
 type RawSource = "claude" | "codex" | "github";
 
 const TARGET_DATE = "2026-06-29";
+
+const allEnabled = (): SourceConfigMap => defaultSourceConfigMap();
+
+const withDisabled = (...sources: SourceName[]): SourceConfigMap => {
+  const map = defaultSourceConfigMap();
+  for (const source of sources) {
+    map[source] = { enabled: false };
+  }
+  return map;
+};
 
 async function makeProjectRoot(prefix = "unc-164-"): Promise<string> {
   return await mkdtemp(join(tmpdir(), prefix));
@@ -51,7 +66,7 @@ describe("readTier1Archives", () => {
 
     const { turns } = await readTier1Archives({
       projects: [{ id: "proj-a", root: projectRoot }],
-      config: {},
+      sourceConfig: allEnabled(),
       targetDate: TARGET_DATE
     });
 
@@ -77,7 +92,7 @@ describe("readTier1Archives", () => {
 
     const { turns } = await readTier1Archives({
       projects: [{ id: "proj-a", root: projectRoot }],
-      config: {},
+      sourceConfig: allEnabled(),
       targetDate: TARGET_DATE
     });
 
@@ -98,7 +113,7 @@ describe("readTier1Archives", () => {
 
     const { turns } = await readTier1Archives({
       projects: [{ id: "proj-a", root: projectRoot }],
-      config: {},
+      sourceConfig: allEnabled(),
       targetDate: TARGET_DATE
     });
 
@@ -121,7 +136,7 @@ describe("readTier1Archives", () => {
 
     const { turns } = await readTier1Archives({
       projects: [{ id: "proj-a", root: projectRoot }],
-      config: {},
+      sourceConfig: allEnabled(),
       targetDate: TARGET_DATE
     });
 
@@ -147,7 +162,7 @@ describe("readTier1Archives", () => {
 
     const { turns, discoveries } = await readTier1Archives({
       projects: [{ id: "proj-a", root: projectRoot }],
-      config: { sources: { claude: { enabled: false } } },
+      sourceConfig: withDisabled("claude"),
       targetDate: TARGET_DATE
     });
 
@@ -175,7 +190,7 @@ describe("readTier1Archives", () => {
 
     const { discoveries } = await readTier1Archives({
       projects: [{ id: "proj-a", root: projectRoot }],
-      config: {},
+      sourceConfig: allEnabled(),
       targetDate: TARGET_DATE
     });
 
@@ -203,7 +218,7 @@ describe("readTier1Archives", () => {
 
     const { turns } = await readTier1Archives({
       projects: [{ id: "proj-a", root: projectRoot }],
-      config: {},
+      sourceConfig: allEnabled(),
       targetDate: TARGET_DATE
     });
 
@@ -219,7 +234,7 @@ describe("readTier1Archives", () => {
 
     const { turns } = await readTier1Archives({
       projects: [{ id: "proj-a", root: projectRoot }],
-      config: {},
+      sourceConfig: allEnabled(),
       targetDate: TARGET_DATE
     });
 
@@ -250,7 +265,7 @@ describe("buildRawNarrativeProjection", () => {
 
     const projection = await buildRawNarrativeProjection({
       projects: [{ id: "proj-a", root: projectRoot }],
-      config: {},
+      sourceConfig: allEnabled(),
       configFilePath: join(projectRoot, "config.json"),
       targetDate: TARGET_DATE,
       budget: 1000
@@ -264,7 +279,7 @@ describe("buildRawNarrativeProjection", () => {
   it("returns an empty projection when all archives are absent", async () => {
     const projection = await buildRawNarrativeProjection({
       projects: [{ id: "proj-a", root: projectRoot }],
-      config: {},
+      sourceConfig: allEnabled(),
       configFilePath: join(projectRoot, "config.json"),
       targetDate: TARGET_DATE,
       budget: 500
@@ -289,13 +304,7 @@ describe("buildRawNarrativeProjection", () => {
 
     const projection = await buildRawNarrativeProjection({
       projects: [{ id: "proj-a", root: projectRoot }],
-      config: {
-        sources: {
-          claude: { enabled: false },
-          codex: { enabled: false },
-          github: { enabled: false }
-        }
-      },
+      sourceConfig: withDisabled("claude", "codex", "github"),
       configFilePath: join(projectRoot, "config.json"),
       targetDate: TARGET_DATE,
       budget: 500
@@ -308,7 +317,7 @@ describe("buildRawNarrativeProjection", () => {
   it("yields a visibly different (non-empty vs empty) projection present vs absent (Q4)", async () => {
     const absent = await buildRawNarrativeProjection({
       projects: [{ id: "proj-a", root: projectRoot }],
-      config: {},
+      sourceConfig: allEnabled(),
       configFilePath: join(projectRoot, "config.json"),
       targetDate: TARGET_DATE,
       budget: 1000
@@ -326,7 +335,7 @@ describe("buildRawNarrativeProjection", () => {
 
     const present = await buildRawNarrativeProjection({
       projects: [{ id: "proj-a", root: projectRoot }],
-      config: {},
+      sourceConfig: allEnabled(),
       configFilePath: join(projectRoot, "config.json"),
       targetDate: TARGET_DATE,
       budget: 1000
@@ -355,7 +364,7 @@ describe("buildRawNarrativeProjection", () => {
 
     const projection = await buildRawNarrativeProjection({
       projects: [{ id: "proj-a", root: projectRoot }],
-      config: {},
+      sourceConfig: allEnabled(),
       configFilePath: join(projectRoot, "config.json"),
       targetDate: TARGET_DATE,
       budget: 1000

--- a/tests/raw-narrative-archive.test.ts
+++ b/tests/raw-narrative-archive.test.ts
@@ -1,0 +1,369 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  readTier1Archives,
+  buildRawNarrativeProjection
+} from "../src/raw-narrative-archive.js";
+
+type RawSource = "claude" | "codex" | "github";
+
+const TARGET_DATE = "2026-06-29";
+
+async function makeProjectRoot(prefix = "unc-164-"): Promise<string> {
+  return await mkdtemp(join(tmpdir(), prefix));
+}
+
+async function seedRawArchive(
+  projectRoot: string,
+  source: RawSource,
+  lines: string[],
+  targetDate = TARGET_DATE
+): Promise<string> {
+  const rawDir = join(projectRoot, ".uncommitted", "events", source, "raw");
+  await mkdir(rawDir, { recursive: true });
+  const file = join(rawDir, `${targetDate}.jsonl`);
+  await writeFile(file, lines.join("\n") + "\n", "utf8");
+  return file;
+}
+
+describe("readTier1Archives", () => {
+  let projectRoot: string;
+
+  beforeEach(async () => {
+    projectRoot = await makeProjectRoot();
+  });
+
+  afterEach(async () => {
+    await rm(projectRoot, { recursive: true, force: true });
+  });
+
+  it("normalizes a claude conversation turn into a NarrativeTurn", async () => {
+    await seedRawArchive(projectRoot, "claude", [
+      JSON.stringify({
+        kind: "turn",
+        role: "assistant",
+        text: "I refactored the parser today.",
+        timestamp: "2026-06-29T10:00:00.000Z"
+      })
+    ]);
+
+    const { turns } = await readTier1Archives({
+      projects: [{ id: "proj-a", root: projectRoot }],
+      config: {},
+      targetDate: TARGET_DATE
+    });
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0]).toMatchObject({
+      source: "claude",
+      text: "I refactored the parser today.",
+      timestamp: "2026-06-29T10:00:00.000Z",
+      sessionId: `claude:proj-a:${TARGET_DATE}`,
+      hasCodeOrToolMarker: false
+    });
+  });
+
+  it("normalizes a claude tool entry, combining tool + target with marker true", async () => {
+    await seedRawArchive(projectRoot, "claude", [
+      JSON.stringify({
+        kind: "tool",
+        tool: "Edit",
+        target: "src/index.ts",
+        timestamp: "2026-06-29T10:01:00.000Z"
+      })
+    ]);
+
+    const { turns } = await readTier1Archives({
+      projects: [{ id: "proj-a", root: projectRoot }],
+      config: {},
+      targetDate: TARGET_DATE
+    });
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0].text).toBe("Edit src/index.ts");
+    expect(turns[0].hasCodeOrToolMarker).toBe(true);
+    expect(turns[0].source).toBe("claude");
+  });
+
+  it("normalizes a codex tool entry without target", async () => {
+    await seedRawArchive(projectRoot, "codex", [
+      JSON.stringify({
+        kind: "tool",
+        tool: "Bash",
+        timestamp: "2026-06-29T10:02:00.000Z"
+      })
+    ]);
+
+    const { turns } = await readTier1Archives({
+      projects: [{ id: "proj-a", root: projectRoot }],
+      config: {},
+      targetDate: TARGET_DATE
+    });
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0].text).toBe("Bash");
+    expect(turns[0].hasCodeOrToolMarker).toBe(true);
+    expect(turns[0].source).toBe("codex");
+  });
+
+  it("extracts authored text from a github own-authored body entry", async () => {
+    await seedRawArchive(projectRoot, "github", [
+      JSON.stringify({
+        source: "pr-body",
+        number: 42,
+        visibility: "public",
+        text: "This PR wires the archive reader into generate.",
+        timestamp: "2026-06-29T09:00:00.000Z"
+      })
+    ]);
+
+    const { turns } = await readTier1Archives({
+      projects: [{ id: "proj-a", root: projectRoot }],
+      config: {},
+      targetDate: TARGET_DATE
+    });
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0]).toMatchObject({
+      source: "github",
+      text: "This PR wires the archive reader into generate.",
+      timestamp: "2026-06-29T09:00:00.000Z",
+      sessionId: `github:proj-a:${TARGET_DATE}`
+    });
+  });
+
+  it("gates a disabled source to zero turns with status 'disabled', distinct from 'no-archive'", async () => {
+    await seedRawArchive(projectRoot, "claude", [
+      JSON.stringify({
+        kind: "turn",
+        role: "user",
+        text: "hello",
+        timestamp: "2026-06-29T10:00:00.000Z"
+      })
+    ]);
+    // codex has no file at all.
+
+    const { turns, discoveries } = await readTier1Archives({
+      projects: [{ id: "proj-a", root: projectRoot }],
+      config: { sources: { claude: { enabled: false } } },
+      targetDate: TARGET_DATE
+    });
+
+    expect(turns).toHaveLength(0);
+
+    const claude = discoveries.find((d) => d.source === "claude");
+    const codex = discoveries.find((d) => d.source === "codex");
+    expect(claude?.status).toBe("disabled");
+    expect(claude?.turnCount).toBe(0);
+    expect(codex?.status).toBe("no-archive");
+    expect(codex?.turnCount).toBe(0);
+    // disabled vs absent are distinguishable.
+    expect(claude?.status).not.toBe(codex?.status);
+  });
+
+  it("marks an enabled source with a present file as 'read'", async () => {
+    await seedRawArchive(projectRoot, "claude", [
+      JSON.stringify({
+        kind: "turn",
+        role: "user",
+        text: "hello there",
+        timestamp: "2026-06-29T10:00:00.000Z"
+      })
+    ]);
+
+    const { discoveries } = await readTier1Archives({
+      projects: [{ id: "proj-a", root: projectRoot }],
+      config: {},
+      targetDate: TARGET_DATE
+    });
+
+    const claude = discoveries.find((d) => d.source === "claude");
+    expect(claude?.status).toBe("read");
+    expect(claude?.turnCount).toBe(1);
+  });
+
+  it("skips malformed JSONL lines without throwing and keeps surrounding valid lines", async () => {
+    await seedRawArchive(projectRoot, "claude", [
+      JSON.stringify({
+        kind: "turn",
+        role: "user",
+        text: "first",
+        timestamp: "2026-06-29T10:00:00.000Z"
+      }),
+      "{ this is not valid json",
+      JSON.stringify({
+        kind: "turn",
+        role: "assistant",
+        text: "second",
+        timestamp: "2026-06-29T10:01:00.000Z"
+      })
+    ]);
+
+    const { turns } = await readTier1Archives({
+      projects: [{ id: "proj-a", root: projectRoot }],
+      config: {},
+      targetDate: TARGET_DATE
+    });
+
+    expect(turns.map((t) => t.text)).toEqual(["first", "second"]);
+  });
+
+  it("skips turn entries with empty or non-string text", async () => {
+    await seedRawArchive(projectRoot, "claude", [
+      JSON.stringify({ kind: "turn", role: "user", text: "", timestamp: "x" }),
+      JSON.stringify({ kind: "turn", role: "user", text: 5, timestamp: "x" }),
+      JSON.stringify({ kind: "turn", role: "user", text: "kept", timestamp: "x" })
+    ]);
+
+    const { turns } = await readTier1Archives({
+      projects: [{ id: "proj-a", root: projectRoot }],
+      config: {},
+      targetDate: TARGET_DATE
+    });
+
+    expect(turns.map((t) => t.text)).toEqual(["kept"]);
+  });
+});
+
+describe("buildRawNarrativeProjection", () => {
+  let projectRoot: string;
+
+  beforeEach(async () => {
+    projectRoot = await makeProjectRoot();
+  });
+
+  afterEach(async () => {
+    await rm(projectRoot, { recursive: true, force: true });
+  });
+
+  it("produces a non-empty projection within budget from present archives", async () => {
+    await seedRawArchive(projectRoot, "claude", [
+      JSON.stringify({
+        kind: "turn",
+        role: "assistant",
+        text: "Implemented the Tier 1 archive reader.",
+        timestamp: "2026-06-29T10:00:00.000Z"
+      })
+    ]);
+
+    const projection = await buildRawNarrativeProjection({
+      projects: [{ id: "proj-a", root: projectRoot }],
+      config: {},
+      configFilePath: join(projectRoot, "config.json"),
+      targetDate: TARGET_DATE,
+      budget: 1000
+    });
+
+    expect(projection.turns.length).toBeGreaterThan(0);
+    expect(projection.totalTokens).toBeLessThanOrEqual(projection.budget);
+    expect(projection.budget).toBe(1000);
+  });
+
+  it("returns an empty projection when all archives are absent", async () => {
+    const projection = await buildRawNarrativeProjection({
+      projects: [{ id: "proj-a", root: projectRoot }],
+      config: {},
+      configFilePath: join(projectRoot, "config.json"),
+      targetDate: TARGET_DATE,
+      budget: 500
+    });
+
+    expect(projection.turns).toEqual([]);
+    expect(projection.totalTokens).toBe(0);
+    expect(projection.droppedTurns).toBe(0);
+    expect(projection.droppedTokens).toBe(0);
+    expect(projection.budget).toBe(500);
+  });
+
+  it("returns an empty projection when every source is disabled", async () => {
+    await seedRawArchive(projectRoot, "claude", [
+      JSON.stringify({
+        kind: "turn",
+        role: "user",
+        text: "present but disabled",
+        timestamp: "2026-06-29T10:00:00.000Z"
+      })
+    ]);
+
+    const projection = await buildRawNarrativeProjection({
+      projects: [{ id: "proj-a", root: projectRoot }],
+      config: {
+        sources: {
+          claude: { enabled: false },
+          codex: { enabled: false },
+          github: { enabled: false }
+        }
+      },
+      configFilePath: join(projectRoot, "config.json"),
+      targetDate: TARGET_DATE,
+      budget: 500
+    });
+
+    expect(projection.turns).toEqual([]);
+    expect(projection.budget).toBe(500);
+  });
+
+  it("yields a visibly different (non-empty vs empty) projection present vs absent (Q4)", async () => {
+    const absent = await buildRawNarrativeProjection({
+      projects: [{ id: "proj-a", root: projectRoot }],
+      config: {},
+      configFilePath: join(projectRoot, "config.json"),
+      targetDate: TARGET_DATE,
+      budget: 1000
+    });
+    expect(absent.turns).toHaveLength(0);
+
+    await seedRawArchive(projectRoot, "claude", [
+      JSON.stringify({
+        kind: "turn",
+        role: "assistant",
+        text: "Now there is real raw narrative material to project.",
+        timestamp: "2026-06-29T10:00:00.000Z"
+      })
+    ]);
+
+    const present = await buildRawNarrativeProjection({
+      projects: [{ id: "proj-a", root: projectRoot }],
+      config: {},
+      configFilePath: join(projectRoot, "config.json"),
+      targetDate: TARGET_DATE,
+      budget: 1000
+    });
+
+    expect(present.turns.length).toBeGreaterThan(0);
+    expect(present.turns.length).not.toBe(absent.turns.length);
+  });
+
+  it("drops a turn containing a planted secret in the egress step and counts it", async () => {
+    const secret = "ghp_" + "a".repeat(36);
+    await seedRawArchive(projectRoot, "claude", [
+      JSON.stringify({
+        kind: "turn",
+        role: "assistant",
+        text: `Here is the token to use: ${secret}`,
+        timestamp: "2026-06-29T10:00:00.000Z"
+      }),
+      JSON.stringify({
+        kind: "turn",
+        role: "assistant",
+        text: "A perfectly clean follow-up line of narrative.",
+        timestamp: "2026-06-29T10:01:00.000Z"
+      })
+    ]);
+
+    const projection = await buildRawNarrativeProjection({
+      projects: [{ id: "proj-a", root: projectRoot }],
+      config: {},
+      configFilePath: join(projectRoot, "config.json"),
+      targetDate: TARGET_DATE,
+      budget: 1000
+    });
+
+    expect(projection.droppedTurns).toBeGreaterThanOrEqual(1);
+    for (const turn of projection.turns) {
+      expect(turn.text).not.toContain("ghp_");
+    }
+  });
+});

--- a/tests/raw-narrative-egress.test.ts
+++ b/tests/raw-narrative-egress.test.ts
@@ -85,6 +85,28 @@ describe("revalidateTurnsForEgress", () => {
     }
   });
 
+  it("drops a raw-code/tool turn even when it trips no secret signature", () => {
+    // Plain code with no credential pattern — the project rule forbids raw code
+    // reaching AI providers, so the egress filter must drop it on the marker.
+    const code = turn("function renderCard() { return draw(slides); }", {
+      hasCodeOrToolMarker: true
+    });
+    const result = revalidateTurnsForEgress([code]);
+    expect(result.kept).toEqual([]);
+    expect(result.droppedTurns).toBe(1);
+    expect(result.droppedTokens).toBe(defaultTokenCounter.estimate(code.text));
+  });
+
+  it("keeps clean prose but drops a marked code turn in the same batch", () => {
+    const prose = turn("Spent the morning untangling the selection policy.");
+    const code = turn("const budget = readBudget()", {
+      hasCodeOrToolMarker: true
+    });
+    const result = revalidateTurnsForEgress([prose, code]);
+    expect(result.kept).toEqual([prose]);
+    expect(result.droppedTurns).toBe(1);
+  });
+
   it("returns a zeroed result for empty input", () => {
     expect(revalidateTurnsForEgress([])).toEqual({
       kept: [],

--- a/tests/raw-narrative-egress.test.ts
+++ b/tests/raw-narrative-egress.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { revalidateTurnsForEgress } from "../src/raw-narrative-egress.js";
+import {
+  defaultTokenCounter,
+  type NarrativeTurn
+} from "../src/raw-narrative-projection.js";
+
+function turn(text: string, overrides: Partial<NarrativeTurn> = {}): NarrativeTurn {
+  return {
+    source: "claude",
+    text,
+    timestamp: "2026-06-29T00:00:00.000Z",
+    sessionId: "s1",
+    hasCodeOrToolMarker: false,
+    ...overrides
+  };
+}
+
+const AWS_KEY = "AKIAIOSFODNN7EXAMPLE";
+const GITHUB_PAT = "ghp_" + "a".repeat(36);
+const HIGH_ENTROPY = "a1B2c3D4e5F6g7H8i9J0kLmNoPqRsTuVwXyZ1234";
+
+describe("revalidateTurnsForEgress", () => {
+  it("drops a turn containing an AWS access key", () => {
+    const result = revalidateTurnsForEgress([turn(`creds: ${AWS_KEY} here`)]);
+    expect(result.kept).toEqual([]);
+    expect(result.droppedTurns).toBe(1);
+  });
+
+  it("drops a turn containing a GitHub PAT", () => {
+    const result = revalidateTurnsForEgress([turn(`token ${GITHUB_PAT} leaked`)]);
+    expect(result.kept).toEqual([]);
+    expect(result.droppedTurns).toBe(1);
+  });
+
+  it("drops a turn containing a high-entropy 40-char token", () => {
+    const result = revalidateTurnsForEgress([turn(`opaque ${HIGH_ENTROPY} value`)]);
+    expect(result.kept).toEqual([]);
+    expect(result.droppedTurns).toBe(1);
+  });
+
+  it("keeps a clean prose turn unchanged (same text)", () => {
+    const clean = turn("Refactored the activity summary and fixed a flaky test.");
+    const result = revalidateTurnsForEgress([clean]);
+    expect(result.kept).toHaveLength(1);
+    expect(result.kept[0]).toBe(clean);
+    expect(result.kept[0].text).toBe(clean.text);
+    expect(result.droppedTurns).toBe(0);
+    expect(result.droppedTokens).toBe(0);
+  });
+
+  it("computes exact drop count, dropped token sum, and preserves kept order", () => {
+    const cleanA = turn("Started the morning by reviewing yesterday's notes.");
+    const dirty1 = turn(`AWS key ${AWS_KEY} in the config`);
+    const cleanB = turn("Then I paired on the renderer with no drama.");
+    const dirty2 = turn(`PAT ${GITHUB_PAT} pasted by mistake`);
+
+    const result = revalidateTurnsForEgress([cleanA, dirty1, cleanB, dirty2]);
+
+    expect(result.kept).toEqual([cleanA, cleanB]);
+    expect(result.droppedTurns).toBe(2);
+    const expectedDroppedTokens =
+      defaultTokenCounter.estimate(dirty1.text) +
+      defaultTokenCounter.estimate(dirty2.text);
+    expect(result.droppedTokens).toBe(expectedDroppedTokens);
+  });
+
+  it("leak guard: no kept turn contains any planted secret substring", () => {
+    const secrets = [AWS_KEY, GITHUB_PAT, HIGH_ENTROPY];
+    const turns = [
+      turn("A perfectly innocent line about coffee."),
+      turn(`AWS ${AWS_KEY}`),
+      turn("Another clean reflection on the day."),
+      turn(`PAT ${GITHUB_PAT}`),
+      turn(`entropy ${HIGH_ENTROPY}`),
+      turn("Wrapping up with a quiet commit.")
+    ];
+
+    const result = revalidateTurnsForEgress(turns);
+
+    for (const kept of result.kept) {
+      for (const secret of secrets) {
+        expect(kept.text).not.toContain(secret);
+      }
+    }
+  });
+
+  it("returns a zeroed result for empty input", () => {
+    expect(revalidateTurnsForEgress([])).toEqual({
+      kept: [],
+      droppedTurns: 0,
+      droppedTokens: 0
+    });
+  });
+
+  it("uses a provided token counter for dropped token accounting", () => {
+    const fixed = { estimate: () => 7 };
+    const result = revalidateTurnsForEgress(
+      [turn(`AWS ${AWS_KEY}`), turn(`PAT ${GITHUB_PAT}`)],
+      fixed
+    );
+    expect(result.droppedTokens).toBe(14);
+  });
+});

--- a/tests/raw-narrative-projection.test.ts
+++ b/tests/raw-narrative-projection.test.ts
@@ -1,0 +1,309 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { MockAiProvider } from "../src/ai-provider.js";
+import type { ActivitySummary } from "../src/activity-summary.js";
+import { generateDiaryDraft } from "../src/diary-generator.js";
+import type { StoryFormatPlan } from "../src/story-format-plan.js";
+import {
+  DEFAULT_CAPTION_PROJECTION_TOKEN_BUDGET,
+  assembleRawNarrativeProjection,
+  defaultTokenCounter,
+  emptyRawNarrativeProjection,
+  readCaptionProjectionTokenBudget
+} from "../src/raw-narrative-projection.js";
+import type {
+  NarrativeTurn,
+  RawNarrativeProjection
+} from "../src/raw-narrative-projection.js";
+
+describe("defaultTokenCounter", () => {
+  it("returns 0 for empty string", () => {
+    expect(defaultTokenCounter.estimate("")).toBe(0);
+  });
+
+  it("uses ceil(length / 4)", () => {
+    expect(defaultTokenCounter.estimate("abcd")).toBe(1);
+    expect(defaultTokenCounter.estimate("abcde")).toBe(2);
+  });
+});
+
+describe("emptyRawNarrativeProjection", () => {
+  it("returns a zeroed projection echoing the budget", () => {
+    expect(emptyRawNarrativeProjection(123)).toEqual({
+      turns: [],
+      totalTokens: 0,
+      droppedTurns: 0,
+      droppedTokens: 0,
+      budget: 123
+    });
+  });
+});
+
+describe("assembleRawNarrativeProjection", () => {
+  const turn = (source: NarrativeTurn["source"], text: string): NarrativeTurn => ({
+    source,
+    text,
+    timestamp: "",
+    sessionId: "s",
+    hasCodeOrToolMarker: false
+  });
+
+  it("keeps all turns when they fit and computes totals", () => {
+    const turns = [turn("claude", "abcd"), turn("codex", "abcdefgh")];
+    const result = assembleRawNarrativeProjection(turns, { budget: 100 });
+
+    expect(result.turns).toEqual([
+      { source: "claude", text: "abcd", tokenEstimate: 1 },
+      { source: "codex", text: "abcdefgh", tokenEstimate: 2 }
+    ]);
+    expect(result.totalTokens).toBe(3);
+    expect(result.droppedTurns).toBe(0);
+    expect(result.droppedTokens).toBe(0);
+    expect(result.budget).toBe(100);
+  });
+
+  it("drops trailing turns once the budget is exceeded", () => {
+    // estimates: 1, 1, 1 (each 4 chars). budget 2 keeps first two, drops third.
+    const turns = [
+      turn("claude", "aaaa"),
+      turn("claude", "bbbb"),
+      turn("codex", "cccc")
+    ];
+    const result = assembleRawNarrativeProjection(turns, { budget: 2 });
+
+    expect(result.turns).toEqual([
+      { source: "claude", text: "aaaa", tokenEstimate: 1 },
+      { source: "claude", text: "bbbb", tokenEstimate: 1 }
+    ]);
+    expect(result.totalTokens).toBe(2);
+    expect(result.droppedTurns).toBe(1);
+    expect(result.droppedTokens).toBe(1);
+    expect(result.budget).toBe(2);
+  });
+
+  it("drops an oversized single turn", () => {
+    const turns = [turn("github", "a".repeat(20))]; // estimate 5
+    const result = assembleRawNarrativeProjection(turns, { budget: 3 });
+
+    expect(result.turns).toEqual([]);
+    expect(result.totalTokens).toBe(0);
+    expect(result.droppedTurns).toBe(1);
+    expect(result.droppedTokens).toBe(5);
+    expect(result.budget).toBe(3);
+  });
+
+  it("returns a zeroed projection for empty input", () => {
+    const result = assembleRawNarrativeProjection([], { budget: 50 });
+    expect(result).toEqual({
+      turns: [],
+      totalTokens: 0,
+      droppedTurns: 0,
+      droppedTokens: 0,
+      budget: 50
+    });
+  });
+
+  it("returns a zeroed projection when budget <= 0", () => {
+    const turns = [turn("claude", "aaaa")];
+    const result = assembleRawNarrativeProjection(turns, { budget: 0 });
+    expect(result).toEqual({
+      turns: [],
+      totalTokens: 0,
+      droppedTurns: 0,
+      droppedTokens: 0,
+      budget: 0
+    });
+  });
+});
+
+describe("readCaptionProjectionTokenBudget", () => {
+  async function writeConfig(value: unknown): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), "unc-cap-budget-"));
+    const file = join(dir, "config.json");
+    await writeFile(file, JSON.stringify(value), "utf8");
+    return file;
+  }
+
+  it("uses a present positive value (floored)", async () => {
+    const file = await writeConfig({ captionProjectionTokenBudget: 1500.9 });
+    expect(await readCaptionProjectionTokenBudget(file)).toBe(1500);
+  });
+
+  it("falls back to the default when the key is missing", async () => {
+    const file = await writeConfig({ somethingElse: 7 });
+    expect(await readCaptionProjectionTokenBudget(file)).toBe(
+      DEFAULT_CAPTION_PROJECTION_TOKEN_BUDGET
+    );
+    expect(DEFAULT_CAPTION_PROJECTION_TOKEN_BUDGET).toBe(4000);
+  });
+
+  it("falls back to the default for an invalid type", async () => {
+    const file = await writeConfig({ captionProjectionTokenBudget: "lots" });
+    expect(await readCaptionProjectionTokenBudget(file)).toBe(4000);
+  });
+
+  it("falls back to the default for a non-positive value", async () => {
+    const file = await writeConfig({ captionProjectionTokenBudget: 0 });
+    expect(await readCaptionProjectionTokenBudget(file)).toBe(4000);
+  });
+
+  it("falls back to the default for a nonexistent file", async () => {
+    expect(
+      await readCaptionProjectionTokenBudget(
+        join(tmpdir(), "unc-cap-budget-does-not-exist", "config.json")
+      )
+    ).toBe(4000);
+  });
+});
+
+describe("generateDiaryDraft rawNarrativeProjection integration", () => {
+  it("includes rawNarrativeProjection in the provider input when provided", async () => {
+    const provider = new MockAiProvider({ response: createProviderDraft() });
+    const projection: RawNarrativeProjection = {
+      turns: [{ source: "claude", text: "renamed a test for clarity", tokenEstimate: 7 }],
+      totalTokens: 7,
+      droppedTurns: 0,
+      droppedTokens: 0,
+      budget: 4000
+    };
+
+    await generateDiaryDraft({
+      activitySummary: createActivitySummary(),
+      storyFormatPlan: createStoryFormatPlan(),
+      provider,
+      persona: "wry coworker",
+      roastLevel: 2,
+      rawNarrativeProjection: projection
+    });
+
+    const input = provider.requests[0]?.input as Record<string, unknown>;
+    expect(input.rawNarrativeProjection).toEqual(projection);
+    expect(input.activitySignals).toBeDefined();
+  });
+
+  it("omits the rawNarrativeProjection key when not provided", async () => {
+    const provider = new MockAiProvider({ response: createProviderDraft() });
+
+    await generateDiaryDraft({
+      activitySummary: createActivitySummary(),
+      storyFormatPlan: createStoryFormatPlan(),
+      provider,
+      persona: "wry coworker",
+      roastLevel: 2
+    });
+
+    const input = provider.requests[0]?.input as Record<string, unknown>;
+    expect("rawNarrativeProjection" in input).toBe(false);
+    expect(input.activitySignals).toBeDefined();
+  });
+});
+
+function createProviderDraft() {
+  return {
+    title: "Provider Boundary Day",
+    slides: [
+      {
+        index: 1,
+        title: "Opening statement",
+        body: "Provider validation work moved from vibes to typed boundaries.",
+        visualMood: "quiet terminal with warm contrast"
+      },
+      {
+        index: 2,
+        title: "Evidence",
+        body: "Two commits and one note kept the AI request shape honest.",
+        visualMood: "annotated checklist"
+      },
+      {
+        index: 3,
+        title: "Verdict",
+        body: "The mock provider behaved, which is suspicious but welcome.",
+        visualMood: "rubber stamp on terminal"
+      }
+    ],
+    altText:
+      "AI coworker diary carousel about provider validation work in Uncommitted."
+  };
+}
+
+function createStoryFormatPlan(): StoryFormatPlan {
+  return {
+    schemaVersion: 1,
+    formatName: "Bug Court Transcript",
+    voice: "tired QA narrator",
+    tone: "deadpan, witty, affectionate",
+    reason: "Medium coding day with clear evidence suits a wry recap.",
+    structure: [
+      { part: "Opening", purpose: "Set the scene" },
+      { part: "Evidence", purpose: "Show the work" },
+      { part: "Verdict", purpose: "Land the joke" }
+    ],
+    suggestedSlideCount: 3,
+    captionStyle: "wry",
+    doNotMention: []
+  };
+}
+
+function createActivitySummary(): ActivitySummary {
+  return {
+    schemaVersion: 1,
+    targetDate: "2026-05-12",
+    generatedAt: "2026-05-12T23:30:00.000Z",
+    activityLevel: "medium",
+    dominantTheme: "coding",
+    projects: [
+      {
+        projectId: "uncommitted",
+        projectName: "Uncommitted",
+        summary: "Worked on provider boundary validation.",
+        commitCount: 2,
+        filesChanged: 3,
+        insertions: 40,
+        deletions: 5,
+        uncommittedChangeCount: 1,
+        manualNoteCount: 1,
+        themes: ["coding"]
+      }
+    ],
+    commitSignals: {
+      totalCommits: 2,
+      filesChanged: 3,
+      insertions: 40,
+      deletions: 5,
+      subjects: ["add provider boundary", "validate request shape"],
+      themes: ["coding"]
+    },
+    uncommittedChanges: {
+      totalFiles: 1,
+      byStatus: {
+        modified: 1,
+        added: 0,
+        deleted: 0,
+        renamed: 0,
+        copied: 0,
+        untracked: 0,
+        other: 0
+      },
+      files: []
+    },
+    manualContext: {
+      noteCount: 1,
+      notes: [
+        {
+          projectId: "uncommitted",
+          timestamp: "2026-05-12T10:00:00.000Z",
+          text: "Kept the request shape honest."
+        }
+      ]
+    },
+    smallWins: ["Provider boundary now typed."],
+    blockersOrConfusion: [],
+    unfinishedThreads: ["One uncommitted file waiting."],
+    possibleJokes: ["The mock provider behaved."],
+    publicSafetyNotes: [],
+    privateItemsToAvoid: [],
+    uncertaintyNotes: []
+  } as ActivitySummary;
+}

--- a/tests/raw-narrative-selection.test.ts
+++ b/tests/raw-narrative-selection.test.ts
@@ -96,9 +96,12 @@ describe("selectTurns precedence", () => {
 
   it("backfills an older session into slack left after a partial eviction", () => {
     // Newest session: two 7-token turns (28 chars each) = 14 tokens, over the
-    // budget of 10. Lowest-density turn is evicted first, so the code-marked
-    // turn (higher density) survives at 7 tokens, leaving 3 tokens of slack.
-    // The older session's single 2-token turn fits that slack and is kept.
+    // budget of 10, so it cannot be kept whole. Phase 1 keeps the older
+    // session's single 2-token turn whole (recency order, fits the budget),
+    // leaving 8 tokens; phase 2 partial-fills the newest session into that
+    // slack — its lowest-density turn is evicted, so the code-marked turn
+    // (higher density) survives at 7 tokens. Result: newest fragment + whole
+    // older session.
     const newKept = turn({
       sessionId: "new",
       timestamp: "2026-06-01T00:00:02Z",
@@ -124,6 +127,27 @@ describe("selectTurns precedence", () => {
       0
     );
     expect(total).toBeLessThanOrEqual(10);
+  });
+
+  it("prefers a whole older session over a fragment of the newest one", () => {
+    // Newest session is one 14-token turn that cannot fit the budget of 10.
+    // An older session is one 10-token turn that fits whole. Completeness
+    // outranks recency, so the whole older session must win over a (here
+    // impossible anyway) fragment of the newer one — and crucially the newer
+    // session must NOT be partial-filled ahead of the fitting older session.
+    const newerOversized = turn({
+      sessionId: "new",
+      timestamp: "2026-06-01T00:00:00Z",
+      text: "n".repeat(56) // 14 tokens, > budget
+    });
+    const olderWhole = turn({
+      sessionId: "old",
+      timestamp: "2026-01-01T00:00:00Z",
+      text: "o".repeat(40) // 10 tokens, == budget
+    });
+    const kept = selectTurns([newerOversized, olderWhole], { budget: 10 });
+    expect(kept.map((t) => t.sessionId)).toEqual(["old"]);
+    expect(kept.map((t) => t.text)).toEqual([olderWhole.text]);
   });
 
   it("lets recency beat raw density when they conflict", () => {

--- a/tests/raw-narrative-selection.test.ts
+++ b/tests/raw-narrative-selection.test.ts
@@ -94,6 +94,38 @@ describe("selectTurns precedence", () => {
     expect(kept).toHaveLength(2);
   });
 
+  it("backfills an older session into slack left after a partial eviction", () => {
+    // Newest session: two 7-token turns (28 chars each) = 14 tokens, over the
+    // budget of 10. Lowest-density turn is evicted first, so the code-marked
+    // turn (higher density) survives at 7 tokens, leaving 3 tokens of slack.
+    // The older session's single 2-token turn fits that slack and is kept.
+    const newKept = turn({
+      sessionId: "new",
+      timestamp: "2026-06-01T00:00:02Z",
+      text: "n".repeat(28),
+      hasCodeOrToolMarker: true
+    });
+    const newEvicted = turn({
+      sessionId: "new",
+      timestamp: "2026-06-01T00:00:01Z",
+      text: "m".repeat(28),
+      hasCodeOrToolMarker: false
+    });
+    const oldSmall = turn({
+      sessionId: "old",
+      timestamp: "2026-01-01T00:00:00Z",
+      text: "o".repeat(8) // ~2 tokens
+    });
+    const kept = selectTurns([oldSmall, newEvicted, newKept], { budget: 10 });
+    expect(kept.map((t) => t.sessionId)).toEqual(["new", "old"]);
+    expect(kept.map((t) => t.text)).toEqual([newKept.text, oldSmall.text]);
+    const total = kept.reduce(
+      (sum, t) => sum + defaultTokenCounter.estimate(t.text),
+      0
+    );
+    expect(total).toBeLessThanOrEqual(10);
+  });
+
   it("lets recency beat raw density when they conflict", () => {
     // Older session has a very high-density turn; newer session is plain.
     // Budget fits only one whole session -> recency wins.

--- a/tests/raw-narrative-selection.test.ts
+++ b/tests/raw-narrative-selection.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "vitest";
+import {
+  DENSITY_WEIGHT_CODE_OR_TOOL,
+  DENSITY_WEIGHT_LENGTH,
+  DENSITY_WEIGHT_SECRET_TRIGGER,
+  selectTurns,
+  signalDensity
+} from "../src/raw-narrative-selection.js";
+import {
+  defaultTokenCounter
+} from "../src/raw-narrative-projection.js";
+import type { NarrativeTurn } from "../src/raw-narrative-projection.js";
+
+function turn(overrides: Partial<NarrativeTurn>): NarrativeTurn {
+  return {
+    source: "claude",
+    text: "x",
+    timestamp: "",
+    sessionId: "s",
+    hasCodeOrToolMarker: false,
+    ...overrides
+  };
+}
+
+// An obvious vendor secret (GitHub PAT: ghp_ + 36 chars) — fires the
+// secret-trigger category in credential-detector's detectSecrets.
+const SECRET_TEXT = "leaked ghp_" + "a".repeat(36) + " here";
+
+describe("signalDensity", () => {
+  it("scores longer text higher (length proxy = tokenEstimate)", () => {
+    const short = turn({ text: "hi" });
+    const long = turn({ text: "x".repeat(400) });
+    expect(signalDensity(long)).toBeGreaterThan(signalDensity(short));
+  });
+
+  it("adds the code/tool weight when hasCodeOrToolMarker is set", () => {
+    const plain = turn({ text: "same text body here", hasCodeOrToolMarker: false });
+    const marked = turn({ text: "same text body here", hasCodeOrToolMarker: true });
+    expect(signalDensity(marked) - signalDensity(plain)).toBeCloseTo(
+      DENSITY_WEIGHT_CODE_OR_TOOL
+    );
+  });
+
+  it("adds the secret-trigger weight when text contains an obvious secret", () => {
+    const clean = turn({ text: "leaked nothing here at all today" });
+    const leaked = turn({ text: SECRET_TEXT });
+    // Isolate the secret contribution by matching token length closely is hard;
+    // instead assert the secret turn includes the secret weight on top of its
+    // own length + (no code marker).
+    const cleanLen = DENSITY_WEIGHT_LENGTH * defaultTokenCounter.estimate(clean.text);
+    const leakedLen = DENSITY_WEIGHT_LENGTH * defaultTokenCounter.estimate(leaked.text);
+    expect(signalDensity(leaked) - leakedLen).toBeCloseTo(
+      DENSITY_WEIGHT_SECRET_TRIGGER
+    );
+    expect(signalDensity(clean) - cleanLen).toBeCloseTo(0);
+  });
+
+  it("composes weights as a sum (length + code + secret)", () => {
+    const t = turn({ text: SECRET_TEXT, hasCodeOrToolMarker: true });
+    const expected =
+      DENSITY_WEIGHT_LENGTH * defaultTokenCounter.estimate(t.text) +
+      DENSITY_WEIGHT_CODE_OR_TOOL +
+      DENSITY_WEIGHT_SECRET_TRIGGER;
+    expect(signalDensity(t)).toBeCloseTo(expected);
+  });
+});
+
+describe("selectTurns precedence", () => {
+  it("keeps the more-recent session when budget forces a choice", () => {
+    // Two whole sessions; budget fits only one.
+    const older = turn({
+      sessionId: "old",
+      timestamp: "2026-01-01T00:00:00Z",
+      text: "o".repeat(40) // ~10 tokens
+    });
+    const newer = turn({
+      sessionId: "new",
+      timestamp: "2026-06-01T00:00:00Z",
+      text: "n".repeat(40) // ~10 tokens
+    });
+    const kept = selectTurns([older, newer], { budget: 10 });
+    expect(kept.map((t) => t.sessionId)).toEqual(["new"]);
+  });
+
+  it("prefers a complete session over a partial older one", () => {
+    // newest session has 2 turns (~5 tokens each = 10), older has 1 (~5).
+    // budget 12 fits the whole newest session but not all three turns.
+    const a1 = turn({ sessionId: "new", timestamp: "2026-06-01T00:00:01Z", text: "a".repeat(20) });
+    const a2 = turn({ sessionId: "new", timestamp: "2026-06-01T00:00:02Z", text: "b".repeat(20) });
+    const b1 = turn({ sessionId: "old", timestamp: "2026-01-01T00:00:00Z", text: "c".repeat(20) });
+    const kept = selectTurns([b1, a1, a2], { budget: 12 });
+    // Whole "new" session kept; "old" dropped because it wouldn't fit whole.
+    expect(new Set(kept.map((t) => t.sessionId))).toEqual(new Set(["new"]));
+    expect(kept).toHaveLength(2);
+  });
+
+  it("lets recency beat raw density when they conflict", () => {
+    // Older session has a very high-density turn; newer session is plain.
+    // Budget fits only one whole session -> recency wins.
+    const olderDense = turn({
+      sessionId: "old",
+      timestamp: "2026-01-01T00:00:00Z",
+      text: SECRET_TEXT,
+      hasCodeOrToolMarker: true
+    });
+    const newerPlain = turn({
+      sessionId: "new",
+      timestamp: "2026-06-01T00:00:00Z",
+      text: "n".repeat(40)
+    });
+    const budget = defaultTokenCounter.estimate(newerPlain.text);
+    const kept = selectTurns([olderDense, newerPlain], { budget });
+    expect(kept.map((t) => t.sessionId)).toEqual(["new"]);
+  });
+});
+
+describe("selectTurns intra-session eviction", () => {
+  it("drops the lowest-density turns first when a session overflows", () => {
+    // One session, three turns of equal length; one carries a secret + code
+    // marker (highest density), one carries a code marker (mid), one plain.
+    const plain = turn({
+      sessionId: "s",
+      timestamp: "2026-06-01T00:00:01Z",
+      text: "p".repeat(40),
+      hasCodeOrToolMarker: false
+    });
+    const mid = turn({
+      sessionId: "s",
+      timestamp: "2026-06-01T00:00:02Z",
+      text: "m".repeat(40),
+      hasCodeOrToolMarker: true
+    });
+    const high = turn({
+      sessionId: "s",
+      timestamp: "2026-06-01T00:00:03Z",
+      text: "h".repeat(34) + " ghp_" + "a".repeat(36),
+      hasCodeOrToolMarker: true
+    });
+    // plain=10 tok (density 10), mid=10 tok (density 60),
+    // high=19 tok (density 94). Budget fits mid+high (29) but not plain too.
+    const budget =
+      defaultTokenCounter.estimate(mid.text) +
+      defaultTokenCounter.estimate(high.text);
+    const kept = selectTurns([plain, mid, high], { budget });
+    const keptTexts = new Set(kept.map((t) => t.text));
+    expect(keptTexts.has(plain.text)).toBe(false); // lowest density evicted
+    expect(keptTexts.has(high.text)).toBe(true);
+    expect(keptTexts.has(mid.text)).toBe(true);
+  });
+
+  it("keeps within-session output in chronological order", () => {
+    const t1 = turn({ sessionId: "s", timestamp: "2026-06-01T00:00:01Z", text: "1".repeat(20) });
+    const t2 = turn({ sessionId: "s", timestamp: "2026-06-01T00:00:02Z", text: "2".repeat(20) });
+    const t3 = turn({ sessionId: "s", timestamp: "2026-06-01T00:00:03Z", text: "3".repeat(20) });
+    const kept = selectTurns([t3, t1, t2], { budget: 1000 });
+    expect(kept.map((t) => t.text)).toEqual([t1.text, t2.text, t3.text]);
+  });
+});
+
+describe("selectTurns budget", () => {
+  it("keeps total tokens within budget", () => {
+    const turns: NarrativeTurn[] = [];
+    for (let i = 0; i < 10; i += 1) {
+      turns.push(
+        turn({
+          sessionId: `s${i % 3}`,
+          timestamp: `2026-06-01T00:00:0${i}Z`,
+          text: "z".repeat(40 + i)
+        })
+      );
+    }
+    const budget = 30;
+    const kept = selectTurns(turns, { budget });
+    const total = kept.reduce(
+      (sum, t) => sum + defaultTokenCounter.estimate(t.text),
+      0
+    );
+    expect(total).toBeLessThanOrEqual(budget);
+  });
+
+  it("returns empty for non-positive budget", () => {
+    const t = turn({ text: "hello", sessionId: "s", timestamp: "2026-06-01T00:00:00Z" });
+    expect(selectTurns([t], { budget: 0 })).toEqual([]);
+  });
+});
+
+describe("selectTurns determinism", () => {
+  it("produces identical output for shuffled input", () => {
+    const base: NarrativeTurn[] = [
+      turn({ sessionId: "a", timestamp: "2026-06-01T00:00:01Z", text: "aaa".repeat(10) }),
+      turn({ sessionId: "a", timestamp: "2026-06-01T00:00:02Z", text: "bbb".repeat(10) }),
+      turn({ sessionId: "b", timestamp: "2026-05-01T00:00:01Z", text: "ccc".repeat(10) }),
+      turn({ sessionId: "c", timestamp: "", text: "ddd".repeat(10) })
+    ];
+    const order1 = selectTurns(base, { budget: 40 });
+    const shuffled = [base[3], base[1], base[0], base[2]];
+    const order2 = selectTurns(shuffled, { budget: 40 });
+    expect(order2.map((t) => t.text)).toEqual(order1.map((t) => t.text));
+    // Repeated call is stable too.
+    const order3 = selectTurns(base, { budget: 40 });
+    expect(order3.map((t) => t.text)).toEqual(order1.map((t) => t.text));
+  });
+});


### PR DESCRIPTION
# Goal

🤖 **Auto-generated by Uncommitted Builder (Routine B v2)**

Build the **Tier 2 caption projection** boundary: deterministically project Tier 1 raw conversation archives (Claude/Codex/GitHub) into a bounded, secret-re-validated narrative input for the caption-writer LLM, and inject it into `generate` alongside the existing git/notes signals. Cost and privacy are both controlled at this single egress boundary.

## Related Issue

Parent: [UNC-156 — Tier 2 caption projection](https://linear.app/sangchu/issue/UNC-156)

Sub-issues (all implemented in this PR):
- [x] [UNC-161 [T1]](https://linear.app/sangchu/issue/UNC-161) — `rawNarrativeProjection` assembly + token-budget enforcement (✅ done)
- [x] [UNC-162 [T2]](https://linear.app/sangchu/issue/UNC-162) — deterministic rule-based turn selection w/ signal-density scoring (✅ done)
- [x] [UNC-163 [T3]](https://linear.app/sangchu/issue/UNC-163) — pre-egress UNC-155 secret re-validation per turn (✅ done)
- [x] [UNC-164 [T4]](https://linear.app/sangchu/issue/UNC-164) — Tier 1 archive reader + UNC-120 source gating + absent no-op + `generate` wiring (✅ done)

Linear is the source of truth for these issues; there is no GitHub issue to auto-close.

## Acceptance Criteria

- [x] Projection generated within the token budget (default 4000, from `captionProjectionTokenBudget`); excess deterministically dropped with `droppedTurns`/`droppedTokens` accounted (no silent truncation).
- [x] No turn text reaches the projection unless it passes aggressive `detectSecrets` re-validation at the projection→caption-writer boundary; failing turns are dropped (over-redact) and counted. Leak-guard test asserts no secret substring survives.
- [x] `generate` reflects raw-based narrative input — non-empty `rawNarrativeProjection` when archives present vs. empty in the git-only baseline (Q4 snapshot-style assertion).
- [x] Unit tests for budget / selection / re-validation + safety tests (TDD).
- [x] Source on/off gating (`isSourceEnabled`) honored; absent archives or all-disabled sources → graceful empty no-op, `generate` proceeds with git-only signals.

## Implementation Notes

New modules (all under `src/`, read-only over Tier 1 `raw/` archives — no collection logic changed):
- `raw-narrative-projection.ts` (T1) — `NarrativeTurn`/`ProjectionTurn`/`RawNarrativeProjection` contract, `TokenCounter` interface (chars/4 default, swappable for tiktoken later), `assembleRawNarrativeProjection` (deterministic budget cap), `readCaptionProjectionTokenBudget` (mirrors `readRawRetentionDays`). Threaded an optional `rawNarrativeProjection` field through `DiaryGeneratorOptions` → private `buildSafeDiaryInput`; existing `activitySignals`/`highlights` untouched.
- `raw-narrative-selection.ts` (T2) — `selectTurns` with fixed precedence **session-boundary completeness > recency > signal density**; signal-density = documented weighted sum (length=1, code/tool marker=50, secret-trigger marker=25); intra-session lowest-density eviction; backfills older sessions into leftover slack; fully deterministic. No LLM.
- `raw-narrative-egress.ts` (T3) — `revalidateTurnsForEgress`: drops any turn where `detectSecrets` fires a category **or** mutates the text (belt-and-suspenders at the sole egress boundary). No new redaction rules.
- `raw-narrative-archive.ts` (T4) — reads `events/{claude,codex,github}/raw/<date>.jsonl`, gates by `isSourceEnabled` (disabled vs. absent distinguishable in discoveries), normalizes per-source entries (claude/codex turn+tool, github authored-body `text`) into `NarrativeTurn`; `buildRawNarrativeProjection` orchestrates read → select → revalidate → assemble, folding (summing) egress + budget drop counters. Wired into `generate-command.ts` after `loadSourceConfig`, failure-isolated (falls back to empty projection so a projection error never blocks generation).

Decision: the daily LLM call count is unchanged (1 caption); only the input grows, bounded by the budget cap.

## Validation

- `pnpm test` — **674 passed / 2 skipped**; the single `carousel-renderer-smoke` failure is a pre-existing Playwright-under-parallel-load timeout flake (passes 3/3 in isolation on this branch and on `origin/main`), not introduced here.
- `pnpm exec tsc --noEmit` — clean.
- `pnpm exec eslint src tests` — clean.
- `pnpm build` — clean.
- `git diff --check` — clean.
- 49 new tests across the 4 modules; per-task spec + quality review passed.

## Remaining Risk

- Token accounting uses a chars/4 heuristic behind `TokenCounter`; swap to a real tokenizer later without caller changes.
- Privacy guarantee at egress inherits `detectSecrets` rule coverage (reused as-is; no new rules added here). The `value !== text` belt-and-suspenders removes dependency on the detector's implicit "mutate ⟹ category" invariant.
- `raw-narrative-archive.ts` `discoveries` collapses a non-ENOENT read error into `no-archive`; harmless today (discoveries unused by callers) but worth a distinct `read-error` status if discoveries become diagnostically surfaced.
- Density weights are documented tunable constants; initial values are heuristic.

## Review checklist
- [ ] Review each sub-issue's commits separately (T1→T4, dependency-ordered)
- [ ] Verify TDD test coverage (budget / selection / egress / archive + gating)
- [ ] Confirm no lockfile changes and no auto-publish code introduced
- [ ] Run `pnpm install && pnpm test && pnpm build` locally
- [ ] Confirm the egress re-validation cannot leak (leak-guard test + belt-and-suspenders)

---
이 PR은 자동 생성되었습니다. 머지 전 사람의 리뷰가 반드시 필요합니다.
