### PR TITLE
🤖 OpenAI 429 insufficient_quota billing classifier (UNC-189)

### DIFF
--- a/src/ai-provider.ts
+++ b/src/ai-provider.ts
@@ -2,6 +2,10 @@ import process from "node:process";
 import { resolveConfigPaths } from "./config-paths.js";
 import { isRoastLevel, loadGlobalConfig } from "./global-config.js";
 import { isRecord } from "./type-guards.js";
+import {
+  BILLING_429_MESSAGE,
+  classify429ResponseBody
+} from "./provider-429-classifier.js";
 
 export type JsonPrimitive = string | number | boolean | null;
 export type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
@@ -416,7 +420,7 @@ class OpenAiCompatibleProvider implements AiProvider {
       });
 
       if (!response.ok) {
-        throwProviderHttpError(response.status);
+        await throwProviderHttpError(response);
       }
 
       return { responseJson: extractChatCompletionContent(await readResponseJson(response)) };
@@ -476,7 +480,7 @@ class AnthropicProvider implements AiProvider {
       });
 
       if (!response.ok) {
-        throwProviderHttpError(response.status);
+        await throwProviderHttpError(response);
       }
 
       return {
@@ -744,7 +748,11 @@ async function readResponseJson(
   }
 }
 
-function throwProviderHttpError(status: number): never {
+async function throwProviderHttpError(
+  response: AiProviderHttpResponse
+): Promise<never> {
+  const status = response.status;
+
   if (status === 401 || status === 403) {
     throw new AiGenerationError(
       "AI provider authentication failed. Check API key.",
@@ -760,6 +768,10 @@ function throwProviderHttpError(status: number): never {
   }
 
   if (status === 429) {
+    if ((await classify429Response(response)) === "billing") {
+      throw new AiGenerationError(BILLING_429_MESSAGE, "provider-failed");
+    }
+
     throw new AiGenerationError(
       "AI provider rate limit exceeded. Try again later.",
       "provider-failed"
@@ -770,6 +782,20 @@ function throwProviderHttpError(status: number): never {
     "AI provider failed. Check provider configuration.",
     "provider-failed"
   );
+}
+
+async function classify429Response(
+  response: AiProviderHttpResponse
+): Promise<"billing" | "generic"> {
+  let body: unknown;
+
+  try {
+    body = await response.json();
+  } catch {
+    return "generic";
+  }
+
+  return classify429ResponseBody(body);
 }
 
 function throwInvalidProviderJson(): never {

--- a/src/provider-429-classifier.ts
+++ b/src/provider-429-classifier.ts
@@ -11,6 +11,8 @@
  * Call sites keep their own verbatim generic rate-limit message.
  */
 
+import { isRecord } from "./type-guards.js";
+
 export type Provider429Classification = "billing" | "generic";
 
 /**
@@ -29,10 +31,6 @@ const BILLING_429_KEYS: ReadonlySet<string> = new Set([
  */
 export const BILLING_429_MESSAGE =
   "AI provider credit/billing quota exhausted. Check your plan and billing details.";
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 /**
  * Classify a 429 response body as billing-class vs generic rate-limit.

--- a/src/provider-429-classifier.ts
+++ b/src/provider-429-classifier.ts
@@ -1,0 +1,62 @@
+/**
+ * Pure classifier for HTTP 429 response bodies from OpenAI-compatible /
+ * Anthropic providers.
+ *
+ * A 429 can mean either a temporary rate limit ("slow down, retry later") or
+ * billing/quota exhaustion ("out of credit, waiting will not help"). The latter
+ * must NOT be surfaced as a temporary rate-limit message, which previously
+ * misled diagnosis.
+ *
+ * This module owns the billing-key set and the shared English billing message.
+ * Call sites keep their own verbatim generic rate-limit message.
+ */
+
+export type Provider429Classification = "billing" | "generic";
+
+/**
+ * Provider `error.type` / `error.code` values that indicate billing/quota
+ * exhaustion rather than a temporary rate limit.
+ */
+const BILLING_429_KEYS: ReadonlySet<string> = new Set([
+  "insufficient_quota",
+  "billing_hard_limit_reached"
+]);
+
+/**
+ * Shared, user-facing message for billing-class 429 responses. Names a
+ * credit/billing-quota cause and deliberately avoids implying "just wait and
+ * retry". Contains no raw provider internals, secrets, or tokens.
+ */
+export const BILLING_429_MESSAGE =
+  "AI provider credit/billing quota exhausted. Check your plan and billing details.";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Classify a 429 response body as billing-class vs generic rate-limit.
+ *
+ * Matches billing if EITHER `error.type` OR `error.code` is in the billing key
+ * set. Any parse failure, missing/non-object error, or unrecognized type & code
+ * safely falls back to "generic".
+ */
+export function classify429ResponseBody(
+  body: unknown
+): Provider429Classification {
+  if (!isRecord(body) || !isRecord(body.error)) {
+    return "generic";
+  }
+
+  const { type, code } = body.error;
+
+  if (typeof type === "string" && BILLING_429_KEYS.has(type)) {
+    return "billing";
+  }
+
+  if (typeof code === "string" && BILLING_429_KEYS.has(code)) {
+    return "billing";
+  }
+
+  return "generic";
+}

--- a/src/visual-assets.ts
+++ b/src/visual-assets.ts
@@ -17,6 +17,10 @@ import {
   writeDraftArtifactBinary
 } from "./draft-storage.js";
 import { checkDraftSafety } from "./safety-report.js";
+import {
+  BILLING_429_MESSAGE,
+  classify429ResponseBody
+} from "./provider-429-classifier.js";
 
 export type VisualAssetFallbackState =
   | "none"
@@ -273,7 +277,7 @@ class OpenAiImageAssetProvider implements ImageAssetProvider {
       });
 
       if (!response.ok) {
-        throwOpenAiImageHttpError(response.status);
+        await throwOpenAiImageHttpError(response);
       }
 
       return {
@@ -387,7 +391,11 @@ function decodeOpenAiImageResponse(value: unknown): Uint8Array {
   return Buffer.from(value.data[0].b64_json, "base64");
 }
 
-function throwOpenAiImageHttpError(status: number): never {
+async function throwOpenAiImageHttpError(
+  response: AiProviderHttpResponse
+): Promise<never> {
+  const status = response.status;
+
   if (status === 401 || status === 403) {
     throw new VisualAssetGenerationError(
       "Image provider authentication failed. Check API key.",
@@ -403,6 +411,10 @@ function throwOpenAiImageHttpError(status: number): never {
   }
 
   if (status === 429) {
+    if ((await classify429Response(response)) === "billing") {
+      throw new VisualAssetGenerationError(BILLING_429_MESSAGE, "provider-failed");
+    }
+
     throw new VisualAssetGenerationError(
       "Image provider rate limit exceeded. Try again later.",
       "provider-failed"
@@ -413,6 +425,20 @@ function throwOpenAiImageHttpError(status: number): never {
     "Visual generation failed. Check image provider configuration.",
     "provider-failed"
   );
+}
+
+async function classify429Response(
+  response: AiProviderHttpResponse
+): Promise<"billing" | "generic"> {
+  let body: unknown;
+
+  try {
+    body = await response.json();
+  } catch {
+    return "generic";
+  }
+
+  return classify429ResponseBody(body);
 }
 
 function resolveProviderTimeoutMs(

--- a/tests/ai-provider.test.ts
+++ b/tests/ai-provider.test.ts
@@ -453,6 +453,108 @@ describe("AI provider abstraction", () => {
     });
   });
 
+  it("reports a billing-class 429 (insufficient_quota) distinctly, not as a temporary rate limit", async () => {
+    const provider = createAiProvider(
+      {
+        provider: "openai",
+        persona: "dry reviewer",
+        roastLevel: 3
+      },
+      {
+        env: { OPENAI_API_KEY: "sk-test-secret" },
+        transport: createTransport(
+          [],
+          { error: { type: "insufficient_quota", code: "insufficient_quota" } },
+          429
+        )
+      }
+    );
+
+    await expect(
+      generateStructured(
+        provider,
+        createAiGenerationRequest({
+          task: "draft",
+          instructions: "Return JSON.",
+          summary: createQuietSummary()
+        })
+      )
+    ).rejects.toMatchObject({
+      code: "provider-failed",
+      exitCode: 4,
+      message:
+        "AI provider credit/billing quota exhausted. Check your plan and billing details."
+    });
+  });
+
+  it("keeps the generic 429 message verbatim for a plain rate-limit body", async () => {
+    const provider = createAiProvider(
+      {
+        provider: "openai",
+        persona: "dry reviewer",
+        roastLevel: 3
+      },
+      {
+        env: { OPENAI_API_KEY: "sk-test-secret" },
+        transport: createTransport(
+          [],
+          { error: { type: "rate_limit_exceeded" } },
+          429
+        )
+      }
+    );
+
+    await expect(
+      generateStructured(
+        provider,
+        createAiGenerationRequest({
+          task: "draft",
+          instructions: "Return JSON.",
+          summary: createQuietSummary()
+        })
+      )
+    ).rejects.toMatchObject({
+      code: "provider-failed",
+      exitCode: 4,
+      message: "AI provider rate limit exceeded. Try again later."
+    });
+  });
+
+  it("falls back to the generic 429 message when the 429 body cannot be parsed", async () => {
+    const provider = createAiProvider(
+      {
+        provider: "openai",
+        persona: "dry reviewer",
+        roastLevel: 3
+      },
+      {
+        env: { OPENAI_API_KEY: "sk-test-secret" },
+        transport: async () => ({
+          ok: false,
+          status: 429,
+          json: async () => {
+            throw new Error("not json");
+          }
+        })
+      }
+    );
+
+    await expect(
+      generateStructured(
+        provider,
+        createAiGenerationRequest({
+          task: "draft",
+          instructions: "Return JSON.",
+          summary: createQuietSummary()
+        })
+      )
+    ).rejects.toMatchObject({
+      code: "provider-failed",
+      exitCode: 4,
+      message: "AI provider rate limit exceeded. Try again later."
+    });
+  });
+
   it("normalizes Anthropic timeout via env override", async () => {
     const provider = createAiProvider(
       {

--- a/tests/ai-provider.test.ts
+++ b/tests/ai-provider.test.ts
@@ -487,6 +487,40 @@ describe("AI provider abstraction", () => {
     });
   });
 
+  it("reports a billing-class 429 recognized via error.code only (billing_hard_limit_reached)", async () => {
+    const provider = createAiProvider(
+      {
+        provider: "openai",
+        persona: "dry reviewer",
+        roastLevel: 3
+      },
+      {
+        env: { OPENAI_API_KEY: "sk-test-secret" },
+        transport: createTransport(
+          [],
+          { error: { code: "billing_hard_limit_reached" } },
+          429
+        )
+      }
+    );
+
+    await expect(
+      generateStructured(
+        provider,
+        createAiGenerationRequest({
+          task: "draft",
+          instructions: "Return JSON.",
+          summary: createQuietSummary()
+        })
+      )
+    ).rejects.toMatchObject({
+      code: "provider-failed",
+      exitCode: 4,
+      message:
+        "AI provider credit/billing quota exhausted. Check your plan and billing details."
+    });
+  });
+
   it("keeps the generic 429 message verbatim for a plain rate-limit body", async () => {
     const provider = createAiProvider(
       {

--- a/tests/provider-429-classifier.test.ts
+++ b/tests/provider-429-classifier.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  BILLING_429_MESSAGE,
+  classify429ResponseBody
+} from "../src/provider-429-classifier.js";
+
+describe("429 billing-vs-rate-limit classifier", () => {
+  it("classifies insufficient_quota (error.type) as billing", () => {
+    expect(
+      classify429ResponseBody({ error: { type: "insufficient_quota" } })
+    ).toBe("billing");
+  });
+
+  it("classifies billing_hard_limit_reached (error.type) as billing", () => {
+    expect(
+      classify429ResponseBody({ error: { type: "billing_hard_limit_reached" } })
+    ).toBe("billing");
+  });
+
+  it("classifies a billing key surfaced via error.code as billing", () => {
+    expect(
+      classify429ResponseBody({
+        error: { type: "some_other_type", code: "insufficient_quota" }
+      })
+    ).toBe("billing");
+  });
+
+  it("classifies a plain rate-limit body as generic", () => {
+    expect(
+      classify429ResponseBody({
+        error: { type: "rate_limit_exceeded", code: "rate_limit_exceeded" }
+      })
+    ).toBe("generic");
+  });
+
+  it("falls back to generic on a null / non-object / missing-error body", () => {
+    expect(classify429ResponseBody(null)).toBe("generic");
+    expect(classify429ResponseBody(undefined)).toBe("generic");
+    expect(classify429ResponseBody("not json")).toBe("generic");
+    expect(classify429ResponseBody(42)).toBe("generic");
+    expect(classify429ResponseBody({})).toBe("generic");
+    expect(classify429ResponseBody({ error: null })).toBe("generic");
+    expect(classify429ResponseBody({ error: { type: 123 } })).toBe("generic");
+  });
+
+  it("exposes a billing message that names a credit/billing cause and does not imply retry", () => {
+    expect(BILLING_429_MESSAGE.toLowerCase()).toContain("billing");
+    expect(BILLING_429_MESSAGE.toLowerCase()).not.toContain("try again later");
+  });
+});

--- a/tests/visual-assets.test.ts
+++ b/tests/visual-assets.test.ts
@@ -154,6 +154,109 @@ describe("visual asset generation", () => {
     );
   });
 
+  it("reports a billing-class 429 (insufficient_quota) distinctly, not as a temporary rate limit", async () => {
+    const calls: Array<{ url: string; request: AiProviderHttpRequest }> = [];
+    const provider = createImageAssetProvider(
+      {
+        provider: "openai",
+        persona: "wry coworker",
+        roastLevel: 2
+      },
+      {
+        env: { OPENAI_API_KEY: "sk-test-secret" },
+        transport: createTransport(
+          calls,
+          { error: { type: "insufficient_quota" } },
+          429
+        )
+      }
+    );
+
+    await expect(
+      provider?.generateImageAsset({
+        schemaVersion: 1,
+        slideIndex: 1,
+        assetSlotId: "slide-01-visual",
+        prompt: "safe visual prompt",
+        promptSummary: "safe visual prompt"
+      })
+    ).rejects.toEqual(
+      new VisualAssetGenerationError(
+        "AI provider credit/billing quota exhausted. Check your plan and billing details.",
+        "provider-failed"
+      )
+    );
+  });
+
+  it("keeps the generic image 429 message verbatim for a plain rate-limit body", async () => {
+    const calls: Array<{ url: string; request: AiProviderHttpRequest }> = [];
+    const provider = createImageAssetProvider(
+      {
+        provider: "openai",
+        persona: "wry coworker",
+        roastLevel: 2
+      },
+      {
+        env: { OPENAI_API_KEY: "sk-test-secret" },
+        transport: createTransport(
+          calls,
+          { error: { type: "rate_limit_exceeded" } },
+          429
+        )
+      }
+    );
+
+    await expect(
+      provider?.generateImageAsset({
+        schemaVersion: 1,
+        slideIndex: 1,
+        assetSlotId: "slide-01-visual",
+        prompt: "safe visual prompt",
+        promptSummary: "safe visual prompt"
+      })
+    ).rejects.toEqual(
+      new VisualAssetGenerationError(
+        "Image provider rate limit exceeded. Try again later.",
+        "provider-failed"
+      )
+    );
+  });
+
+  it("falls back to the generic image 429 message when the 429 body cannot be parsed", async () => {
+    const provider = createImageAssetProvider(
+      {
+        provider: "openai",
+        persona: "wry coworker",
+        roastLevel: 2
+      },
+      {
+        env: { OPENAI_API_KEY: "sk-test-secret" },
+        transport: async () => ({
+          ok: false,
+          status: 429,
+          json: async () => {
+            throw new Error("not json");
+          }
+        })
+      }
+    );
+
+    await expect(
+      provider?.generateImageAsset({
+        schemaVersion: 1,
+        slideIndex: 1,
+        assetSlotId: "slide-01-visual",
+        prompt: "safe visual prompt",
+        promptSummary: "safe visual prompt"
+      })
+    ).rejects.toEqual(
+      new VisualAssetGenerationError(
+        "Image provider rate limit exceeded. Try again later.",
+        "provider-failed"
+      )
+    );
+  });
+
   it("writes deterministic placeholder PNG assets with stable slide filenames", async () => {
     const revision = await createTestRevision();
     const cards = createCarouselHtmlCards(createStoryDraft());


### PR DESCRIPTION
🤖 **Auto-generated by Uncommitted Builder (Routine B v2)**

## Parent issue
[UNC-189: OpenAI 429 `insufficient_quota`를 "rate limit exceeded"로 뭉뚱그려 표기 — 빌링 고갈 원인이 가려짐](https://linear.app/sangchu/issue/UNC-189)

## Sub-issues progress
- [x] UNC-191: [T1] Extract a pure 429 billing-vs-rate-limit classification helper (✅ done)
- [x] UNC-192: [T2] Apply the 429 classifier at both provider call sites (text and image) (✅ done)

## What changed
- New pure module `src/provider-429-classifier.ts` — `classify429ResponseBody` inspects `error.type`/`error.code` against a billing set (`insufficient_quota`, `billing_hard_limit_reached`) and returns a `'billing' | 'generic'` discriminant, with safe generic fallback on unparseable/unknown/null bodies. Owns the shared `BILLING_429_MESSAGE`.
- `src/ai-provider.ts` (`throwProviderHttpError`) and `src/visual-assets.ts` (`throwOpenAiImageHttpError`) now thread the 429 response body through the classifier at both text call sites (OpenAI-like + Anthropic) and the image call site. Billing-class 429 emits a credit/billing-exhaustion message instead of the misleading "rate limit exceeded. Try again later."; generic 429 keeps each site's existing message **verbatim**.
- Exit code 4 (AI generation) and the `provider-failed` error kinds are preserved; only diagnostic message content is strengthened. The body is read only inside the 429 branch (single-consume respected).

## Status
- Branch: `claude/UNC-189-openai-429-billing-classifier`
- Tests: ✅ 745/747 (vitest; 1 skipped; the sole cold-start failure is the pre-existing `carousel-renderer-smoke` Playwright flake — passes in 600ms on warm/isolated re-run, unrelated to these files)
- Build: ✅
- Type check: ✅
- Lint: ✅

## TDD trail
UNC-191:
- Attempt 1: ✅ success (6 unit tests: insufficient_quota / billing_hard_limit_reached / error.code match / generic rate-limit / unparseable / null)
UNC-192:
- Attempt 1: ✅ success (3+3 tests across ai-provider & visual-assets: billing-429, generic-429 verbatim, parse-failure fallback)

## Notes
- No new env vars, no dependency/lockfile changes.
- T1/T2 message-ownership reconciliation: the classifier owns only the shared billing string; each call site keeps its own site-specific generic message verbatim (satisfies UNC-192's per-site requirement).

## Review checklist
- [ ] Review each sub-issue's commits separately
- [ ] Verify TDD test coverage
- [ ] Confirm no lockfile changes (none introduced)
- [ ] Run `pnpm install && pnpm test && pnpm build` locally
- [ ] Confirm no auto-publish code introduced

---
이 PR은 자동 생성되었습니다. 머지 전 사람의 리뷰가 반드시 필요합니다.
