### PR TITLE
♻️ refactor(config): unify global config loading into a single typed loader (UNC-171)

### DIFF
--- a/src/ai-provider.ts
+++ b/src/ai-provider.ts
@@ -1,6 +1,7 @@
-import { readFile } from "node:fs/promises";
 import process from "node:process";
 import { resolveConfigPaths } from "./config-paths.js";
+import { isRoastLevel, loadGlobalConfig } from "./global-config.js";
+import { isRecord } from "./type-guards.js";
 
 export type JsonPrimitive = string | number | boolean | null;
 export type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
@@ -213,39 +214,30 @@ export async function loadAiProviderConfig(
   options: LoadAiProviderConfigOptions = {}
 ): Promise<AiProviderConfig> {
   const paths = resolveConfigPaths({ homeDir: options.homeDir });
+  const outcome = await loadGlobalConfig(paths.configFile);
 
-  try {
-    const parsed = JSON.parse(await readFile(paths.configFile, "utf8")) as unknown;
+  if (outcome.status === "missing") {
+    throw new AiGenerationError(
+      "AI config is missing. Run `uncommitted init` first.",
+      "invalid-config"
+    );
+  }
 
-    if (!isAiConfigFile(parsed)) {
-      throw new AiGenerationError("AI config is invalid.", "invalid-config");
-    }
-
-    const provider = parseProviderName(parsed.aiProvider);
-
-    if (!provider) {
-      throw new AiGenerationError("AI provider is not supported.", "invalid-config");
-    }
-
-    return {
-      provider,
-      persona: parsed.persona,
-      roastLevel: parsed.roastLevel
-    };
-  } catch (error) {
-    if (error instanceof AiGenerationError) {
-      throw error;
-    }
-
-    if (isNodeError(error) && error.code === "ENOENT") {
-      throw new AiGenerationError(
-        "AI config is missing. Run `uncommitted init` first.",
-        "invalid-config"
-      );
-    }
-
+  if (outcome.status !== "ok" || !isAiConfigFile(outcome.value)) {
     throw new AiGenerationError("AI config is invalid.", "invalid-config");
   }
+
+  const provider = parseProviderName(outcome.value.aiProvider);
+
+  if (!provider) {
+    throw new AiGenerationError("AI provider is not supported.", "invalid-config");
+  }
+
+  return {
+    provider,
+    persona: outcome.value.persona,
+    roastLevel: outcome.value.roastLevel
+  };
 }
 
 export function createAiProvider(
@@ -941,7 +933,7 @@ function isAiConfigFile(value: unknown): value is {
     value.schemaVersion === 1 &&
     typeof value.aiProvider === "string" &&
     typeof value.persona === "string" &&
-    Number.isInteger(value.roastLevel)
+    isRoastLevel(value.roastLevel)
   );
 }
 
@@ -990,19 +982,12 @@ function isJsonValue(value: unknown): value is JsonValue {
 }
 
 function isJsonObject(value: unknown): value is JsonObject {
-  if (!isRecord(value) || Array.isArray(value)) {
+  // isRecord already excludes arrays, so no separate Array.isArray check.
+  if (!isRecord(value)) {
     return false;
   }
 
   return Object.values(value).every(isJsonValue);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-function isNodeError(error: unknown): error is NodeJS.ErrnoException {
-  return error instanceof Error && "code" in error;
 }
 
 function isAbortError(error: unknown): boolean {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 import { realpathSync } from "node:fs";
-import { readFile } from "node:fs/promises";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import {
   collectGitForRegisteredProjects,
@@ -41,6 +40,7 @@ import {
   type ProjectRecord
 } from "./project-registry.js";
 import { resolveConfigPaths } from "./config-paths.js";
+import { loadGlobalConfig, selectDraftRoot } from "./global-config.js";
 import {
   loadSourceConfig,
   SourceConfigError,
@@ -524,24 +524,21 @@ async function readPreviewDraftRoot(
   configFile: string,
   homeDir: string | undefined
 ): Promise<string> {
-  try {
-    const parsed = JSON.parse(await readFile(configFile, "utf8")) as unknown;
-    if (
-      typeof parsed === "object" &&
-      parsed !== null &&
-      !Array.isArray(parsed) &&
-      typeof (parsed as Record<string, unknown>).draftRoot === "string"
-    ) {
-      return resolveConfigPaths({
-        homeDir,
-        draftRoot: (parsed as Record<string, unknown>).draftRoot as string
-      }).defaultDraftRoot;
-    }
-  } catch (err) {
-    if (!isCliNodeError(err) || err.code !== "ENOENT") {
-      throw err;
+  const outcome = await loadGlobalConfig(configFile);
+
+  // Preview is best-effort: a missing config falls back to the default draft
+  // root, but an unreadable or malformed config surfaces its original error.
+  if (outcome.status === "read-error" || outcome.status === "parse-error") {
+    throw outcome.error;
+  }
+
+  if (outcome.status === "ok") {
+    const draftRoot = selectDraftRoot(outcome.value);
+    if (draftRoot !== undefined) {
+      return resolveConfigPaths({ homeDir, draftRoot }).defaultDraftRoot;
     }
   }
+
   return resolveConfigPaths({ homeDir }).defaultDraftRoot;
 }
 
@@ -667,10 +664,6 @@ async function runFeedback(
   } finally {
     prompter.close?.();
   }
-}
-
-function isCliNodeError(error: unknown): error is NodeJS.ErrnoException {
-  return error instanceof Error && "code" in error;
 }
 
 async function runExport(

--- a/src/doctor-command.ts
+++ b/src/doctor-command.ts
@@ -1,10 +1,12 @@
 import { execFile } from "node:child_process";
 import { constants } from "node:fs";
-import { access, readFile } from "node:fs/promises";
+import { access } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import process from "node:process";
 import { promisify } from "node:util";
 import { resolveConfigPaths } from "./config-paths.js";
+import { loadGlobalConfig, type GlobalConfig } from "./global-config.js";
+import { isRecord } from "./type-guards.js";
 
 const execFileAsync = promisify(execFile);
 const minimumNodeVersion = "22.13.0";
@@ -37,11 +39,10 @@ export type DoctorOptions = {
   checkAccess?: (path: string, mode: number) => Promise<boolean>;
 };
 
-type DoctorConfig = {
-  schemaVersion: 1;
-  draftRoot: string;
-  aiProvider: string;
-};
+type DoctorConfig = Pick<
+  GlobalConfig,
+  "schemaVersion" | "draftRoot" | "aiProvider"
+>;
 
 const aiProviderEnvKeys: Record<string, string | undefined> = {
   none: undefined,
@@ -150,44 +151,21 @@ export function formatDoctorReport(report: DoctorReport): string {
 async function readConfig(
   configFile: string
 ): Promise<{ config?: DoctorConfig; check: DoctorCheck }> {
-  try {
-    const parsed = JSON.parse(await readFile(configFile, "utf8")) as unknown;
+  const outcome = await loadGlobalConfig(configFile);
 
-    if (!isDoctorConfig(parsed)) {
-      return {
-        check: {
-          id: "config",
-          label: "Global config",
-          status: "fail",
-          message: `Config file is invalid: ${configFile}`,
-          exitCode: 2
-        }
-      };
-    }
-
+  if (outcome.status === "missing") {
     return {
-      config: parsed,
       check: {
         id: "config",
         label: "Global config",
-        status: "pass",
-        message: "Config file found.",
-        detail: configFile
+        status: "fail",
+        message: `Config file is missing: ${configFile}`,
+        exitCode: 2
       }
     };
-  } catch (error) {
-    if (isNodeError(error) && error.code === "ENOENT") {
-      return {
-        check: {
-          id: "config",
-          label: "Global config",
-          status: "fail",
-          message: `Config file is missing: ${configFile}`,
-          exitCode: 2
-        }
-      };
-    }
+  }
 
+  if (outcome.status !== "ok" || !isDoctorConfig(outcome.value)) {
     return {
       check: {
         id: "config",
@@ -198,6 +176,17 @@ async function readConfig(
       }
     };
   }
+
+  return {
+    config: outcome.value,
+    check: {
+      id: "config",
+      label: "Global config",
+      status: "pass",
+      message: "Config file found.",
+      detail: configFile
+    }
+  };
 }
 
 function createNodeCheck(nodeVersion: string): DoctorCheck {
@@ -457,12 +446,4 @@ function isDoctorConfig(value: unknown): value is DoctorConfig {
     typeof value.draftRoot === "string" &&
     typeof value.aiProvider === "string"
   );
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-function isNodeError(error: unknown): error is NodeJS.ErrnoException {
-  return error instanceof Error && "code" in error;
 }

--- a/src/generate-command.ts
+++ b/src/generate-command.ts
@@ -18,6 +18,12 @@ import type { GitActivityEvent } from "./collect-git-command.js";
 import { isActivitySignal, type ActivitySignal } from "./event-source.js";
 import { resolveConfigPaths } from "./config-paths.js";
 import {
+  isRoastLevel,
+  loadGlobalConfig,
+  type GlobalConfig
+} from "./global-config.js";
+import { isNodeError, isRecord } from "./type-guards.js";
+import {
   deriveCaptionText,
   generateCaption,
   generateDiaryDraft,
@@ -104,13 +110,15 @@ type GenerateConfig = AiProviderConfig & {
   carouselVisualStyle: CarouselVisualStyleMode;
 };
 
-type GenerateConfigFile = {
-  schemaVersion: 1;
-  draftRoot: string;
+// On-disk view of the canonical GlobalConfig that `generate` needs, with
+// `aiProvider` narrowed to a known provider and `carouselVisualStyle` optional
+// (older configs may omit it).
+type GenerateConfigFile = Pick<
+  GlobalConfig,
+  "schemaVersion" | "draftRoot" | "persona" | "roastLevel"
+> & {
   aiProvider: AiProviderName;
   carouselVisualStyle?: CarouselVisualStyleMode;
-  persona: string;
-  roastLevel: number;
 };
 
 type DraftMetadataBase = {
@@ -598,37 +606,31 @@ async function readGenerateConfig(
   path: string,
   homeDir: string | undefined
 ): Promise<GenerateConfig> {
-  try {
-    const parsed = JSON.parse(await readFile(path, "utf8")) as unknown;
+  const outcome = await loadGlobalConfig(path);
 
-    if (!isGenerateConfigFile(parsed)) {
-      throw new GenerateCommandError("AI config is invalid.", "invalid-config");
-    }
+  if (outcome.status === "missing") {
+    throw new GenerateCommandError(
+      "AI config is missing. Run `uncommitted init` first.",
+      "invalid-config"
+    );
+  }
 
-    return {
-      draftRoot: resolveConfigPaths({
-        homeDir,
-        draftRoot: parsed.draftRoot
-      }).defaultDraftRoot,
-      provider: parsed.aiProvider,
-      carouselVisualStyle: parsed.carouselVisualStyle ?? "photo-first",
-      persona: parsed.persona,
-      roastLevel: parsed.roastLevel
-    };
-  } catch (error) {
-    if (error instanceof GenerateCommandError) {
-      throw error;
-    }
-
-    if (isNodeError(error) && error.code === "ENOENT") {
-      throw new GenerateCommandError(
-        "AI config is missing. Run `uncommitted init` first.",
-        "invalid-config"
-      );
-    }
-
+  if (outcome.status !== "ok" || !isGenerateConfigFile(outcome.value)) {
     throw new GenerateCommandError("AI config is invalid.", "invalid-config");
   }
+
+  const parsed = outcome.value;
+
+  return {
+    draftRoot: resolveConfigPaths({
+      homeDir,
+      draftRoot: parsed.draftRoot
+    }).defaultDraftRoot,
+    provider: parsed.aiProvider,
+    carouselVisualStyle: parsed.carouselVisualStyle ?? "photo-first",
+    persona: parsed.persona,
+    roastLevel: parsed.roastLevel
+  };
 }
 
 async function readProjectsFile(path: string): Promise<ProjectsFile> {
@@ -823,10 +825,7 @@ function isGenerateConfigFile(value: unknown): value is GenerateConfigFile {
     (value.carouselVisualStyle === undefined ||
       isCarouselVisualStyleMode(value.carouselVisualStyle)) &&
     typeof value.persona === "string" &&
-    typeof value.roastLevel === "number" &&
-    Number.isInteger(value.roastLevel) &&
-    value.roastLevel >= 0 &&
-    value.roastLevel <= 5
+    isRoastLevel(value.roastLevel)
   );
 }
 
@@ -946,12 +945,4 @@ function isAiProviderName(value: unknown): value is AiProviderName {
     typeof value === "string" &&
     providerNames.includes(value as AiProviderName)
   );
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-function isNodeError(error: unknown): error is NodeJS.ErrnoException {
-  return error instanceof Error && "code" in error;
 }

--- a/src/github-token-resolver.ts
+++ b/src/github-token-resolver.ts
@@ -1,5 +1,5 @@
-import { readFile } from "node:fs/promises";
 import { join } from "node:path";
+import { loadGlobalConfig, selectGitHubToken } from "./global-config.js";
 
 export type ResolvedGitHubToken = {
   token: string | null;
@@ -20,22 +20,13 @@ export async function resolveGitHubToken(
     return { token: envToken, source: "env" };
   }
   const configPath = join(input.homeDir, ".uncommitted", "config.json");
-  try {
-    const raw = await readFile(configPath, "utf8");
-    const parsed = JSON.parse(raw) as unknown;
-    if (
-      typeof parsed === "object" &&
-      parsed !== null &&
-      typeof (parsed as { githubToken?: unknown }).githubToken === "string" &&
-      (parsed as { githubToken: string }).githubToken.length > 0
-    ) {
-      return {
-        token: (parsed as { githubToken: string }).githubToken,
-        source: "config"
-      };
+  const outcome = await loadGlobalConfig(configPath);
+  if (outcome.status === "ok") {
+    const token = selectGitHubToken(outcome.value);
+    if (token !== null) {
+      return { token, source: "config" };
     }
-  } catch {
-    // Missing / unreadable / invalid JSON → fall through to "missing".
   }
+  // Missing / unreadable / invalid JSON / no token → "missing".
   return { token: null, source: "missing" };
 }

--- a/src/global-config.ts
+++ b/src/global-config.ts
@@ -1,0 +1,141 @@
+import { readFile } from "node:fs/promises";
+import type { SourceConfigMap } from "./source-config.js";
+import { isNodeError, isRecord } from "./type-guards.js";
+
+export type CarouselVisualStyleMode = "photo-first" | "story-card";
+
+/**
+ * Canonical shape of `~/.uncommitted/config.json` as written by `init`.
+ *
+ * This is the single source of truth shared by the writer (`init-command.ts`)
+ * and every reader. Individual readers consume only the subset of fields they
+ * need via the selectors below; they no longer define their own partial config
+ * types. `githubToken` is optional because `init` does not write it (the user
+ * adds it by hand, env-first being preferred).
+ */
+export interface GlobalConfig {
+  schemaVersion: 1;
+  draftRoot: string;
+  scheduleTime: string;
+  aiProvider: string;
+  carouselVisualStyle: CarouselVisualStyleMode;
+  persona: string;
+  roastLevel: number;
+  rawRetentionDays: number;
+  captionProjectionTokenBudget: number;
+  sources: SourceConfigMap;
+  githubToken?: string;
+}
+
+/**
+ * Outcome of attempting to load the global config. Readers map these neutral
+ * states onto their own error/default behavior, so this loader stays free of
+ * any one command's error type while still distinguishing the cases readers
+ * care about (missing vs. unreadable vs. malformed vs. parsed).
+ *
+ * `value` on `ok` is intentionally `unknown`: a file containing valid JSON that
+ * is not an object (e.g. `42`) is a successful read, and several readers treat
+ * that as "fall back to defaults" rather than an error.
+ */
+export type GlobalConfigLoadOutcome =
+  | { status: "ok"; value: unknown }
+  | { status: "missing" }
+  | { status: "read-error"; error: unknown }
+  | { status: "parse-error"; error: unknown };
+
+const cache = new Map<string, Promise<GlobalConfigLoadOutcome>>();
+
+/** Drop all cached config reads. Primarily for test isolation. */
+export function clearGlobalConfigCache(): void {
+  cache.clear();
+}
+
+/**
+ * Read and parse the global config once per process invocation.
+ *
+ * Successful reads are cached by path so multiple readers in a single command
+ * (e.g. `generate` reading provider config and source gating) hit disk once.
+ * Non-`ok` outcomes are not cached, so a config written after an initial
+ * missing read is observed on the next call.
+ */
+export function loadGlobalConfig(
+  configFilePath: string
+): Promise<GlobalConfigLoadOutcome> {
+  const cached = cache.get(configFilePath);
+  if (cached) {
+    return cached;
+  }
+
+  const pending = readGlobalConfigOutcome(configFilePath).then(
+    (outcome) => {
+      if (outcome.status !== "ok") {
+        cache.delete(configFilePath);
+      }
+      return outcome;
+    },
+    (error) => {
+      // readGlobalConfigOutcome catches its own errors today, but never leave a
+      // rejected promise wedged in the cache if that ever changes.
+      cache.delete(configFilePath);
+      throw error;
+    }
+  );
+
+  cache.set(configFilePath, pending);
+  return pending;
+}
+
+async function readGlobalConfigOutcome(
+  configFilePath: string
+): Promise<GlobalConfigLoadOutcome> {
+  let raw: string;
+
+  try {
+    raw = await readFile(configFilePath, "utf8");
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return { status: "missing" };
+    }
+    return { status: "read-error", error };
+  }
+
+  let value: unknown;
+
+  try {
+    value = JSON.parse(raw);
+  } catch (error) {
+    return { status: "parse-error", error };
+  }
+
+  return { status: "ok", value };
+}
+
+/** Unified roast-level guard: an integer in the inclusive range 0–5. */
+export function isRoastLevel(value: unknown): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isInteger(value) &&
+    value >= 0 &&
+    value <= 5
+  );
+}
+
+/** Extract `draftRoot` when present as a string, else `undefined`. */
+export function selectDraftRoot(value: unknown): string | undefined {
+  if (isRecord(value) && typeof value.draftRoot === "string") {
+    return value.draftRoot;
+  }
+  return undefined;
+}
+
+/** Extract a non-empty `githubToken`, else `null`. */
+export function selectGitHubToken(value: unknown): string | null {
+  if (
+    isRecord(value) &&
+    typeof value.githubToken === "string" &&
+    value.githubToken.length > 0
+  ) {
+    return value.githubToken;
+  }
+  return null;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -225,6 +225,7 @@ export type {
   InitCommandResult,
   InitConfig
 } from "./init-command.js";
+export type { GlobalConfig } from "./global-config.js";
 export { addProject, ProjectAddError } from "./project-add.js";
 export type {
   AddProjectOptions,

--- a/src/init-command.ts
+++ b/src/init-command.ts
@@ -3,7 +3,11 @@ import process from "node:process";
 import { createInterface } from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
 import { ensureConfigDirectories, resolveConfigPaths } from "./config-paths.js";
-import { defaultSourceConfigMap, type SourceConfigMap } from "./source-config.js";
+import { clearGlobalConfigCache, type GlobalConfig } from "./global-config.js";
+import { defaultSourceConfigMap } from "./source-config.js";
+
+/** @deprecated Use {@link GlobalConfig}, the canonical config shape. */
+export type InitConfig = GlobalConfig;
 
 export type InitAnswers = {
   draftRoot?: string;
@@ -21,22 +25,9 @@ export type InitCommandOptions = {
   answers?: InitAnswers;
 };
 
-export type InitConfig = {
-  schemaVersion: 1;
-  draftRoot: string;
-  scheduleTime: string;
-  aiProvider: string;
-  carouselVisualStyle: "photo-first" | "story-card";
-  persona: string;
-  roastLevel: number;
-  rawRetentionDays: number;
-  captionProjectionTokenBudget: number;
-  sources: SourceConfigMap;
-};
-
 export type InitCommandResult = {
   created: true;
-  config: InitConfig;
+  config: GlobalConfig;
 };
 
 const defaultAnswers = {
@@ -87,7 +78,7 @@ export async function runInitCommand(
 
   await ensureConfigDirectories(paths);
 
-  const config: InitConfig = {
+  const config: GlobalConfig = {
     schemaVersion: 1,
     draftRoot: paths.defaultDraftRoot,
     scheduleTime,
@@ -101,6 +92,9 @@ export async function runInitCommand(
   };
 
   await writeJson(paths.configFile, config);
+  // Invalidate any config cached earlier in this process so a subsequent read
+  // in the same invocation reflects the freshly written config.
+  clearGlobalConfigCache();
   await writeJsonIfMissing(paths.projectsFile, { schemaVersion: 1, projects: [] });
   await writeJsonIfMissing(paths.formatHistoryFile, { schemaVersion: 1, formats: [] });
 

--- a/src/raw-archive-prune.ts
+++ b/src/raw-archive-prune.ts
@@ -1,4 +1,6 @@
-import { readdir, readFile, stat, unlink } from "node:fs/promises";
+import { readdir, stat, unlink } from "node:fs/promises";
+import { loadGlobalConfig } from "./global-config.js";
+import { isRecord } from "./type-guards.js";
 import { join } from "node:path";
 
 export type RawArchiveSource = "claude" | "codex" | "github";
@@ -83,22 +85,13 @@ export async function pruneRawArchives(
 export async function readRawRetentionDays(
   configFilePath: string
 ): Promise<number> {
-  let raw: string;
-  try {
-    raw = await readFile(configFilePath, "utf8");
-  } catch {
+  // 0 means "keep forever" (the unlimited sentinel), so every unreadable,
+  // malformed, or invalid case falls back to no pruning.
+  const outcome = await loadGlobalConfig(configFilePath);
+  if (outcome.status !== "ok" || !isRecord(outcome.value)) {
     return 0;
   }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    return 0;
-  }
-  if (typeof parsed !== "object" || parsed === null) {
-    return 0;
-  }
-  const value = (parsed as Record<string, unknown>).rawRetentionDays;
+  const value = outcome.value.rawRetentionDays;
   if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
     return 0;
   }

--- a/src/raw-narrative-projection.ts
+++ b/src/raw-narrative-projection.ts
@@ -1,4 +1,5 @@
-import { readFile } from "node:fs/promises";
+import { loadGlobalConfig } from "./global-config.js";
+import { isRecord } from "./type-guards.js";
 
 export type NarrativeSource = "claude" | "codex" | "github";
 
@@ -99,25 +100,19 @@ export function assembleRawNarrativeProjection(
 export async function readCaptionProjectionTokenBudget(
   configFilePath: string
 ): Promise<number> {
-  let raw: string;
-  try {
-    raw = await readFile(configFilePath, "utf8");
-  } catch {
+  const outcome = await loadGlobalConfig(configFilePath);
+  if (outcome.status !== "ok" || !isRecord(outcome.value)) {
     return DEFAULT_CAPTION_PROJECTION_TOKEN_BUDGET;
   }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
+  const value = outcome.value.captionProjectionTokenBudget;
+  if (typeof value !== "number" || !Number.isFinite(value)) {
     return DEFAULT_CAPTION_PROJECTION_TOKEN_BUDGET;
   }
-  if (typeof parsed !== "object" || parsed === null) {
+  // Floor first: a fractional value in (0, 1) is positive but floors to 0,
+  // which would silently empty every projection. Treat sub-1 budgets as unset.
+  const floored = Math.floor(value);
+  if (floored < 1) {
     return DEFAULT_CAPTION_PROJECTION_TOKEN_BUDGET;
   }
-  const value = (parsed as Record<string, unknown>)
-    .captionProjectionTokenBudget;
-  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
-    return DEFAULT_CAPTION_PROJECTION_TOKEN_BUDGET;
-  }
-  return Math.floor(value);
+  return floored;
 }

--- a/src/render-command.ts
+++ b/src/render-command.ts
@@ -12,6 +12,8 @@ import {
   type CarouselPngVisualAsset
 } from "./carousel-renderer.js";
 import { resolveConfigPaths } from "./config-paths.js";
+import { loadGlobalConfig } from "./global-config.js";
+import { isRecord } from "./type-guards.js";
 import {
   DraftStorageError,
   readLatestDraftPointer,
@@ -45,11 +47,6 @@ export type RenderCommandResult = {
   outputDir: string;
   carouselDir: string;
   renderResult: CarouselPngRenderResult;
-};
-
-type RenderConfigFile = {
-  schemaVersion: 1;
-  draftRoot: string;
 };
 
 const usage = "Usage: uncommitted render latest";
@@ -130,31 +127,28 @@ async function readDraftRoot(
   configFile: string,
   homeDir: string | undefined
 ): Promise<string> {
-  try {
-    const parsed = JSON.parse(await readFile(configFile, "utf8")) as unknown;
+  const outcome = await loadGlobalConfig(configFile);
 
-    if (!isRenderConfigFile(parsed)) {
-      throw new RenderCommandError("AI config is invalid.", "invalid-config");
-    }
+  if (outcome.status === "missing") {
+    throw new RenderCommandError(
+      "AI config is missing. Run `uncommitted init` first.",
+      "invalid-config"
+    );
+  }
 
-    return resolveConfigPaths({
-      homeDir,
-      draftRoot: parsed.draftRoot
-    }).defaultDraftRoot;
-  } catch (error) {
-    if (error instanceof RenderCommandError) {
-      throw error;
-    }
-
-    if (isNodeError(error) && error.code === "ENOENT") {
-      throw new RenderCommandError(
-        "AI config is missing. Run `uncommitted init` first.",
-        "invalid-config"
-      );
-    }
-
+  if (
+    outcome.status !== "ok" ||
+    !isRecord(outcome.value) ||
+    outcome.value.schemaVersion !== 1 ||
+    typeof outcome.value.draftRoot !== "string"
+  ) {
     throw new RenderCommandError("AI config is invalid.", "invalid-config");
   }
+
+  return resolveConfigPaths({
+    homeDir,
+    draftRoot: outcome.value.draftRoot
+  }).defaultDraftRoot;
 }
 
 async function readLatestPointer(draftRoot: string) {
@@ -300,14 +294,6 @@ function mergeFiles(existingFiles: unknown, renderedFiles: string[]): string[] {
   return Array.from(new Set([...files, ...renderedFiles]));
 }
 
-function isRenderConfigFile(value: unknown): value is RenderConfigFile {
-  return (
-    isRecord(value) &&
-    value.schemaVersion === 1 &&
-    typeof value.draftRoot === "string"
-  );
-}
-
 function isVisualAssetMetadata(value: unknown): value is CarouselPngVisualAsset {
   return (
     isRecord(value) &&
@@ -330,12 +316,4 @@ function isPathInside(rootPath: string, valuePath: string): boolean {
       !relativePath.startsWith(`..${sep}`) &&
       !isAbsolute(relativePath))
   );
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-function isNodeError(error: unknown): error is NodeJS.ErrnoException {
-  return error instanceof Error && "code" in error;
 }

--- a/src/source-config.ts
+++ b/src/source-config.ts
@@ -1,4 +1,5 @@
-import { readFile } from "node:fs/promises";
+import { loadGlobalConfig } from "./global-config.js";
+import { isRecord } from "./type-guards.js";
 
 export type SourceName = "git" | "claude" | "codex" | "github";
 
@@ -44,33 +45,25 @@ export function listEnabledSources(config: unknown): SourceName[] {
 export async function loadSourceConfig(
   configFilePath: string
 ): Promise<SourceConfigMap> {
-  let raw: string;
+  const outcome = await loadGlobalConfig(configFilePath);
 
-  try {
-    raw = await readFile(configFilePath, "utf8");
-  } catch (error) {
+  switch (outcome.status) {
     // A missing config file is a valid first-run state: default everything on.
-    // Any other read error (permissions, I/O) must surface as a config error
-    // rather than silently enabling all sources.
-    if (isNotFoundError(error)) {
+    case "missing":
       return buildSourceConfigMap({});
-    }
-    throw new SourceConfigError(
-      `Unable to read source config at ${configFilePath}.`
-    );
+    // Any other read error (permissions, I/O) must surface rather than
+    // silently enabling all sources.
+    case "read-error":
+      throw new SourceConfigError(
+        `Unable to read source config at ${configFilePath}.`
+      );
+    case "parse-error":
+      throw new SourceConfigError(
+        `Malformed source config at ${configFilePath}; fix or remove the file.`
+      );
+    case "ok":
+      return buildSourceConfigMap(outcome.value);
   }
-
-  let parsed: unknown;
-
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    throw new SourceConfigError(
-      `Malformed source config at ${configFilePath}; fix or remove the file.`
-    );
-  }
-
-  return buildSourceConfigMap(parsed);
 }
 
 export function buildSourceConfigMap(config: unknown): SourceConfigMap {
@@ -118,12 +111,4 @@ function readSourceRecord(
   }
 
   return { enabled };
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function isNotFoundError(error: unknown): boolean {
-  return isRecord(error) && error.code === "ENOENT";
 }

--- a/src/type-guards.ts
+++ b/src/type-guards.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared runtime type guards used across config readers and validators.
+ *
+ * Previously `isRecord` and `isNodeError` were copy-pasted into six modules,
+ * with one copy (`ai-provider.ts`) subtly accepting arrays. The canonical
+ * `isRecord` here excludes arrays so every reader agrees on what "a config
+ * object" means.
+ */
+
+/** True for non-null, non-array objects (plain records). */
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** True for `Error` instances carrying a Node `code` (e.g. `ENOENT`). */
+export function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}

--- a/tests/global-config.test.ts
+++ b/tests/global-config.test.ts
@@ -1,0 +1,106 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearGlobalConfigCache,
+  isRoastLevel,
+  loadGlobalConfig,
+  selectDraftRoot,
+  selectGitHubToken
+} from "../src/global-config.js";
+
+let homeDir: string;
+let configFile: string;
+
+beforeEach(async () => {
+  clearGlobalConfigCache();
+  homeDir = await mkdtemp(join(tmpdir(), "global-config-"));
+  configFile = join(homeDir, "config.json");
+});
+
+afterEach(async () => {
+  clearGlobalConfigCache();
+  await rm(homeDir, { recursive: true, force: true });
+});
+
+describe("loadGlobalConfig", () => {
+  it("reports missing when the config file does not exist", async () => {
+    const outcome = await loadGlobalConfig(configFile);
+    expect(outcome.status).toBe("missing");
+  });
+
+  it("reports parse-error for malformed JSON", async () => {
+    await writeFile(configFile, "{ not json");
+    const outcome = await loadGlobalConfig(configFile);
+    expect(outcome.status).toBe("parse-error");
+  });
+
+  it("reports read-error for a non-ENOENT failure", async () => {
+    // A directory at the config path triggers EISDIR, not ENOENT.
+    await mkdir(configFile);
+    const outcome = await loadGlobalConfig(configFile);
+    expect(outcome.status).toBe("read-error");
+  });
+
+  it("returns the parsed value for a valid config", async () => {
+    await writeFile(configFile, JSON.stringify({ draftRoot: "~/x", roastLevel: 2 }));
+    const outcome = await loadGlobalConfig(configFile);
+    expect(outcome).toEqual({
+      status: "ok",
+      value: { draftRoot: "~/x", roastLevel: 2 }
+    });
+  });
+
+  it("caches successful reads so later calls do not touch disk", async () => {
+    await writeFile(configFile, JSON.stringify({ draftRoot: "~/x" }));
+    const first = await loadGlobalConfig(configFile);
+    // Removing the file would make a fresh read report "missing"; the cached
+    // value must survive, proving the second call did not re-read disk.
+    await rm(configFile, { force: true });
+    const second = await loadGlobalConfig(configFile);
+    expect(second).toEqual(first);
+    expect(second).toEqual({ status: "ok", value: { draftRoot: "~/x" } });
+  });
+
+  it("does not cache a missing outcome, so a later write is observed", async () => {
+    expect((await loadGlobalConfig(configFile)).status).toBe("missing");
+    await writeFile(configFile, JSON.stringify({ draftRoot: "~/late" }));
+    const outcome = await loadGlobalConfig(configFile);
+    expect(outcome).toEqual({ status: "ok", value: { draftRoot: "~/late" } });
+  });
+});
+
+describe("selectors", () => {
+  it("selectDraftRoot returns the draftRoot string or undefined", () => {
+    expect(selectDraftRoot({ draftRoot: "~/Uncommitted" })).toBe("~/Uncommitted");
+    expect(selectDraftRoot({})).toBeUndefined();
+    expect(selectDraftRoot({ draftRoot: 5 })).toBeUndefined();
+    expect(selectDraftRoot([])).toBeUndefined();
+    expect(selectDraftRoot(42)).toBeUndefined();
+  });
+
+  it("selectGitHubToken returns a non-empty token or null", () => {
+    expect(selectGitHubToken({ githubToken: "ghp_x" })).toBe("ghp_x");
+    expect(selectGitHubToken({ githubToken: "" })).toBeNull();
+    expect(selectGitHubToken({})).toBeNull();
+    expect(selectGitHubToken({ githubToken: 1 })).toBeNull();
+    expect(selectGitHubToken(null)).toBeNull();
+  });
+});
+
+describe("isRoastLevel", () => {
+  it("accepts integers 0 through 5", () => {
+    for (const level of [0, 1, 2, 3, 4, 5]) {
+      expect(isRoastLevel(level)).toBe(true);
+    }
+  });
+
+  it("rejects out-of-range, fractional, and non-number values", () => {
+    expect(isRoastLevel(-1)).toBe(false);
+    expect(isRoastLevel(6)).toBe(false);
+    expect(isRoastLevel(2.5)).toBe(false);
+    expect(isRoastLevel("3")).toBe(false);
+    expect(isRoastLevel(undefined)).toBe(false);
+  });
+});

--- a/tests/raw-narrative-projection.test.ts
+++ b/tests/raw-narrative-projection.test.ts
@@ -149,6 +149,12 @@ describe("readCaptionProjectionTokenBudget", () => {
     expect(await readCaptionProjectionTokenBudget(file)).toBe(4000);
   });
 
+  it("falls back to the default for a fractional value below 1", async () => {
+    // 0.5 is positive but floors to 0, which would silently empty projections.
+    const file = await writeConfig({ captionProjectionTokenBudget: 0.5 });
+    expect(await readCaptionProjectionTokenBudget(file)).toBe(4000);
+  });
+
   it("falls back to the default for a nonexistent file", async () => {
     expect(
       await readCaptionProjectionTokenBudget(

--- a/tests/type-guards.test.ts
+++ b/tests/type-guards.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { isNodeError, isRecord } from "../src/type-guards.js";
+
+describe("isRecord", () => {
+  it("returns true for plain objects", () => {
+    expect(isRecord({})).toBe(true);
+    expect(isRecord({ a: 1 })).toBe(true);
+  });
+
+  it("excludes arrays", () => {
+    expect(isRecord([])).toBe(false);
+    expect(isRecord([1, 2, 3])).toBe(false);
+  });
+
+  it("excludes null", () => {
+    expect(isRecord(null)).toBe(false);
+  });
+
+  it("excludes primitives", () => {
+    expect(isRecord(42)).toBe(false);
+    expect(isRecord("config")).toBe(false);
+    expect(isRecord(true)).toBe(false);
+    expect(isRecord(undefined)).toBe(false);
+  });
+});
+
+describe("isNodeError", () => {
+  it("returns true for an Error carrying a code", () => {
+    const error = Object.assign(new Error("boom"), { code: "ENOENT" });
+    expect(isNodeError(error)).toBe(true);
+    if (isNodeError(error)) {
+      expect(error.code).toBe("ENOENT");
+    }
+  });
+
+  it("returns false for a plain Error without a code", () => {
+    expect(isNodeError(new Error("boom"))).toBe(false);
+  });
+
+  it("returns false for non-error values", () => {
+    expect(isNodeError({ code: "ENOENT" })).toBe(false);
+    expect(isNodeError("ENOENT")).toBe(false);
+    expect(isNodeError(null)).toBe(false);
+  });
+});


### PR DESCRIPTION
# Goal

Collapse the seven-plus places that independently read, parse, and type-guard `~/.uncommitted/config.json` onto a single cached loader and one canonical config type, removing the duplication, drift, and redundant disk reads called out in UNC-171.

## Related Issue

Linear: [UNC-171 — Unify global config loading into a single typed loader](https://linear.app/sangchu/issue/UNC-171/unify-global-config-loading-into-a-single-typed-loader) (sub-issues UNC-183/184/185/186).

## Acceptance Criteria

- [x] Every caller that directly `readFile`/`JSON.parse`-ed config now goes through one shared `loadGlobalConfig`.
- [x] A single canonical `GlobalConfig` type is shared by the `init` writer and all readers; the drifting partial types (`InitConfig`, `GenerateConfigFile`, `RenderConfigFile`, `DoctorConfig`) are removed.
- [x] `isRecord`/`isNodeError` are consolidated into one module (`src/type-guards.ts`), array-excluding everywhere.
- [x] `roastLevel` range validation is unified into a single guard.
- [x] `pnpm test`, `pnpm typecheck`, `pnpm lint`, `pnpm build` green.
- [x] No behavior regression beyond the issue's intended `roastLevel` unification.

## Implementation Notes

Built in the decomposed order T1 → T2 → T3/T4 (TDD throughout):

- **T1** — `src/type-guards.ts`: array-excluding `isRecord` + `isNodeError`.
- **T2** — `src/global-config.ts`: canonical `GlobalConfig`, in-process-cached `loadGlobalConfig` (one read+parse per invocation; non-`ok` outcomes are not cached so a later write is observed), `selectDraftRoot`/`selectGitHubToken` selectors, and the unified `isRoastLevel(0–5)` guard. The loader returns a neutral `ok / missing / read-error / parse-error` outcome so each reader keeps its own error semantics.
- **T3** — `source-config`, `github-token-resolver`, `ai-provider` readers rewritten as thin selectors over the loader.
- **T4** — `generate`, `render`, cli `preview`, `doctor`, and the caption-projection budget reader rewritten the same way; `generate` now reads `config.json` once per invocation; partial types removed in favor of `GlobalConfig`/`Pick<GlobalConfig, …>`.

Intended behavior change (per the issue): `ai-provider` now enforces `roastLevel` 0–5 via the shared guard, matching `generate`.

Review fixes from `/code-review xhigh` folded in: deprecated `InitConfig` alias kept for API compat, sub-1 fractional caption budgets rejected, rejected loader promises evicted from the cache, cache cleared after `init` writes, dead `Array.isArray` guard dropped, and the public barrel narrowed to the canonical `GlobalConfig` type.

## Validation

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm build` — clean
- `pnpm test` — 703 passing / 1 skipped (added `type-guards`, `global-config`, and a fractional-budget regression test)
- `git diff --check` — clean

## Remaining Risk

- The in-process cache is process-lifetime scoped (per the issue's explicit assumption); a concurrent `init` rewriting config mid-`generate` is an accepted trade-off for the single-read optimization.
- Error-handling unification across readers is intentionally deferred to follow-up UNC-172.
- The one flaky suite is the pre-existing `carousel-renderer-smoke` Playwright timing test (passes in isolation), unrelated to this change.
