### PR TITLE
🤖 Wire scheduleTime config key into schedule install/status (UNC-174)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -284,12 +284,21 @@ async function runSchedule(
       if (subcommandArgs[i] === "--time" && i + 1 < subcommandArgs.length) {
         scheduleTime = subcommandArgs[i + 1];
         i++;
+      } else {
+        // Reject malformed/unknown arguments outright: only a genuinely
+        // argument-free invocation may fall back to config.scheduleTime,
+        // otherwise a typo would silently reschedule with the stored time.
+        if (subcommandArgs[i] !== "--time") {
+          io.stderr(`Unknown argument: ${subcommandArgs[i]}`);
+        }
+        io.stderr("Usage: uncommitted schedule install --time HH:mm");
+        return 1;
       }
     }
 
     if (!scheduleTime) {
-      // --time omitted: fall back to config.scheduleTime so the value the user
-      // set at `init` is actually honored instead of being write-only.
+      // --time omitted entirely: fall back to config.scheduleTime so the value
+      // the user set at `init` is actually honored instead of being write-only.
       const configFile = resolveConfigPaths({
         homeDir: options.homeDir
       }).configFile;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,7 +40,11 @@ import {
   type ProjectRecord
 } from "./project-registry.js";
 import { resolveConfigPaths } from "./config-paths.js";
-import { loadGlobalConfig, selectDraftRoot } from "./global-config.js";
+import {
+  loadGlobalConfig,
+  selectDraftRoot,
+  selectScheduleTime
+} from "./global-config.js";
 import {
   loadSourceConfig,
   SourceConfigError,
@@ -284,6 +288,18 @@ async function runSchedule(
     }
 
     if (!scheduleTime) {
+      // --time omitted: fall back to config.scheduleTime so the value the user
+      // set at `init` is actually honored instead of being write-only.
+      const configFile = resolveConfigPaths({
+        homeDir: options.homeDir
+      }).configFile;
+      const outcome = await loadGlobalConfig(configFile);
+      if (outcome.status === "ok") {
+        scheduleTime = selectScheduleTime(outcome.value);
+      }
+    }
+
+    if (!scheduleTime) {
       io.stderr("Usage: uncommitted schedule install --time HH:mm");
       return 1;
     }
@@ -342,6 +358,33 @@ async function runSchedule(
 
     io.stdout(`Scheduler: installed, ${loadedLabel}`);
     io.stdout(`Plist path: ${result.plistPath}`);
+
+    // Surface the stored config time vs the actual installed launchd time.
+    // Degrade gracefully: only compare when both are readable.
+    const configFile = resolveConfigPaths({ homeDir: options.homeDir }).configFile;
+    const configOutcome = await loadGlobalConfig(configFile);
+    const configScheduleTime =
+      configOutcome.status === "ok"
+        ? selectScheduleTime(configOutcome.value)
+        : undefined;
+    const installedScheduleTime = result.installedScheduleTime;
+
+    if (
+      configScheduleTime !== undefined &&
+      installedScheduleTime !== undefined &&
+      configScheduleTime !== installedScheduleTime
+    ) {
+      io.stdout(`Installed schedule time: ${installedScheduleTime}`);
+      io.stdout(`Config schedule time: ${configScheduleTime}`);
+      io.stdout(
+        "Warning: installed schedule time diverges from config.scheduleTime. " +
+          "Run `uncommitted schedule install` to realign."
+      );
+    } else if (installedScheduleTime !== undefined) {
+      io.stdout(`Schedule time: ${installedScheduleTime}`);
+    } else if (configScheduleTime !== undefined) {
+      io.stdout(`Schedule time: ${configScheduleTime} (from config)`);
+    }
 
     if (result.launchctlError) {
       io.stderr(`launchctl: ${result.launchctlError}`);

--- a/src/global-config.ts
+++ b/src/global-config.ts
@@ -138,6 +138,27 @@ export function selectDraftRoot(value: unknown): string | undefined {
   return undefined;
 }
 
+/** 24-hour HH:mm shape, matching `parseScheduleTime` in scheduler.ts. */
+const scheduleTimePattern = /^(?:[01]\d|2[0-3]):[0-5]\d$/;
+
+/**
+ * Extract a usable `scheduleTime` (24-hour HH:mm string) when present, else
+ * `undefined`. Callers fall back to their own default/usage error when the key
+ * is absent or not a valid time. Validated here so a malformed stored value is
+ * treated the same as "not set" rather than flowing into scheduler code as a
+ * throwing input.
+ */
+export function selectScheduleTime(value: unknown): string | undefined {
+  if (
+    isRecord(value) &&
+    typeof value.scheduleTime === "string" &&
+    scheduleTimePattern.test(value.scheduleTime)
+  ) {
+    return value.scheduleTime;
+  }
+  return undefined;
+}
+
 /** Extract a non-empty `githubToken`, else `null`. */
 export function selectGitHubToken(value: unknown): string | null {
   if (

--- a/src/schedule-status-command.ts
+++ b/src/schedule-status-command.ts
@@ -1,6 +1,7 @@
-import { access } from "node:fs/promises";
+import { access, readFile } from "node:fs/promises";
 import {
   getLaunchdLabel,
+  parseInstalledPlistScheduleTime,
   resolveLaunchAgentPlistPath,
   runLaunchctl,
   type LaunchctlRawRunner,
@@ -17,6 +18,11 @@ export type ScheduleStatusResult = {
   loaded: boolean | undefined;
   /** Resolved plist path (always present for display). */
   plistPath: string;
+  /**
+   * Actual scheduled time (24-hour `HH:mm`) parsed from the installed plist.
+   * Undefined when not installed or the plist lacks a valid Hour/Minute pair.
+   */
+  installedScheduleTime?: string;
   /** Short actionable error from launchctl, present when the check failed. */
   launchctlError?: string;
 };
@@ -37,6 +43,9 @@ export async function runScheduleStatus(
   const plistPath = resolveLaunchAgentPlistPath(options);
 
   const installed = await fileExists(plistPath);
+  const installedScheduleTime = installed
+    ? await readInstalledScheduleTime(plistPath)
+    : undefined;
 
   // Always query launchctl — a job may be loaded even when the plist is absent
   const launchctlResult = await runLaunchctl(["list"], options.runner);
@@ -46,13 +55,29 @@ export async function runScheduleStatus(
       installed,
       loaded: undefined,
       plistPath,
+      installedScheduleTime,
       launchctlError: launchctlResult.stderr || "launchctl check failed."
     };
   }
 
   const loaded = isJobLoaded(launchctlResult.stdout, getLaunchdLabel());
 
-  return { installed, loaded, plistPath };
+  return { installed, loaded, plistPath, installedScheduleTime };
+}
+
+/**
+ * Read the installed plist and parse its scheduled time. Returns undefined on
+ * any read/parse failure so status never throws over a hand-edited plist.
+ */
+async function readInstalledScheduleTime(
+  plistPath: string
+): Promise<string | undefined> {
+  try {
+    const xml = await readFile(plistPath, "utf8");
+    return parseInstalledPlistScheduleTime(xml);
+  } catch {
+    return undefined;
+  }
 }
 
 /**

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -183,6 +183,46 @@ export function parseScheduleTime(value: string): ScheduleTime {
   return { hour, minute };
 }
 
+/**
+ * Parse the scheduled Hour/Minute back out of an installed LaunchAgent plist's
+ * XML and return it as a zero-padded 24-hour `HH:mm` string. Returns `undefined`
+ * when the plist does not contain a valid `StartCalendarInterval` Hour/Minute
+ * pair (e.g. a stub or hand-edited file), so callers can degrade gracefully.
+ *
+ * Pure and injectable — the caller reads the file; this only parses the string.
+ */
+export function parseInstalledPlistScheduleTime(
+  xml: string
+): string | undefined {
+  const hour = extractPlistInteger(xml, "Hour");
+  const minute = extractPlistInteger(xml, "Minute");
+
+  if (hour === undefined || minute === undefined) {
+    return undefined;
+  }
+
+  if (hour < 0 || hour > 23 || minute < 0 || minute > 59) {
+    return undefined;
+  }
+
+  return `${pad2(hour)}:${pad2(minute)}`;
+}
+
+function extractPlistInteger(xml: string, key: string): number | undefined {
+  const pattern = new RegExp(
+    `<key>${key}</key>\\s*<integer>(-?\\d+)</integer>`
+  );
+  const match = pattern.exec(xml);
+  if (!match) {
+    return undefined;
+  }
+  return Number(match[1]);
+}
+
+function pad2(value: number): string {
+  return value.toString().padStart(2, "0");
+}
+
 export function buildLaunchAgentPlist(
   options: LaunchAgentPlistOptions
 ): LaunchAgentPlist {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -983,6 +983,49 @@ describe("cli", () => {
     vi.unstubAllGlobals();
   });
 
+  it("rejects unknown install arguments instead of falling back to config", async () => {
+    vi.stubGlobal("process", { ...process, platform: "darwin" });
+    const { io, stdout, stderr } = createIo();
+    const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-schedule-bogus-"));
+    const homeDir = join(directory, "home");
+    await writeConfig(homeDir, join(directory, "drafts")); // writes scheduleTime "23:30"
+
+    const exitCode = await runCli(["schedule", "install", "--bogus"], io, {
+      homeDir,
+      schedulerExecutor: async () => ({ stdout: "", stderr: "" })
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toEqual([]);
+    expect(stderr.join("\n")).toContain("Unknown argument: --bogus");
+    expect(stderr.join("\n")).toContain("Usage: uncommitted schedule install --time HH:mm");
+
+    const plistPath = join(homeDir, "Library", "LaunchAgents", "com.uncommitted.schedule.plist");
+    await expect(access(plistPath)).rejects.toThrow();
+    vi.unstubAllGlobals();
+  });
+
+  it("rejects --time without a value instead of falling back to config", async () => {
+    vi.stubGlobal("process", { ...process, platform: "darwin" });
+    const { io, stdout, stderr } = createIo();
+    const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-schedule-timenoval-"));
+    const homeDir = join(directory, "home");
+    await writeConfig(homeDir, join(directory, "drafts")); // writes scheduleTime "23:30"
+
+    const exitCode = await runCli(["schedule", "install", "--time"], io, {
+      homeDir,
+      schedulerExecutor: async () => ({ stdout: "", stderr: "" })
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toEqual([]);
+    expect(stderr.join("\n")).toContain("Usage: uncommitted schedule install --time HH:mm");
+
+    const plistPath = join(homeDir, "Library", "LaunchAgents", "com.uncommitted.schedule.plist");
+    await expect(access(plistPath)).rejects.toThrow();
+    vi.unstubAllGlobals();
+  });
+
   it("rejects invalid schedule time", async () => {
     vi.stubGlobal("process", { ...process, platform: "darwin" });
     const { io, stdout, stderr } = createIo();

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -28,6 +28,7 @@ import {
   writeLatestDraftPointer
 } from "../src/draft-storage.js";
 import { addProject } from "../src/project-add.js";
+import { buildLaunchAgentPlist } from "../src/scheduler.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -920,15 +921,65 @@ describe("cli", () => {
     vi.unstubAllGlobals();
   });
 
-  it("rejects schedule install without --time", async () => {
+  it("rejects schedule install without --time when config has no usable scheduleTime", async () => {
     vi.stubGlobal("process", { ...process, platform: "darwin" });
     const { io, stdout, stderr } = createIo();
+    const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-schedule-notime-"));
+    const homeDir = join(directory, "home");
+    // No config file written → nothing to fall back to.
 
-    const exitCode = await runCli(["schedule", "install"], io);
+    const exitCode = await runCli(["schedule", "install"], io, { homeDir });
 
     expect(exitCode).toBe(1);
     expect(stdout).toEqual([]);
     expect(stderr.join("\n")).toContain("Usage: uncommitted schedule install --time HH:mm");
+    vi.unstubAllGlobals();
+  });
+
+  it("falls back to config.scheduleTime when --time is omitted", async () => {
+    vi.stubGlobal("process", { ...process, platform: "darwin" });
+    const { io, stdout, stderr } = createIo();
+    const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-schedule-configtime-"));
+    const homeDir = join(directory, "home");
+    await writeConfig(homeDir, join(directory, "drafts")); // writes scheduleTime "23:30"
+
+    const exitCode = await runCli(["schedule", "install"], io, {
+      homeDir,
+      schedulerExecutor: async () => ({ stdout: "", stderr: "" })
+    });
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toEqual([]);
+    expect(stdout.join("\n")).toContain("Installed macOS schedule for 23:30.");
+
+    const plistPath = join(homeDir, "Library", "LaunchAgents", "com.uncommitted.schedule.plist");
+    const plistContent = await readFile(plistPath, "utf8");
+    expect(plistContent).toContain("<integer>23</integer>");
+    expect(plistContent).toContain("<integer>30</integer>");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("prefers --time over config.scheduleTime when both are present", async () => {
+    vi.stubGlobal("process", { ...process, platform: "darwin" });
+    const { io, stdout } = createIo();
+    const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-schedule-override-"));
+    const homeDir = join(directory, "home");
+    await writeConfig(homeDir, join(directory, "drafts")); // config scheduleTime "23:30"
+
+    const exitCode = await runCli(["schedule", "install", "--time", "06:45"], io, {
+      homeDir,
+      schedulerExecutor: async () => ({ stdout: "", stderr: "" })
+    });
+
+    expect(exitCode).toBe(0);
+    expect(stdout.join("\n")).toContain("Installed macOS schedule for 06:45.");
+
+    const plistPath = join(homeDir, "Library", "LaunchAgents", "com.uncommitted.schedule.plist");
+    const plistContent = await readFile(plistPath, "utf8");
+    expect(plistContent).toContain("<integer>6</integer>");
+    expect(plistContent).toContain("<integer>45</integer>");
+
     vi.unstubAllGlobals();
   });
 
@@ -1076,6 +1127,90 @@ describe("cli", () => {
     expect(exitCode).toBe(0);
     expect(stderr.join("\n")).toContain("launchctl");
     expect(stdout.join("\n")).toContain("Scheduler: installed, unknown");
+  });
+
+  it("reports a concise schedule time line when config and installed times match", async () => {
+    const { io, stdout } = createIo();
+    const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-status-match-"));
+    const homeDir = join(directory, "home");
+    await writeConfig(homeDir, join(directory, "drafts")); // scheduleTime "23:30"
+
+    const { xml } = buildLaunchAgentPlist({ homeDir, scheduleTime: "23:30" });
+    const plistDir = join(homeDir, "Library", "LaunchAgents");
+    await mkdir(plistDir, { recursive: true });
+    await writeFile(join(plistDir, "com.uncommitted.schedule.plist"), xml, "utf8");
+
+    const exitCode = await runCli(["schedule", "status"], io, {
+      homeDir,
+      schedulerRunner: async () => ({
+        exitCode: 0,
+        stdout: "123\t0\tcom.uncommitted.schedule\n",
+        stderr: ""
+      })
+    });
+
+    expect(exitCode).toBe(0);
+    const out = stdout.join("\n");
+    expect(out).toContain("Schedule time: 23:30");
+    expect(out).not.toMatch(/warning/i);
+    expect(out).not.toMatch(/diverge/i);
+  });
+
+  it("warns and shows both times when config and installed schedule times diverge", async () => {
+    const { io, stdout } = createIo();
+    const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-status-diverge-"));
+    const homeDir = join(directory, "home");
+    await writeConfig(homeDir, join(directory, "drafts")); // config scheduleTime "23:30"
+
+    const { xml } = buildLaunchAgentPlist({ homeDir, scheduleTime: "07:15" });
+    const plistDir = join(homeDir, "Library", "LaunchAgents");
+    await mkdir(plistDir, { recursive: true });
+    await writeFile(join(plistDir, "com.uncommitted.schedule.plist"), xml, "utf8");
+
+    const exitCode = await runCli(["schedule", "status"], io, {
+      homeDir,
+      schedulerRunner: async () => ({
+        exitCode: 0,
+        stdout: "123\t0\tcom.uncommitted.schedule\n",
+        stderr: ""
+      })
+    });
+
+    expect(exitCode).toBe(0);
+    const out = stdout.join("\n");
+    expect(out).toMatch(/warning/i);
+    expect(out).toContain("07:15"); // installed
+    expect(out).toContain("23:30"); // config
+  });
+
+  it("degrades gracefully in status when config is unreadable", async () => {
+    const { io, stdout, stderr } = createIo();
+    const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-status-noconfig-"));
+    const homeDir = join(directory, "home");
+    // No config file written.
+
+    const { xml } = buildLaunchAgentPlist({ homeDir, scheduleTime: "07:15" });
+    const plistDir = join(homeDir, "Library", "LaunchAgents");
+    await mkdir(plistDir, { recursive: true });
+    await writeFile(join(plistDir, "com.uncommitted.schedule.plist"), xml, "utf8");
+
+    const exitCode = await runCli(["schedule", "status"], io, {
+      homeDir,
+      schedulerRunner: async () => ({
+        exitCode: 0,
+        stdout: "123\t0\tcom.uncommitted.schedule\n",
+        stderr: ""
+      })
+    });
+
+    expect(exitCode).toBe(0);
+    const out = stdout.join("\n");
+    expect(out).toContain("Scheduler: installed, loaded");
+    // Installed time still surfaced even without config to compare against.
+    expect(out).toContain("07:15");
+    // No crash, no divergence warning when there is nothing to compare.
+    expect(out).not.toMatch(/warning/i);
+    expect(stderr).toEqual([]);
   });
 
   it("rejects schedule status with unexpected arguments", async () => {

--- a/tests/global-config.test.ts
+++ b/tests/global-config.test.ts
@@ -7,7 +7,8 @@ import {
   isRoastLevel,
   loadGlobalConfig,
   selectDraftRoot,
-  selectGitHubToken
+  selectGitHubToken,
+  selectScheduleTime
 } from "../src/global-config.js";
 
 let homeDir: string;
@@ -86,6 +87,20 @@ describe("selectors", () => {
     expect(selectGitHubToken({})).toBeNull();
     expect(selectGitHubToken({ githubToken: 1 })).toBeNull();
     expect(selectGitHubToken(null)).toBeNull();
+  });
+
+  it("selectScheduleTime returns a valid HH:mm string or undefined", () => {
+    expect(selectScheduleTime({ scheduleTime: "23:30" })).toBe("23:30");
+    expect(selectScheduleTime({ scheduleTime: "00:00" })).toBe("00:00");
+    // Non-HH:mm strings are not usable schedule times.
+    expect(selectScheduleTime({ scheduleTime: "9:5" })).toBeUndefined();
+    expect(selectScheduleTime({ scheduleTime: "25:00" })).toBeUndefined();
+    expect(selectScheduleTime({ scheduleTime: "" })).toBeUndefined();
+    expect(selectScheduleTime({})).toBeUndefined();
+    expect(selectScheduleTime({ scheduleTime: 5 })).toBeUndefined();
+    expect(selectScheduleTime([])).toBeUndefined();
+    expect(selectScheduleTime(null)).toBeUndefined();
+    expect(selectScheduleTime(42)).toBeUndefined();
   });
 });
 

--- a/tests/scheduler-status.test.ts
+++ b/tests/scheduler-status.test.ts
@@ -3,7 +3,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { runScheduleStatus } from "../src/schedule-status-command.js";
-import { resolveLaunchAgentPlistPath, getLaunchdLabel } from "../src/scheduler.js";
+import {
+  buildLaunchAgentPlist,
+  resolveLaunchAgentPlistPath,
+  getLaunchdLabel
+} from "../src/scheduler.js";
 import type { LaunchctlRawRunner } from "../src/scheduler.js";
 
 /**
@@ -128,5 +132,39 @@ describe("runScheduleStatus", () => {
     expect(result.installed).toBe(false);
     expect(result.loaded).toBeUndefined();
     expect(result.launchctlError).toMatch(/launchctl not found/i);
+  });
+
+  it("surfaces the actual installed launchd time parsed from the plist", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "uncommitted-status-time-"));
+    const plistPath = resolveLaunchAgentPlistPath({ homeDir });
+    await mkdir(join(homeDir, "Library", "LaunchAgents"), { recursive: true });
+    const { xml } = buildLaunchAgentPlist({ homeDir, scheduleTime: "07:15" });
+    await writeFile(plistPath, xml, "utf8");
+
+    const result = await runScheduleStatus({ homeDir, runner: makeRunner(0, "", "") });
+
+    expect(result.installed).toBe(true);
+    expect(result.installedScheduleTime).toBe("07:15");
+  });
+
+  it("leaves installedScheduleTime undefined when the plist is absent", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "uncommitted-status-notime-"));
+
+    const result = await runScheduleStatus({ homeDir, runner: makeRunner(0, "", "") });
+
+    expect(result.installed).toBe(false);
+    expect(result.installedScheduleTime).toBeUndefined();
+  });
+
+  it("leaves installedScheduleTime undefined when the plist is unparseable", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "uncommitted-status-badtime-"));
+    const plistPath = resolveLaunchAgentPlistPath({ homeDir });
+    await mkdir(join(homeDir, "Library", "LaunchAgents"), { recursive: true });
+    await writeFile(plistPath, "<plist/>", "utf8");
+
+    const result = await runScheduleStatus({ homeDir, runner: makeRunner(0, "", "") });
+
+    expect(result.installed).toBe(true);
+    expect(result.installedScheduleTime).toBeUndefined();
   });
 });

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -4,6 +4,7 @@ import {
   buildLaunchAgentPlist,
   captureProviderEnv,
   getLaunchdLabel,
+  parseInstalledPlistScheduleTime,
   parseScheduleTime,
   resolveLaunchAgentPlistPath,
   resolveSchedulerLogPaths
@@ -260,6 +261,49 @@ describe("macOS scheduler plist helpers", () => {
 `;
 
     expect(plist.xml).toBe(expectedXml);
+  });
+});
+
+describe("parseInstalledPlistScheduleTime", () => {
+  it("parses Hour and Minute out of a generated plist as an HH:mm string", () => {
+    const plist = buildLaunchAgentPlist({
+      homeDir: "/tmp/uncommitted-scheduler-home",
+      scheduleTime: "23:30"
+    });
+
+    expect(parseInstalledPlistScheduleTime(plist.xml)).toBe("23:30");
+  });
+
+  it("zero-pads single-digit hour and minute integers", () => {
+    const plist = buildLaunchAgentPlist({
+      homeDir: "/tmp/uncommitted-scheduler-home",
+      scheduleTime: "08:05"
+    });
+
+    expect(parseInstalledPlistScheduleTime(plist.xml)).toBe("08:05");
+  });
+
+  it("tolerates whitespace between key and integer tags", () => {
+    const xml = `<dict>
+  <key>Hour</key>   <integer>9</integer>
+  <key>Minute</key>
+    <integer>7</integer>
+</dict>`;
+
+    expect(parseInstalledPlistScheduleTime(xml)).toBe("09:07");
+  });
+
+  it("returns undefined when Hour or Minute is absent or malformed", () => {
+    expect(parseInstalledPlistScheduleTime("")).toBeUndefined();
+    expect(parseInstalledPlistScheduleTime("<plist/>")).toBeUndefined();
+    expect(
+      parseInstalledPlistScheduleTime("<key>Hour</key><integer>9</integer>")
+    ).toBeUndefined();
+    expect(
+      parseInstalledPlistScheduleTime(
+        "<key>Hour</key><integer>99</integer><key>Minute</key><integer>0</integer>"
+      )
+    ).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
🤖 **Auto-generated by Uncommitted Builder (Routine B v2)**

## Parent issue
[UNC-174: Resolve write-only config keys (scheduleTime, rawRetentionDays, captionProjectionTokenBudget)](https://linear.app/sangchu/issue/UNC-174)

## Sub-issues progress
- [x] UNC-187: [T1] Wire scheduleTime into schedule install default and schedule status reporting (✅ done)
- [~] UNC-188: [T2] Remove rawRetentionDays and captionProjectionTokenBudget from init writer — **Canceled** (human-canceled 2026-07-02; out of scope for this PR)

> Scope note: only `scheduleTime` remains in the parent's active decomposition (UNC-188 canceled). This PR closes the parent by wiring `scheduleTime`. `rawRetentionDays` / `captionProjectionTokenBudget` are intentionally left untouched here per the canceled sub.

## What changed
- `src/global-config.ts` — new `selectScheduleTime(value)` reader (HH:mm-validated, same regex as `parseScheduleTime`; malformed stored value → treated as "not set"). **No `GlobalConfig` schema change** — an existing key is simply read for the first time.
- `src/cli.ts` `schedule install` — when `--time` is omitted, falls back to `config.scheduleTime`; `--time` always overrides; missing/invalid config with no `--time` keeps the original usage error (exit 1).
- `src/cli.ts` `schedule status` + `src/schedule-status-command.ts` — result now carries `installedScheduleTime` parsed from the installed plist; status surfaces stored config time vs actual installed launchd time, with a divergence warning when they differ (match → single line).
- `src/scheduler.ts` — new pure `parseInstalledPlistScheduleTime` helper (regex over `<key>Hour/Minute</key><integer>N</integer>`, whitespace-tolerant, range-checked), unit-tested.

## Status
- Branch: `claude/UNC-174-scheduletime-config`
- Tests: ✅ 746/748 (vitest; 1 skipped; the sole cold-start failure is the pre-existing `carousel-renderer-smoke` Playwright flake — passes in 605ms on warm/isolated re-run, unrelated to these files). Targeted suites (global-config / scheduler / scheduler-status / cli) 136/136 green.
- Build: ✅
- Type check: ✅
- Lint: ✅

## TDD trail
UNC-187:
- Attempt 1: ✅ success (selectScheduleTime cases; plist-time parse unit tests; install config-fallback + --time override + missing-config error; status match / diverge / unreadable-config)

## Notes
- No new env vars, no dependency/lockfile changes, no config schema change.
- Divergence warning is printed to stdout (consistent with existing status output style; stderr reserved for launchctl errors).

## Review checklist
- [ ] Review the sub-issue's commit
- [ ] Verify TDD test coverage
- [ ] Confirm no lockfile changes (none introduced)
- [ ] Run `pnpm install && pnpm test && pnpm build` locally
- [ ] Confirm no auto-publish code introduced
- [ ] Confirm the canceled UNC-188 scope (other two keys) is correctly left out

---
이 PR은 자동 생성되었습니다. 머지 전 사람의 리뷰가 반드시 필요합니다.
