### PR TITLE
🤖 Fix inconsistent + silent config error handling (UNC-172)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -100,6 +100,21 @@ export class PreviewConfigError extends Error {
   }
 }
 
+/**
+ * Returns true for any config-corruption error regardless of which reader
+ * produced it. Recognises both `SourceConfigError` (by class) and the
+ * `code === "config-corruption"` tag carried by `GitHubTokenConfigError`
+ * and `PreviewConfigError` — avoiding hard imports of those classes here.
+ */
+function isConfigCorruptionError(error: unknown): boolean {
+  if (error instanceof SourceConfigError) return true;
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as { code?: unknown }).code === "config-corruption"
+  );
+}
+
 export type CliIo = {
   stdout: (message: string) => void;
   stderr: (message: string) => void;
@@ -186,54 +201,66 @@ export async function runCli(
     return result.exitCode;
   }
 
-  const [subcommand, value] = commandArgs;
+  // Central config-corruption mapper: any reader that throws a config-corruption
+  // error (GitHubTokenConfigError, PreviewConfigError, SourceConfigError) is
+  // caught here and converted to exit 2 + unified message. Non-config errors
+  // are rethrown so per-command handlers remain intact.
+  try {
+    const [subcommand, value] = commandArgs;
 
-  if (command === "project" && subcommand === "add") {
-    return await runProjectAdd(value, io, options);
+    if (command === "project" && subcommand === "add") {
+      return await runProjectAdd(value, io, options);
+    }
+
+    if (command === "project" && subcommand === "list") {
+      return await runProjectList(commandArgs.slice(1), io, options);
+    }
+
+    if (command === "project" && subcommand === "remove") {
+      return await runProjectRemove(value, commandArgs.slice(2), io, options);
+    }
+
+    if (command === "note") {
+      return await runNote(commandArgs, io, options);
+    }
+
+    if (command === "collect") {
+      return await runCollect(commandArgs, io, options);
+    }
+
+    if (command === "generate") {
+      return await runGenerate(commandArgs, io, options);
+    }
+
+    if (command === "render") {
+      return await runRender(commandArgs, io, options);
+    }
+
+    if (command === "preview") {
+      return await runPreview(commandArgs, io, options);
+    }
+
+    if (command === "export") {
+      return await runExport(commandArgs, io, options);
+    }
+
+    if (command === "schedule") {
+      return await runSchedule(commandArgs, io, options);
+    }
+
+    if (command === "feedback") {
+      return await runFeedback(commandArgs, io, options);
+    }
+
+    io.stderr(`Command not implemented yet: ${command}`);
+    return 1;
+  } catch (error) {
+    if (isConfigCorruptionError(error)) {
+      io.stderr(error instanceof Error ? error.message : String(error));
+      return 2;
+    }
+    throw error;
   }
-
-  if (command === "project" && subcommand === "list") {
-    return await runProjectList(commandArgs.slice(1), io, options);
-  }
-
-  if (command === "project" && subcommand === "remove") {
-    return await runProjectRemove(value, commandArgs.slice(2), io, options);
-  }
-
-  if (command === "note") {
-    return await runNote(commandArgs, io, options);
-  }
-
-  if (command === "collect") {
-    return await runCollect(commandArgs, io, options);
-  }
-
-  if (command === "generate") {
-    return await runGenerate(commandArgs, io, options);
-  }
-
-  if (command === "render") {
-    return await runRender(commandArgs, io, options);
-  }
-
-  if (command === "preview") {
-    return await runPreview(commandArgs, io, options);
-  }
-
-  if (command === "export") {
-    return await runExport(commandArgs, io, options);
-  }
-
-  if (command === "schedule") {
-    return await runSchedule(commandArgs, io, options);
-  }
-
-  if (command === "feedback") {
-    return await runFeedback(commandArgs, io, options);
-  }
-
-  io.stderr(`Command not implemented yet: ${command}`);
-  return 1;
 }
 
 async function runSchedule(
@@ -871,16 +898,7 @@ async function runCollect(
   }
 
   const paths = resolveConfigPaths({ homeDir: options.homeDir });
-  let sourceConfig;
-  try {
-    sourceConfig = await loadSourceConfig(paths.configFile);
-  } catch (error) {
-    if (error instanceof SourceConfigError) {
-      io.stderr(error.message);
-      return 2;
-    }
-    throw error;
-  }
+  const sourceConfig = await loadSourceConfig(paths.configFile);
   if (!sourceConfig[source].enabled) {
     io.stdout(
       `Source '${source}' is disabled in config; skipping collection.`
@@ -1037,22 +1055,13 @@ async function runCollectAllCommand(
   io: CliIo,
   options: CliOptions
 ): Promise<number> {
-  let summary;
-  try {
-    summary = await runCollectAll({
-      homeDir: options.homeDir,
-      claudeHome: options.claudeHome,
-      codexHome: options.codexHome,
-      now: options.now,
-      collectInvokers: options.collectInvokers
-    });
-  } catch (error) {
-    if (error instanceof SourceConfigError) {
-      io.stderr(error.message);
-      return 2;
-    }
-    throw error;
-  }
+  const summary = await runCollectAll({
+    homeDir: options.homeDir,
+    claudeHome: options.claudeHome,
+    codexHome: options.codexHome,
+    now: options.now,
+    collectInvokers: options.collectInvokers
+  });
 
   const enabledEntries = summary.entries.filter(
     (entry) => entry.status !== "disabled"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -84,6 +84,21 @@ import {
 } from "./feedback-command.js";
 import type { CarouselHtmlToPngRenderer } from "./carousel-renderer.js";
 import type { ImageAssetProvider } from "./visual-assets.js";
+import { isRecord } from "./type-guards.js";
+
+/**
+ * Thrown by readPreviewDraftRoot when config.json is unreadable, malformed,
+ * or has an unsupported schemaVersion. Task 3's exit-code mapper recognises
+ * this via `code === "config-corruption"`.
+ */
+export class PreviewConfigError extends Error {
+  readonly code = "config-corruption" as const;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "PreviewConfigError";
+  }
+}
 
 export type CliIo = {
   stdout: (message: string) => void;
@@ -527,12 +542,21 @@ async function readPreviewDraftRoot(
   const outcome = await loadGlobalConfig(configFile);
 
   // Preview is best-effort: a missing config falls back to the default draft
-  // root, but an unreadable or malformed config surfaces its original error.
+  // root, but an unreadable or malformed config surfaces a typed error.
   if (outcome.status === "read-error" || outcome.status === "parse-error") {
-    throw outcome.error;
+    throw new PreviewConfigError(
+      `Config error: ${configFile} is unreadable or malformed. Fix or remove the file.`
+    );
   }
 
   if (outcome.status === "ok") {
+    // Guard: reject configs that are records with an unsupported schemaVersion.
+    // Non-record ok values (e.g. JSON primitives) fall through to the default.
+    if (isRecord(outcome.value) && outcome.value.schemaVersion !== 1) {
+      throw new PreviewConfigError(
+        `Config error: ${configFile} is unreadable or malformed. Fix or remove the file.`
+      );
+    }
     const draftRoot = selectDraftRoot(outcome.value);
     if (draftRoot !== undefined) {
       return resolveConfigPaths({ homeDir, draftRoot }).defaultDraftRoot;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -577,9 +577,11 @@ async function readPreviewDraftRoot(
   }
 
   if (outcome.status === "ok") {
-    // Guard: reject configs that are records with an unsupported schemaVersion.
-    // Non-record ok values (e.g. JSON primitives) fall through to the default.
-    if (isRecord(outcome.value) && outcome.value.schemaVersion !== 1) {
+    // Guard: a valid-JSON config must be a record with schemaVersion 1. A
+    // non-record (e.g. `[]`, `42`, `null`) or an unsupported schemaVersion is
+    // corruption, not a default-fallback case — surface it rather than
+    // silently previewing from the wrong root.
+    if (!isRecord(outcome.value) || outcome.value.schemaVersion !== 1) {
       throw new PreviewConfigError(
         `Config error: ${configFile} is unreadable or malformed. Fix or remove the file.`
       );

--- a/src/github-token-resolver.ts
+++ b/src/github-token-resolver.ts
@@ -1,5 +1,6 @@
 import { loadGlobalConfig, selectGitHubToken } from "./global-config.js";
 import { resolveConfigPaths } from "./config-paths.js";
+import { isRecord } from "./type-guards.js";
 
 export type ResolvedGitHubToken = {
   token: string | null;
@@ -36,11 +37,18 @@ export async function resolveGitHubToken(
     );
   }
   if (outcome.status === "ok") {
+    // Valid JSON that is not a config object (e.g. `[]`, `42`, `null`) is
+    // corruption, not "no token" — surface it rather than disguising it.
+    if (!isRecord(outcome.value)) {
+      throw new GitHubTokenConfigError(
+        `Config error: ${configPath} is unreadable or malformed. Fix or remove the file.`
+      );
+    }
     const token = selectGitHubToken(outcome.value);
     if (token !== null) {
       return { token, source: "config" };
     }
   }
-  // Missing or ok-without-token → "missing".
+  // Missing or ok-record-without-token → "missing".
   return { token: null, source: "missing" };
 }

--- a/src/github-token-resolver.ts
+++ b/src/github-token-resolver.ts
@@ -1,5 +1,5 @@
-import { join } from "node:path";
 import { loadGlobalConfig, selectGitHubToken } from "./global-config.js";
+import { resolveConfigPaths } from "./config-paths.js";
 
 export type ResolvedGitHubToken = {
   token: string | null;
@@ -11,6 +11,15 @@ export type ResolveGitHubTokenInput = {
   env?: Record<string, string | undefined>;
 };
 
+export class GitHubTokenConfigError extends Error {
+  readonly code = "config-corruption" as const;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "GitHubTokenConfigError";
+  }
+}
+
 export async function resolveGitHubToken(
   input: ResolveGitHubTokenInput
 ): Promise<ResolvedGitHubToken> {
@@ -19,14 +28,19 @@ export async function resolveGitHubToken(
   if (typeof envToken === "string" && envToken.length > 0) {
     return { token: envToken, source: "env" };
   }
-  const configPath = join(input.homeDir, ".uncommitted", "config.json");
+  const configPath = resolveConfigPaths({ homeDir: input.homeDir }).configFile;
   const outcome = await loadGlobalConfig(configPath);
+  if (outcome.status === "read-error" || outcome.status === "parse-error") {
+    throw new GitHubTokenConfigError(
+      `Config error: ${configPath} is unreadable or malformed. Fix or remove the file.`
+    );
+  }
   if (outcome.status === "ok") {
     const token = selectGitHubToken(outcome.value);
     if (token !== null) {
       return { token, source: "config" };
     }
   }
-  // Missing / unreadable / invalid JSON / no token → "missing".
+  // Missing or ok-without-token → "missing".
   return { token: null, source: "missing" };
 }

--- a/src/source-config.ts
+++ b/src/source-config.ts
@@ -55,11 +55,11 @@ export async function loadSourceConfig(
     // silently enabling all sources.
     case "read-error":
       throw new SourceConfigError(
-        `Unable to read source config at ${configFilePath}.`
+        `Config error: ${configFilePath} is unreadable or malformed. Fix or remove the file.`
       );
     case "parse-error":
       throw new SourceConfigError(
-        `Malformed source config at ${configFilePath}; fix or remove the file.`
+        `Config error: ${configFilePath} is unreadable or malformed. Fix or remove the file.`
       );
     case "ok":
       return buildSourceConfigMap(outcome.value);

--- a/src/source-config.ts
+++ b/src/source-config.ts
@@ -62,6 +62,15 @@ export async function loadSourceConfig(
         `Config error: ${configFilePath} is unreadable or malformed. Fix or remove the file.`
       );
     case "ok":
+      // A record declaring an unsupported schemaVersion is a malformed config,
+      // not a default-on first run — reject it so source gating cannot be
+      // silently bypassed by a schema-mismatched file (matches the preview
+      // reader's guard).
+      if (isRecord(outcome.value) && outcome.value.schemaVersion !== 1) {
+        throw new SourceConfigError(
+          `Config error: ${configFilePath} is unreadable or malformed. Fix or remove the file.`
+        );
+      }
       return buildSourceConfigMap(outcome.value);
   }
 }

--- a/tests/cli-collect-source-gating.test.ts
+++ b/tests/cli-collect-source-gating.test.ts
@@ -159,7 +159,7 @@ describe("cli collect <source> per-source gating", () => {
     const exitCode = await runCli(["collect", "git"], io, { homeDir });
 
     expect(exitCode).toBe(2);
-    expect(stderr.join("\n")).toContain("Malformed source config");
+    expect(stderr.join("\n")).toContain("Config error:");
   });
 
   it("invokes the claude collector when sources.claude.enabled is true (sanity)", async () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -17,7 +17,7 @@ import {
   CarouselPngRenderError,
   type CarouselHtmlToPngRenderer
 } from "../src/carousel-renderer.js";
-import { isDirectRun, runCli } from "../src/cli.js";
+import { isDirectRun, PreviewConfigError, runCli } from "../src/cli.js";
 import type {
   AiProvider,
   AiProviderRawResponse,
@@ -1386,6 +1386,82 @@ describe("cli", () => {
       expect(exitCode).toBe(0);
       expect(stderr).toEqual([]);
       expect(stdout.join("\n")).toContain("Custom root caption");
+    });
+
+    // UNC-177: PreviewConfigError guard tests
+    describe("readPreviewDraftRoot config guards (UNC-177)", () => {
+      it("throws PreviewConfigError when config has schemaVersion: 2", async () => {
+        const homeDir = await mkdtemp(join(tmpdir(), "uncommitted-preview-schema-"));
+        await mkdir(join(homeDir, ".uncommitted"), { recursive: true });
+        await writeFile(
+          join(homeDir, ".uncommitted", "config.json"),
+          JSON.stringify({ schemaVersion: 2, draftRoot: join(homeDir, "drafts") }),
+          "utf8"
+        );
+        const { io } = createIo();
+        await expect(runCli(["preview", "latest"], io, { homeDir })).rejects.toBeInstanceOf(PreviewConfigError);
+      });
+
+      it("throws PreviewConfigError when config is a record missing schemaVersion", async () => {
+        const homeDir = await mkdtemp(join(tmpdir(), "uncommitted-preview-noschema-"));
+        await mkdir(join(homeDir, ".uncommitted"), { recursive: true });
+        await writeFile(
+          join(homeDir, ".uncommitted", "config.json"),
+          JSON.stringify({ draftRoot: join(homeDir, "drafts") }),
+          "utf8"
+        );
+        const { io } = createIo();
+        await expect(runCli(["preview", "latest"], io, { homeDir })).rejects.toBeInstanceOf(PreviewConfigError);
+      });
+
+      it("throws PreviewConfigError when config.json contains malformed JSON", async () => {
+        const homeDir = await mkdtemp(join(tmpdir(), "uncommitted-preview-malformed-"));
+        await mkdir(join(homeDir, ".uncommitted"), { recursive: true });
+        await writeFile(
+          join(homeDir, ".uncommitted", "config.json"),
+          "{ not valid json ~~~",
+          "utf8"
+        );
+        const { io } = createIo();
+        await expect(runCli(["preview", "latest"], io, { homeDir })).rejects.toBeInstanceOf(PreviewConfigError);
+      });
+
+      it("thrown PreviewConfigError has code === 'config-corruption'", async () => {
+        const homeDir = await mkdtemp(join(tmpdir(), "uncommitted-preview-code-"));
+        await mkdir(join(homeDir, ".uncommitted"), { recursive: true });
+        await writeFile(
+          join(homeDir, ".uncommitted", "config.json"),
+          JSON.stringify({ schemaVersion: 2 }),
+          "utf8"
+        );
+        const { io } = createIo();
+        let caught: unknown;
+        try {
+          await runCli(["preview", "latest"], io, { homeDir });
+        } catch (e) {
+          caught = e;
+        }
+        expect(caught).toBeInstanceOf(PreviewConfigError);
+        expect((caught as PreviewConfigError).code).toBe("config-corruption");
+      });
+
+      it("does not throw and returns resolved draftRoot when config has schemaVersion: 1", async () => {
+        const homeDir = await mkdtemp(join(tmpdir(), "uncommitted-preview-valid-"));
+        const customDraftRoot = join(homeDir, "custom", "drafts");
+        await writeConfig(homeDir, customDraftRoot);
+        const { io } = createIo();
+        // No throw — just reaches preview with the custom draft root (no latest draft so exits 1)
+        const exitCode = await runCli(["preview", "latest"], io, { homeDir });
+        expect(exitCode).toBe(1); // 1 because no draft exists, not because of config error
+      });
+
+      it("does not throw and returns default draftRoot when config.json is missing", async () => {
+        const homeDir = await mkdtemp(join(tmpdir(), "uncommitted-preview-missing-config-"));
+        const { io } = createIo();
+        // No throw — falls back to default draft root (no latest draft so exits 1)
+        const exitCode = await runCli(["preview", "latest"], io, { homeDir });
+        expect(exitCode).toBe(1); // 1 because no draft exists, not because of config error
+      });
     });
 
     it("exits 1 with usage message when no subcommand is given", async () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -17,7 +17,7 @@ import {
   CarouselPngRenderError,
   type CarouselHtmlToPngRenderer
 } from "../src/carousel-renderer.js";
-import { isDirectRun, PreviewConfigError, runCli } from "../src/cli.js";
+import { isDirectRun, runCli } from "../src/cli.js";
 import type {
   AiProvider,
   AiProviderRawResponse,
@@ -1388,9 +1388,9 @@ describe("cli", () => {
       expect(stdout.join("\n")).toContain("Custom root caption");
     });
 
-    // UNC-177: PreviewConfigError guard tests
-    describe("readPreviewDraftRoot config guards (UNC-177)", () => {
-      it("throws PreviewConfigError when config has schemaVersion: 2", async () => {
+    // UNC-177/UNC-178: PreviewConfigError guard tests — central handler maps to exit 2 + unified message
+    describe("readPreviewDraftRoot config guards (UNC-177/UNC-178)", () => {
+      it("returns exit 2 with unified message when config has schemaVersion: 2", async () => {
         const homeDir = await mkdtemp(join(tmpdir(), "uncommitted-preview-schema-"));
         await mkdir(join(homeDir, ".uncommitted"), { recursive: true });
         await writeFile(
@@ -1398,11 +1398,14 @@ describe("cli", () => {
           JSON.stringify({ schemaVersion: 2, draftRoot: join(homeDir, "drafts") }),
           "utf8"
         );
-        const { io } = createIo();
-        await expect(runCli(["preview", "latest"], io, { homeDir })).rejects.toBeInstanceOf(PreviewConfigError);
+        const { io, stderr } = createIo();
+        const exitCode = await runCli(["preview", "latest"], io, { homeDir });
+        expect(exitCode).toBe(2);
+        expect(stderr.join("\n")).toContain("Config error:");
+        expect(stderr.join("\n")).toContain("is unreadable or malformed. Fix or remove the file.");
       });
 
-      it("throws PreviewConfigError when config is a record missing schemaVersion", async () => {
+      it("returns exit 2 with unified message when config is a record missing schemaVersion", async () => {
         const homeDir = await mkdtemp(join(tmpdir(), "uncommitted-preview-noschema-"));
         await mkdir(join(homeDir, ".uncommitted"), { recursive: true });
         await writeFile(
@@ -1410,11 +1413,14 @@ describe("cli", () => {
           JSON.stringify({ draftRoot: join(homeDir, "drafts") }),
           "utf8"
         );
-        const { io } = createIo();
-        await expect(runCli(["preview", "latest"], io, { homeDir })).rejects.toBeInstanceOf(PreviewConfigError);
+        const { io, stderr } = createIo();
+        const exitCode = await runCli(["preview", "latest"], io, { homeDir });
+        expect(exitCode).toBe(2);
+        expect(stderr.join("\n")).toContain("Config error:");
+        expect(stderr.join("\n")).toContain("is unreadable or malformed. Fix or remove the file.");
       });
 
-      it("throws PreviewConfigError when config.json contains malformed JSON", async () => {
+      it("returns exit 2 with unified message when config.json contains malformed JSON", async () => {
         const homeDir = await mkdtemp(join(tmpdir(), "uncommitted-preview-malformed-"));
         await mkdir(join(homeDir, ".uncommitted"), { recursive: true });
         await writeFile(
@@ -1422,27 +1428,11 @@ describe("cli", () => {
           "{ not valid json ~~~",
           "utf8"
         );
-        const { io } = createIo();
-        await expect(runCli(["preview", "latest"], io, { homeDir })).rejects.toBeInstanceOf(PreviewConfigError);
-      });
-
-      it("thrown PreviewConfigError has code === 'config-corruption'", async () => {
-        const homeDir = await mkdtemp(join(tmpdir(), "uncommitted-preview-code-"));
-        await mkdir(join(homeDir, ".uncommitted"), { recursive: true });
-        await writeFile(
-          join(homeDir, ".uncommitted", "config.json"),
-          JSON.stringify({ schemaVersion: 2 }),
-          "utf8"
-        );
-        const { io } = createIo();
-        let caught: unknown;
-        try {
-          await runCli(["preview", "latest"], io, { homeDir });
-        } catch (e) {
-          caught = e;
-        }
-        expect(caught).toBeInstanceOf(PreviewConfigError);
-        expect((caught as PreviewConfigError).code).toBe("config-corruption");
+        const { io, stderr } = createIo();
+        const exitCode = await runCli(["preview", "latest"], io, { homeDir });
+        expect(exitCode).toBe(2);
+        expect(stderr.join("\n")).toContain("Config error:");
+        expect(stderr.join("\n")).toContain("is unreadable or malformed. Fix or remove the file.");
       });
 
       it("does not throw and returns resolved draftRoot when config has schemaVersion: 1", async () => {
@@ -1461,6 +1451,50 @@ describe("cli", () => {
         // No throw — falls back to default draft root (no latest draft so exits 1)
         const exitCode = await runCli(["preview", "latest"], io, { homeDir });
         expect(exitCode).toBe(1); // 1 because no draft exists, not because of config error
+      });
+    });
+
+    // UNC-178: Central config-corruption mapper tests
+    describe("central config-corruption mapper (UNC-178)", () => {
+      it("returns exit 2 + unified message for collect github with malformed config.json", async () => {
+        const homeDir = await mkdtemp(join(tmpdir(), "uncommitted-collect-github-malformed-"));
+        await mkdir(join(homeDir, ".uncommitted"), { recursive: true });
+        await writeFile(
+          join(homeDir, ".uncommitted", "config.json"),
+          "{ not valid json ~~~",
+          "utf8"
+        );
+        const { io, stderr } = createIo();
+        const exitCode = await runCli(["collect", "github"], io, { homeDir });
+        expect(exitCode).toBe(2);
+        expect(stderr.join("\n")).toContain("Config error:");
+        expect(stderr.join("\n")).toContain("is unreadable or malformed. Fix or remove the file.");
+      });
+
+      it("returns exit 2 + unified message for collect git with malformed config.json (SourceConfigError path)", async () => {
+        const homeDir = await mkdtemp(join(tmpdir(), "uncommitted-collect-git-malformed-"));
+        await mkdir(join(homeDir, ".uncommitted"), { recursive: true });
+        await writeFile(
+          join(homeDir, ".uncommitted", "config.json"),
+          "{ not valid json ~~~",
+          "utf8"
+        );
+        const { io, stderr } = createIo();
+        const exitCode = await runCli(["collect", "git"], io, { homeDir });
+        expect(exitCode).toBe(2);
+        expect(stderr.join("\n")).toContain("Config error:");
+        expect(stderr.join("\n")).toContain("is unreadable or malformed. Fix or remove the file.");
+      });
+
+      it("does not map exit 2 for valid config (no false positive)", async () => {
+        const homeDir = await mkdtemp(join(tmpdir(), "uncommitted-collect-git-valid-"));
+        const draftRoot = join(homeDir, "drafts");
+        await writeConfig(homeDir, draftRoot);
+        const { io, stderr } = createIo();
+        // collect git with valid config but no projects → exits 3 (collection error), not 2
+        const exitCode = await runCli(["collect", "git"], io, { homeDir });
+        expect(exitCode).toBe(3);
+        expect(stderr.join("\n")).not.toContain("Config error:");
       });
     });
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1420,6 +1420,21 @@ describe("cli", () => {
         expect(stderr.join("\n")).toContain("is unreadable or malformed. Fix or remove the file.");
       });
 
+      it("returns exit 2 with unified message when config is valid JSON but not a record", async () => {
+        const homeDir = await mkdtemp(join(tmpdir(), "uncommitted-preview-nonrecord-"));
+        await mkdir(join(homeDir, ".uncommitted"), { recursive: true });
+        await writeFile(
+          join(homeDir, ".uncommitted", "config.json"),
+          "[]",
+          "utf8"
+        );
+        const { io, stderr } = createIo();
+        const exitCode = await runCli(["preview", "latest"], io, { homeDir });
+        expect(exitCode).toBe(2);
+        expect(stderr.join("\n")).toContain("Config error:");
+        expect(stderr.join("\n")).toContain("is unreadable or malformed. Fix or remove the file.");
+      });
+
       it("returns exit 2 with unified message when config.json contains malformed JSON", async () => {
         const homeDir = await mkdtemp(join(tmpdir(), "uncommitted-preview-malformed-"));
         await mkdir(join(homeDir, ".uncommitted"), { recursive: true });
@@ -1466,6 +1481,21 @@ describe("cli", () => {
         );
         const { io, stderr } = createIo();
         const exitCode = await runCli(["collect", "github"], io, { homeDir });
+        expect(exitCode).toBe(2);
+        expect(stderr.join("\n")).toContain("Config error:");
+        expect(stderr.join("\n")).toContain("is unreadable or malformed. Fix or remove the file.");
+      });
+
+      it("returns exit 2 + unified message for collect git when config has an unsupported schemaVersion", async () => {
+        const homeDir = await mkdtemp(join(tmpdir(), "uncommitted-collect-git-schema-"));
+        await mkdir(join(homeDir, ".uncommitted"), { recursive: true });
+        await writeFile(
+          join(homeDir, ".uncommitted", "config.json"),
+          JSON.stringify({ schemaVersion: 2, sources: { git: { enabled: false } } }),
+          "utf8"
+        );
+        const { io, stderr } = createIo();
+        const exitCode = await runCli(["collect", "git"], io, { homeDir });
         expect(exitCode).toBe(2);
         expect(stderr.join("\n")).toContain("Config error:");
         expect(stderr.join("\n")).toContain("is unreadable or malformed. Fix or remove the file.");

--- a/tests/collect-github-command.test.ts
+++ b/tests/collect-github-command.test.ts
@@ -6,6 +6,8 @@ import {
   collectGitHubForRegisteredProjects,
   CollectGitHubCommandError
 } from "../src/collect-github-command.js";
+import { GitHubTokenConfigError } from "../src/github-token-resolver.js";
+import { clearGlobalConfigCache } from "../src/global-config.js";
 
 async function seedProjects(homeDir: string, projectRoot: string) {
   await mkdir(join(homeDir, ".uncommitted"), { recursive: true });
@@ -42,6 +44,23 @@ describe("collectGitHubForRegisteredProjects", () => {
         httpClient: async () => new Response("{}", { status: 200 })
       })
     ).rejects.toMatchObject({ code: "no-token" });
+  });
+
+  it("surfaces config corruption instead of no-token when config is valid JSON but not a record", async () => {
+    clearGlobalConfigCache();
+    const homeDir = await mkdtemp(join(tmpdir(), "gh-cmd-"));
+    const projectRoot = await mkdtemp(join(tmpdir(), "gh-proj-"));
+    await seedProjects(homeDir, projectRoot);
+    await writeFile(join(homeDir, ".uncommitted", "config.json"), "[]");
+    await expect(
+      collectGitHubForRegisteredProjects({
+        homeDir,
+        env: {},
+        targetDate: "2026-06-17",
+        remoteUrlReader: async () => "https://github.com/foo/bar.git",
+        httpClient: async () => new Response("{}", { status: 200 })
+      })
+    ).rejects.toBeInstanceOf(GitHubTokenConfigError);
   });
 
   it("graceful-skips a project whose origin is not on github.com", async () => {

--- a/tests/github-token-resolver.test.ts
+++ b/tests/github-token-resolver.test.ts
@@ -1,10 +1,15 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { resolveGitHubToken } from "../src/github-token-resolver.js";
+import { resolveGitHubToken, GitHubTokenConfigError } from "../src/github-token-resolver.js";
+import { clearGlobalConfigCache } from "../src/global-config.js";
 
 describe("resolveGitHubToken", () => {
+  beforeEach(() => {
+    clearGlobalConfigCache();
+  });
+
   it("prefers GITHUB_TOKEN env var over config", async () => {
     const homeDir = await mkdtemp(join(tmpdir(), "ght-"));
     await mkdir(join(homeDir, ".uncommitted"), { recursive: true });
@@ -37,5 +42,42 @@ describe("resolveGitHubToken", () => {
     const homeDir = await mkdtemp(join(tmpdir(), "ght-"));
     const result = await resolveGitHubToken({ homeDir, env: { GITHUB_TOKEN: "" } });
     expect(result.source).toBe("missing");
+  });
+
+  it("throws GitHubTokenConfigError when config.json is malformed JSON", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "ght-"));
+    await mkdir(join(homeDir, ".uncommitted"), { recursive: true });
+    await writeFile(join(homeDir, ".uncommitted", "config.json"), "{ not json");
+    await expect(resolveGitHubToken({ homeDir, env: {} })).rejects.toBeInstanceOf(
+      GitHubTokenConfigError
+    );
+  });
+
+  it("error from malformed config has code 'config-corruption'", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "ght-"));
+    await mkdir(join(homeDir, ".uncommitted"), { recursive: true });
+    await writeFile(join(homeDir, ".uncommitted", "config.json"), "{ not json");
+    try {
+      await resolveGitHubToken({ homeDir, env: {} });
+      throw new Error("Expected GitHubTokenConfigError to be thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(GitHubTokenConfigError);
+      expect((err as GitHubTokenConfigError).code).toBe("config-corruption");
+    }
+  });
+
+  it("returns missing when config file does not exist", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "ght-"));
+    // No .uncommitted dir or config.json written
+    const result = await resolveGitHubToken({ homeDir, env: {} });
+    expect(result).toEqual({ token: null, source: "missing" });
+  });
+
+  it("env GITHUB_TOKEN wins even when config is malformed", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "ght-"));
+    await mkdir(join(homeDir, ".uncommitted"), { recursive: true });
+    await writeFile(join(homeDir, ".uncommitted", "config.json"), "{ not json");
+    const result = await resolveGitHubToken({ homeDir, env: { GITHUB_TOKEN: "from-env" } });
+    expect(result).toEqual({ token: "from-env", source: "env" });
   });
 });

--- a/tests/github-token-resolver.test.ts
+++ b/tests/github-token-resolver.test.ts
@@ -66,6 +66,30 @@ describe("resolveGitHubToken", () => {
     }
   });
 
+  it("returns missing when config is a valid record without a token", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "ght-"));
+    await mkdir(join(homeDir, ".uncommitted"), { recursive: true });
+    await writeFile(
+      join(homeDir, ".uncommitted", "config.json"),
+      JSON.stringify({ schemaVersion: 1 })
+    );
+    const result = await resolveGitHubToken({ homeDir, env: {} });
+    expect(result).toEqual({ token: null, source: "missing" });
+  });
+
+  it("throws GitHubTokenConfigError when config is valid JSON but not a record", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "ght-"));
+    await mkdir(join(homeDir, ".uncommitted"), { recursive: true });
+    await writeFile(join(homeDir, ".uncommitted", "config.json"), "[]");
+    try {
+      await resolveGitHubToken({ homeDir, env: {} });
+      throw new Error("Expected GitHubTokenConfigError to be thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(GitHubTokenConfigError);
+      expect((err as GitHubTokenConfigError).code).toBe("config-corruption");
+    }
+  });
+
   it("returns missing when config file does not exist", async () => {
     const homeDir = await mkdtemp(join(tmpdir(), "ght-"));
     // No .uncommitted dir or config.json written

--- a/tests/source-config.test.ts
+++ b/tests/source-config.test.ts
@@ -93,6 +93,26 @@ describe("loadSourceConfig", () => {
     });
   });
 
+  it("rejects a config with an unsupported schemaVersion", async () => {
+    const home = await mkdtemp(join(tmpdir(), "uncommitted-source-config-"));
+    const configDir = join(home, ".uncommitted");
+    await mkdir(configDir, { recursive: true });
+    const configFile = join(configDir, "config.json");
+    await writeFile(
+      configFile,
+      JSON.stringify({
+        schemaVersion: 2,
+        sources: {
+          git: { enabled: false }
+        }
+      })
+    );
+
+    await expect(loadSourceConfig(configFile)).rejects.toBeInstanceOf(
+      SourceConfigError
+    );
+  });
+
   it("rejects a malformed config instead of silently enabling every source", async () => {
     const home = await mkdtemp(join(tmpdir(), "uncommitted-source-config-"));
     const configDir = join(home, ".uncommitted");


### PR DESCRIPTION
# Goal

🤖 **Auto-generated by Uncommitted Builder (Routine B v2)**

Make a corrupted `~/.uncommitted/config.json` surface a clear, consistent error (exit code 2) across every reader, instead of being silently swallowed (token resolver disguising corruption as "no token") or handled ad-hoc (preview falling back without a `schemaVersion` guard).

## Related Issue

Parent: [UNC-172: Fix inconsistent + silent config error handling](https://linear.app/sangchu/issue/UNC-172/fix-inconsistent-silent-config-error-handling)

Sub-issues:
- [x] [UNC-176](https://linear.app/sangchu/issue/UNC-176) (T1) — Surface config corruption in `github-token-resolver` (use `resolveConfigPaths`; throw on parse/read error)
- [x] [UNC-177](https://linear.app/sangchu/issue/UNC-177) (T2) — Guard `readPreviewDraftRoot` against malformed + `schemaVersion`-mismatched config
- [x] [UNC-178](https://linear.app/sangchu/issue/UNC-178) (T3) — Unify malformed-config exit code (always `2`) + message at the CLI entry

## Acceptance Criteria

- [x] Corrupted `config.json` on `collect github` surfaces a config-corruption error, not "no token" (T1 + T3)
- [x] `preview` no longer silently swallows a malformed/schema-mismatched config (T2 + T3)
- [x] `github-token-resolver` resolves the path via `resolveConfigPaths({homeDir}).configFile` (T1)
- [x] Malformed-JSON handling is consistent across readers — always exit `2`, one unified message (T3)
- [x] Tests added for each behavior; `pnpm test/lint/typecheck/build` green

## Implementation Notes

- Builds on the UNC-171 shared loader: all readers go through `loadGlobalConfig(path)` → discriminated outcome (`missing | read-error | parse-error | ok`).
- **Shared recognition contract (no new shared error class):** the two new errors (`GitHubTokenConfigError`, `PreviewConfigError`) carry a string-literal tag `readonly code = "config-corruption"`. A single `isConfigCorruptionError(error)` helper at the CLI entry recognizes that tag **or** `instanceof SourceConfigError`, maps to exit `2`, and emits the unified message: `Config error: <path> is unreadable or malformed. Fix or remove the file.`
- `SourceConfigError`'s two messages were updated to the unified text and the now-redundant inner `runCollect`/`runCollectAll` handlers removed, so all config corruption flows through one central path.
- `doctor-command` intentionally excluded (its fail-check return is the doctor "checks" contract).
- TDD throughout (RED → GREEN per task); 3 commits, one per sub-issue.

## Validation

- `pnpm test` → 716 passed / 1 skipped (71 files)
- `pnpm lint` → clean
- `pnpm typecheck` → clean
- `pnpm build` → clean
- `git diff --check` → clean

## Remaining Risk

- T3 distinguishes config-parse failures of `ai-provider`/`generate-command`/`render-command` only where those readers already produced their own exit-2 paths; this PR does not re-route those internal handlers (out of T3 scope) — their behavior is unchanged.
- `isConfigCorruptionError` is duck-typed on the exact literal `"config-corruption"`; unrelated `.code` values (Node `ENOENT`, `RenderCommandError` `invalid-arguments`, etc.) are not matched (covered by a false-positive sanity test).

---

## Review checklist
- [ ] Review each sub-issue's commit separately (ecb7f04 → 1343ee0 → 3a2a746)
- [ ] Verify TDD test coverage for each path
- [ ] Confirm no lockfile changes (none in this PR)
- [ ] Run `pnpm install && pnpm test && pnpm build` locally
- [ ] Confirm no auto-publish code introduced

이 PR은 자동 생성되었습니다. 머지 전 사람의 리뷰가 반드시 필요합니다.
