### PR TITLE
🤖 Harden githubToken handling: env-first guidance + redaction (UNC-173)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ This project is in its initial CLI bootstrap phase. Commands are routed, but fea
 pnpm install
 ```
 
+### GitHub token
+
+If you use GitHub-sourced collection, prefer setting the `GITHUB_TOKEN` environment variable over storing a token in `config.json`; `init` does not manage `githubToken`, and storing it as plaintext in config is discouraged. `uncommitted doctor` reports only a masked status (env / config-plaintext / not-set) and never prints the token value.
+
 ## Development
 
 ```sh

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -186,8 +186,11 @@ export async function runCli(
 
   if (command === "init") {
     try {
-      await runInitCommand(commandArgs);
+      const result = await runInitCommand(commandArgs);
       io.stdout("Initialized Uncommitted config.");
+      for (const line of result.guidance) {
+        io.stdout(line);
+      }
       return 0;
     } catch (error) {
       io.stderr(error instanceof Error ? error.message : "Init failed.");

--- a/src/doctor-command.ts
+++ b/src/doctor-command.ts
@@ -6,6 +6,7 @@ import process from "node:process";
 import { promisify } from "node:util";
 import { resolveConfigPaths } from "./config-paths.js";
 import { loadGlobalConfig, type GlobalConfig } from "./global-config.js";
+import { describeGitHubTokenStatus } from "./github-token-safety.js";
 import { isRecord } from "./type-guards.js";
 
 const execFileAsync = promisify(execFile);
@@ -41,7 +42,7 @@ export type DoctorOptions = {
 
 type DoctorConfig = Pick<
   GlobalConfig,
-  "schemaVersion" | "draftRoot" | "aiProvider"
+  "schemaVersion" | "draftRoot" | "aiProvider" | "githubToken"
 >;
 
 const aiProviderEnvKeys: Record<string, string | undefined> = {
@@ -119,6 +120,7 @@ export async function createDoctorReport(
 
   if (config) {
     checks.push(createAiApiKeyCheck(config.aiProvider, env));
+    checks.push(createGitHubTokenCheck(config, env));
   }
 
   return { checks };
@@ -391,6 +393,28 @@ function createAiApiKeyCheck(
   };
 }
 
+function createGitHubTokenCheck(
+  config: DoctorConfig,
+  env: Record<string, string | undefined>
+): DoctorCheck {
+  const envToken = env.GITHUB_TOKEN;
+  const source: "env" | "config" | "missing" =
+    typeof envToken === "string" && envToken.length > 0
+      ? "env"
+      : typeof config.githubToken === "string" && config.githubToken.length > 0
+        ? "config"
+        : "missing";
+
+  const message = describeGitHubTokenStatus(source);
+
+  return {
+    id: "github-token",
+    label: "GitHub token",
+    status: source === "config" ? "warn" : "pass",
+    message
+  };
+}
+
 async function defaultCheckCommand(
   command: string,
   args: string[]
@@ -444,6 +468,7 @@ function isDoctorConfig(value: unknown): value is DoctorConfig {
     isRecord(value) &&
     value.schemaVersion === 1 &&
     typeof value.draftRoot === "string" &&
-    typeof value.aiProvider === "string"
+    typeof value.aiProvider === "string" &&
+    (value.githubToken === undefined || typeof value.githubToken === "string")
   );
 }

--- a/src/doctor-command.ts
+++ b/src/doctor-command.ts
@@ -5,7 +5,7 @@ import { dirname, join } from "node:path";
 import process from "node:process";
 import { promisify } from "node:util";
 import { resolveConfigPaths } from "./config-paths.js";
-import { loadGlobalConfig, type GlobalConfig } from "./global-config.js";
+import { loadGlobalConfig, selectGitHubToken, type GlobalConfig } from "./global-config.js";
 import { describeGitHubTokenStatus } from "./github-token-safety.js";
 import { isRecord } from "./type-guards.js";
 
@@ -401,7 +401,7 @@ function createGitHubTokenCheck(
   const source: "env" | "config" | "missing" =
     typeof envToken === "string" && envToken.length > 0
       ? "env"
-      : typeof config.githubToken === "string" && config.githubToken.length > 0
+      : selectGitHubToken(config) !== null
         ? "config"
         : "missing";
 

--- a/src/github-token-safety.ts
+++ b/src/github-token-safety.ts
@@ -16,7 +16,11 @@ export const GITHUB_TOKEN_MASK = "[redacted-github-token]";
  * Mask a GitHub token for display. Always returns the fixed mask; never
  * reveals any characters of the original token (not even a prefix/suffix).
  */
-export function maskGitHubToken(_token: string): string {
+export function maskGitHubToken(token: string): string {
+  // The parameter is part of the documented signature (callers pass the
+  // token being masked) but masking always returns the fixed constant and
+  // never derives output from the input, so nothing else reads it here.
+  void token;
   return GITHUB_TOKEN_MASK;
 }
 

--- a/src/github-token-safety.ts
+++ b/src/github-token-safety.ts
@@ -1,0 +1,59 @@
+import { isRecord } from "./type-guards.js";
+
+/**
+ * Reusable safety helpers for handling a GitHub token value.
+ *
+ * A GitHub token must never appear in stdout/stderr/logs/doctor output. This
+ * module centralizes masking and status-description logic so every caller
+ * (init guidance, doctor checks, config display) applies the same rules
+ * instead of hand-rolling redaction.
+ */
+
+/** Fixed indicator shown in place of any real token value. */
+export const GITHUB_TOKEN_MASK = "[redacted-github-token]";
+
+/**
+ * Mask a GitHub token for display. Always returns the fixed mask; never
+ * reveals any characters of the original token (not even a prefix/suffix).
+ */
+export function maskGitHubToken(_token: string): string {
+  return GITHUB_TOKEN_MASK;
+}
+
+/**
+ * Doctor-facing status text describing where (if anywhere) a GitHub token
+ * was found. Never includes the token value itself.
+ */
+export function describeGitHubTokenStatus(
+  source: "env" | "config" | "missing"
+): string {
+  switch (source) {
+    case "env":
+      return "set (GITHUB_TOKEN env)";
+    case "config":
+      return "set (config file, plaintext — prefer GITHUB_TOKEN env)";
+    case "missing":
+      return "not set";
+  }
+}
+
+/**
+ * Return a shallow clone of `config` with a string `githubToken` field
+ * replaced by the fixed mask. Non-record inputs (including arrays) and
+ * records without a string `githubToken` are passed through unchanged
+ * (unmutated). Never mutates the input.
+ */
+export function redactGitHubTokenForDisplay<T>(config: T): T {
+  if (!isRecord(config)) {
+    return config;
+  }
+
+  if (typeof config.githubToken !== "string") {
+    return config;
+  }
+
+  return {
+    ...config,
+    githubToken: maskGitHubToken(config.githubToken)
+  } as T;
+}

--- a/src/global-config.ts
+++ b/src/global-config.ts
@@ -24,6 +24,16 @@ export interface GlobalConfig {
   rawRetentionDays: number;
   captionProjectionTokenBudget: number;
   sources: SourceConfigMap;
+  /**
+   * Optional GitHub token used by GitHub-sourced collection.
+   *
+   * Not managed by `init` — the user adds it by hand. The `GITHUB_TOKEN`
+   * environment variable is the recommended way to supply it; storing it
+   * here as plaintext in config.json is discouraged (readable by anything
+   * with filesystem access, easy to accidentally commit/share). `doctor`
+   * only ever reports a masked status (env / config-plaintext / not-set)
+   * and never surfaces the value itself.
+   */
   githubToken?: string;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -258,3 +258,9 @@ export type {
   RecordManualNoteOptions,
   RecordManualNoteResult
 } from "./note-command.js";
+export {
+  describeGitHubTokenStatus,
+  GITHUB_TOKEN_MASK,
+  maskGitHubToken,
+  redactGitHubTokenForDisplay
+} from "./github-token-safety.js";

--- a/src/init-command.ts
+++ b/src/init-command.ts
@@ -28,7 +28,13 @@ export type InitCommandOptions = {
 export type InitCommandResult = {
   created: true;
   config: GlobalConfig;
+  guidance: string[];
 };
+
+const githubTokenGuidance: string[] = [
+  "GitHub token: set the GITHUB_TOKEN environment variable rather than storing it in config.",
+  "init does not manage githubToken; storing it as plaintext in config.json is discouraged — prefer GITHUB_TOKEN."
+];
 
 const defaultAnswers = {
   draftRoot: "~/Uncommitted/drafts",
@@ -98,7 +104,7 @@ export async function runInitCommand(
   await writeJsonIfMissing(paths.projectsFile, { schemaVersion: 1, projects: [] });
   await writeJsonIfMissing(paths.formatHistoryFile, { schemaVersion: 1, formats: [] });
 
-  return { created: true, config };
+  return { created: true, config, guidance: githubTokenGuidance };
 }
 
 function parseInitArgs(args: string[]): boolean {

--- a/tests/doctor-command.test.ts
+++ b/tests/doctor-command.test.ts
@@ -339,6 +339,38 @@ describe("doctor command", () => {
       expect(tokenCheck?.status).toBe("pass");
       expect(tokenCheck?.message.toLowerCase()).toContain("not set");
     });
+
+    it("treats an empty-string githubToken in config as not-set, matching selectGitHubToken semantics", async () => {
+      const homeDir = await createHomeWithConfig({ githubToken: "" });
+
+      const report = await createDoctorReport({
+        homeDir,
+        env: {},
+        nodeVersion: "v22.13.0",
+        checkCommand: async () => ({ ok: true, detail: "git version 2.49.0" })
+      });
+
+      const tokenCheck = report.checks.find((c) => c.id === "github-token");
+      expect(tokenCheck).toBeDefined();
+      expect(tokenCheck?.status).toBe("pass");
+      expect(tokenCheck?.message.toLowerCase()).toContain("not set");
+    });
+
+    it("treats an empty-string GITHUB_TOKEN env var as not-set and falls back to config", async () => {
+      const homeDir = await createHomeWithConfig({ githubToken: sampleToken });
+
+      const report = await createDoctorReport({
+        homeDir,
+        env: { GITHUB_TOKEN: "" },
+        nodeVersion: "v22.13.0",
+        checkCommand: async () => ({ ok: true, detail: "git version 2.49.0" })
+      });
+
+      const tokenCheck = report.checks.find((c) => c.id === "github-token");
+      expect(tokenCheck).toBeDefined();
+      expect(tokenCheck?.status).toBe("warn");
+      expect(tokenCheck?.message.toLowerCase()).toContain("config");
+    });
   });
 });
 
@@ -367,7 +399,9 @@ async function createHomeWithConfig(
       aiProvider: overrides.aiProvider ?? "none",
       persona: "wry coworker",
       roastLevel: 2,
-      ...(overrides.githubToken ? { githubToken: overrides.githubToken } : {})
+      ...(overrides.githubToken !== undefined
+        ? { githubToken: overrides.githubToken }
+        : {})
     })}\n`,
     "utf8"
   );

--- a/tests/doctor-command.test.ts
+++ b/tests/doctor-command.test.ts
@@ -279,10 +279,75 @@ describe("doctor command", () => {
     const legacyCheck = report.checks.find((c) => c.id === "directory-legacy-exports");
     expect(legacyCheck).toBeUndefined();
   });
+
+  describe("github token check", () => {
+    const sampleToken = "ghp_superSecretTokenValue1234567890";
+
+    it("shows a config-plaintext status and never leaks the raw token when set only in config", async () => {
+      const homeDir = await createHomeWithConfig({ githubToken: sampleToken });
+
+      const report = await createDoctorReport({
+        homeDir,
+        env: {},
+        nodeVersion: "v22.13.0",
+        checkCommand: async () => ({ ok: true, detail: "git version 2.49.0" })
+      });
+
+      const tokenCheck = report.checks.find((c) => c.id === "github-token");
+      expect(tokenCheck).toBeDefined();
+      expect(tokenCheck?.status).toBe("warn");
+      expect(tokenCheck?.message.toLowerCase()).toContain("config");
+      expect(tokenCheck?.message.toLowerCase()).toContain("plaintext");
+
+      const rendered = formatDoctorReport(report);
+      expect(rendered).not.toContain(sampleToken);
+      expect(JSON.stringify(report)).not.toContain(sampleToken);
+    });
+
+    it("shows an env status when GITHUB_TOKEN is set, regardless of config", async () => {
+      const homeDir = await createHomeWithConfig({ githubToken: sampleToken });
+
+      const report = await createDoctorReport({
+        homeDir,
+        env: { GITHUB_TOKEN: sampleToken },
+        nodeVersion: "v22.13.0",
+        checkCommand: async () => ({ ok: true, detail: "git version 2.49.0" })
+      });
+
+      const tokenCheck = report.checks.find((c) => c.id === "github-token");
+      expect(tokenCheck).toBeDefined();
+      expect(tokenCheck?.status).toBe("pass");
+      expect(tokenCheck?.message.toLowerCase()).toContain("env");
+
+      const rendered = formatDoctorReport(report);
+      expect(rendered).not.toContain(sampleToken);
+      expect(JSON.stringify(report)).not.toContain(sampleToken);
+    });
+
+    it("shows a not-set status when neither env nor config has a token", async () => {
+      const homeDir = await createHomeWithConfig();
+
+      const report = await createDoctorReport({
+        homeDir,
+        env: {},
+        nodeVersion: "v22.13.0",
+        checkCommand: async () => ({ ok: true, detail: "git version 2.49.0" })
+      });
+
+      const tokenCheck = report.checks.find((c) => c.id === "github-token");
+      expect(tokenCheck).toBeDefined();
+      expect(tokenCheck?.status).toBe("pass");
+      expect(tokenCheck?.message.toLowerCase()).toContain("not set");
+    });
+  });
 });
 
 async function createHomeWithConfig(
-  overrides: Partial<{ aiProvider: string; draftRoot: string }> = {}
+  overrides: Partial<{
+    aiProvider: string;
+    draftRoot: string;
+    githubToken: string;
+  }> = {}
 ): Promise<string> {
   const homeDir = await mkdtemp(join(tmpdir(), "uncommitted-doctor-"));
   const configDir = join(homeDir, ".uncommitted");
@@ -301,7 +366,8 @@ async function createHomeWithConfig(
       scheduleTime: "23:30",
       aiProvider: overrides.aiProvider ?? "none",
       persona: "wry coworker",
-      roastLevel: 2
+      roastLevel: 2,
+      ...(overrides.githubToken ? { githubToken: overrides.githubToken } : {})
     })}\n`,
     "utf8"
   );

--- a/tests/github-token-safety.test.ts
+++ b/tests/github-token-safety.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import {
+  describeGitHubTokenStatus,
+  GITHUB_TOKEN_MASK,
+  maskGitHubToken,
+  redactGitHubTokenForDisplay
+} from "../src/github-token-safety.js";
+
+describe("github-token-safety", () => {
+  describe("maskGitHubToken", () => {
+    it("returns the fixed mask without revealing the original token", () => {
+      const sampleToken = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+      const masked = maskGitHubToken(sampleToken);
+
+      expect(masked).toBe(GITHUB_TOKEN_MASK);
+      expect(masked).not.toContain(sampleToken);
+      expect(masked.includes("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")).toBe(false);
+    });
+  });
+
+  describe("describeGitHubTokenStatus", () => {
+    it("returns distinct, value-free strings per source", () => {
+      const envStatus = describeGitHubTokenStatus("env");
+      const configStatus = describeGitHubTokenStatus("config");
+      const missingStatus = describeGitHubTokenStatus("missing");
+
+      expect(envStatus).toContain("GITHUB_TOKEN");
+      expect(configStatus.toLowerCase()).toContain("plaintext");
+      expect(missingStatus.toLowerCase()).toContain("not set");
+
+      const statuses = [envStatus, configStatus, missingStatus];
+      expect(new Set(statuses).size).toBe(3);
+    });
+  });
+
+  describe("redactGitHubTokenForDisplay", () => {
+    it("replaces githubToken with the mask and preserves sibling keys", () => {
+      const config = {
+        schemaVersion: 1,
+        draftRoot: "~/Uncommitted/drafts",
+        githubToken: "ghp_supersecrettoken"
+      };
+
+      const redacted = redactGitHubTokenForDisplay(config);
+
+      expect(redacted).toEqual({
+        schemaVersion: 1,
+        draftRoot: "~/Uncommitted/drafts",
+        githubToken: GITHUB_TOKEN_MASK
+      });
+    });
+
+    it("does not mutate the input object", () => {
+      const config = { githubToken: "ghp_supersecrettoken", other: "value" };
+      const original = { ...config };
+
+      redactGitHubTokenForDisplay(config);
+
+      expect(config).toEqual(original);
+    });
+
+    it("passes through non-record values unchanged", () => {
+      expect(redactGitHubTokenForDisplay(42)).toBe(42);
+      expect(redactGitHubTokenForDisplay(null)).toBe(null);
+      expect(redactGitHubTokenForDisplay("a string")).toBe("a string");
+      expect(redactGitHubTokenForDisplay([1, 2, 3])).toEqual([1, 2, 3]);
+    });
+
+    it("passes through records without a string githubToken unchanged in shape", () => {
+      const config = { schemaVersion: 1, draftRoot: "~/x" };
+
+      const redacted = redactGitHubTokenForDisplay(config);
+
+      expect(redacted).toEqual(config);
+    });
+  });
+});

--- a/tests/init-command.test.ts
+++ b/tests/init-command.test.ts
@@ -192,6 +192,22 @@ describe("init command", () => {
     ).rejects.toThrow("Schedule time must use 24-hour HH:mm format.");
   });
 
+  it("surfaces env-first githubToken guidance and a plaintext warning", async () => {
+    const homeDir = await mkTestHome("github-token-guidance");
+
+    const result = await runInitCommand([], { homeDir });
+
+    expect(result.guidance).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("GITHUB_TOKEN"),
+        expect.stringMatching(/plaintext/i)
+      ])
+    );
+    expect(
+      result.guidance.some((line) => /plaintext/i.test(line) && /init/i.test(line))
+    ).toBe(true);
+  });
+
   it("rejects roast levels outside the MVP range", async () => {
     const homeDir = await mkTestHome("roast");
 


### PR DESCRIPTION
🤖 **Auto-generated by Uncommitted Builder (Routine B v2)**

## Parent issue
[UNC-173: Harden githubToken handling: env-first guidance + redaction](https://linear.app/sangchu/issue/UNC-173)

## Sub-issues progress
- [x] UNC-179 [T1]: Reusable githubToken masking/redaction helper (✅ done 2026-07-02)
- [x] UNC-180 [T2]: env-first guidance + plaintext-config warning in init output (✅ done 2026-07-02)
- [x] UNC-181 [T3]: Mask githubToken in doctor + redact across config-display paths (✅ done 2026-07-02)
- [x] UNC-182 [T4]: Document githubToken handling in schema + README (✅ done 2026-07-02)

## What changed
- **T1** `src/github-token-safety.ts` (new): `GITHUB_TOKEN_MASK`, `maskGitHubToken()`, `describeGitHubTokenStatus(source)`, `redactGitHubTokenForDisplay(config)` — a token value never leaks; config objects can be shallow-cloned with the token masked. Exported from `src/index.ts`.
- **T2** `src/init-command.ts` + `src/cli.ts`: `InitCommandResult.guidance` (additive) carries two notes — recommend `GITHUB_TOKEN` env, and warn that plaintext-in-config is discouraged / `init` does not manage `githubToken`. Printed after "Initialized…". Prompts/refusal/config-write unchanged.
- **T3** `src/doctor-command.ts`: `doctor` now reports a masked GitHub-token status (env → pass, config-plaintext → warn, missing → pass) via the T1 helper; the raw token value never appears in output. Grep sweep of `src/` found no site that stringifies/logs the whole config object (doctor's existing `detail` prints only the file path).
- **T4** `src/global-config.ts` + `README.md`: schema comment and README note document env-first handling.

## Status
- Branch: `claude/UNC-173-harden-githubtoken`
- Tests: ✅ targeted 38/38 (github-token-safety, init-command, doctor-command); full suite 731 passed / 1 skipped / **1 pre-existing flake** (`carousel-renderer-smoke` — a Playwright/Chromium smoke test that times out only under full-suite parallel load; **unmodified by this branch** and passes cleanly in isolation)
- Build: ✅  ·  Type check: ✅  ·  Lint: ✅  ·  `git diff --check`: ✅

## Notes
- **Scope reduction on T4**: the sub also mentioned a "CLAUDE.md Safety section" note. `CLAUDE.md` is a symlink to `AGENTS.md`, a locked file per the Builder guardrails — so that edit was intentionally **skipped**. The schema-comment + README parts of T4 are delivered.
- No lockfile / `.env` / `AGENTS.md` / `CLAUDE.md` changes.
- No auto-publish code introduced.

## Review checklist
- [ ] Review each sub-issue's commits separately (T1 `b15dce8`+`514cef0`, T2 `2151f15`, T3 `22a4599`, T4 `e41bbb2`)
- [ ] Verify TDD test coverage (raw-token-absence assertions in doctor + safety tests)
- [ ] Confirm no lockfile changes
- [ ] Run `pnpm install && pnpm test && pnpm build` locally
- [ ] Confirm no auto-publish code introduced

---
이 PR은 자동 생성되었습니다. 머지 전 사람의 리뷰가 반드시 필요합니다.
