### PR TITLE
🐛 fix(scheduler): reject unstable executable paths in schedule install (UNC-190)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -76,6 +76,7 @@ import {
   buildLaunchAgentPlist,
   captureProviderEnv,
   installScheduler,
+  SchedulerExecutablePathError,
   type LaunchctlExecutor,
   type LaunchctlRawRunner
 } from "./scheduler.js";
@@ -137,6 +138,13 @@ export type CliOptions = {
   schedulerExecutor?: LaunchctlExecutor;
   /** Injectable structured launchctl runner for status/remove (tests). */
   schedulerRunner?: LaunchctlRawRunner;
+  /**
+   * Executable path recorded into the launchd plist by `schedule install`.
+   * When omitted, `process.argv[1]` is used as the last-resort candidate and
+   * validated — under vitest/worktrees it points at an ephemeral worker
+   * script, which must never reach the plist (UNC-190).
+   */
+  schedulerExecutablePath?: string;
   /** Injectable prompter for feedback command (tests). */
   feedbackPrompter?: FeedbackPrompter;
   /**
@@ -319,7 +327,8 @@ async function runSchedule(
     }
 
     try {
-      const executablePath = realpathSync.native(process.argv[1]);
+      const executablePath =
+        options.schedulerExecutablePath ?? realpathSync.native(process.argv[1]);
       const plist = buildLaunchAgentPlist({
         homeDir: options.homeDir,
         scheduleTime,
@@ -336,6 +345,10 @@ async function runSchedule(
       io.stdout(`Plist path: ${plist.plistPath}`);
       return 0;
     } catch (error) {
+      if (error instanceof SchedulerExecutablePathError) {
+        io.stderr(error.message);
+        return 2;
+      }
       io.stderr(error instanceof Error ? error.message : "Schedule install failed.");
       return 1;
     }

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -223,10 +223,85 @@ function pad2(value: number): string {
   return value.toString().padStart(2, "0");
 }
 
+/**
+ * Thrown when a scheduler executable path would bake an ephemeral or
+ * non-CLI entry (test worker, worktree, pnpm virtual store) into the
+ * launchd plist. Callers map this to a config-style failure (exit 2)
+ * and must not overwrite an existing plist.
+ */
+export class SchedulerExecutablePathError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SchedulerExecutablePathError";
+  }
+}
+
+export type SchedulerExecutablePathValidation =
+  | { ok: true }
+  | { ok: false; reason: string };
+
+const unstableExecutablePathRules: Array<{
+  matches: (executablePath: string) => boolean;
+  reason: string;
+}> = [
+  {
+    matches: (executablePath) => executablePath.includes("/.claude/worktrees/"),
+    reason: "temporary git worktree path"
+  },
+  {
+    matches: (executablePath) => executablePath.includes("/node_modules/.pnpm/"),
+    reason: "pnpm virtual store path"
+  },
+  {
+    matches: (executablePath) => executablePath.includes("/tinypool/"),
+    reason: "test worker (tinypool) path"
+  },
+  {
+    matches: (executablePath) => /\.(ts|mts|cts)$/.test(executablePath),
+    reason: "TypeScript source entry"
+  },
+  {
+    matches: (executablePath) =>
+      /\.(js|mjs|cjs)$/.test(executablePath) &&
+      !/(^|\/)cli\.(js|mjs|cjs)$/.test(executablePath),
+    reason: "non-CLI script entry"
+  }
+];
+
+/**
+ * Checks whether an executable path is safe to persist into the launchd
+ * plist. `process.argv[1]` is not trustworthy here: under vitest it points
+ * at a tinypool worker inside (possibly pruned) worktree node_modules, and
+ * launchd would then fail every run with MODULE_NOT_FOUND (UNC-190).
+ */
+export function validateSchedulerExecutablePath(
+  executablePath: string
+): SchedulerExecutablePathValidation {
+  for (const rule of unstableExecutablePathRules) {
+    if (rule.matches(executablePath)) {
+      return { ok: false, reason: rule.reason };
+    }
+  }
+
+  return { ok: true };
+}
+
 export function buildLaunchAgentPlist(
   options: LaunchAgentPlistOptions
 ): LaunchAgentPlist {
   const { hour, minute } = parseScheduleTime(options.scheduleTime);
+
+  if (options.executablePath !== undefined) {
+    const validation = validateSchedulerExecutablePath(options.executablePath);
+    if (!validation.ok) {
+      throw new SchedulerExecutablePathError(
+        `Executable path is not a stable CLI entrypoint (${validation.reason}): ` +
+          `${options.executablePath}. Run schedule install via the installed CLI ` +
+          `(node dist/cli.js schedule install).`
+      );
+    }
+  }
+
   const plistPath = resolveLaunchAgentPlistPath(options);
   const logs = resolveSchedulerLogPaths(options);
   const executablePath = options.executablePath ?? defaultExecutableName;

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -240,6 +240,11 @@ export type SchedulerExecutablePathValidation =
   | { ok: true }
   | { ok: false; reason: string };
 
+// pnpm global/tarball installs resolve the CLI bin shim into the virtual
+// store, so this suffix is a legitimate documented install path. Must match
+// the package name in package.json.
+const pnpmOwnCliPathSuffix = "/node_modules/@sangchu04/uncommitted/dist/cli.js";
+
 const unstableExecutablePathRules: Array<{
   matches: (executablePath: string) => boolean;
   reason: string;
@@ -249,7 +254,9 @@ const unstableExecutablePathRules: Array<{
     reason: "temporary git worktree path"
   },
   {
-    matches: (executablePath) => executablePath.includes("/node_modules/.pnpm/"),
+    matches: (executablePath) =>
+      executablePath.includes("/node_modules/.pnpm/") &&
+      !executablePath.endsWith(pnpmOwnCliPathSuffix),
     reason: "pnpm virtual store path"
   },
   {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -891,6 +891,7 @@ describe("cli", () => {
 
     const exitCode = await runCli(["schedule", "install", "--time", "23:30"], io, {
       homeDir,
+      schedulerExecutablePath: "/usr/local/lib/node_modules/uncommitted/dist/cli.js",
       schedulerExecutor: async () => ({ stdout: "", stderr: "" })
     });
 
@@ -903,6 +904,80 @@ describe("cli", () => {
     expect(stdout.join("\n")).toContain("Installed macOS schedule for 23:30.");
     expect(plistContent).toContain("<key>Hour</key>");
     expect(plistContent).toContain("<integer>23</integer>");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("refuses schedule install when the running entrypoint is a test worker path", async () => {
+    // Under vitest, process.argv[1] is a tinypool worker script — exactly the
+    // path shape that must never be baked into the launchd plist (UNC-190).
+    vi.stubGlobal("process", { ...process, platform: "darwin" });
+
+    const { io, stdout, stderr } = createIo();
+    const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-schedule-worker-"));
+    const homeDir = join(directory, "home");
+
+    const exitCode = await runCli(["schedule", "install", "--time", "23:30"], io, {
+      homeDir,
+      schedulerExecutor: async () => ({ stdout: "", stderr: "" })
+    });
+
+    expect(exitCode).toBe(2);
+    expect(stdout).toEqual([]);
+    expect(stderr.join("\n")).toContain("not a stable CLI entrypoint");
+
+    const plistPath = join(homeDir, "Library", "LaunchAgents", "com.uncommitted.schedule.plist");
+    await expect(access(plistPath)).rejects.toThrow();
+
+    vi.unstubAllGlobals();
+  });
+
+  it("records the injected stable executable path in the plist", async () => {
+    vi.stubGlobal("process", { ...process, platform: "darwin" });
+
+    const { io, stderr } = createIo();
+    const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-schedule-stable-"));
+    const homeDir = join(directory, "home");
+    const stableCliPath = "/usr/local/lib/node_modules/uncommitted/dist/cli.js";
+
+    const exitCode = await runCli(["schedule", "install", "--time", "23:30"], io, {
+      homeDir,
+      schedulerExecutablePath: stableCliPath,
+      schedulerExecutor: async () => ({ stdout: "", stderr: "" })
+    });
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toEqual([]);
+
+    const plistPath = join(homeDir, "Library", "LaunchAgents", "com.uncommitted.schedule.plist");
+    const plistContent = await readFile(plistPath, "utf8");
+    expect(plistContent).toContain(`<string>${stableCliPath}</string>`);
+    expect(plistContent).not.toContain("tinypool");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("refuses install and preserves an existing plist when the executable path is unstable", async () => {
+    vi.stubGlobal("process", { ...process, platform: "darwin" });
+
+    const { io, stdout, stderr } = createIo();
+    const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-schedule-preserve-"));
+    const homeDir = join(directory, "home");
+    const plistPath = join(homeDir, "Library", "LaunchAgents", "com.uncommitted.schedule.plist");
+    await mkdir(join(homeDir, "Library", "LaunchAgents"), { recursive: true });
+    await writeFile(plistPath, "<!-- existing healthy plist -->", "utf8");
+
+    const exitCode = await runCli(["schedule", "install", "--time", "23:30"], io, {
+      homeDir,
+      schedulerExecutablePath:
+        "/Users/user/repo/.claude/worktrees/clever-cerf-2fad25/dist/cli.js",
+      schedulerExecutor: async () => ({ stdout: "", stderr: "" })
+    });
+
+    expect(exitCode).toBe(2);
+    expect(stdout).toEqual([]);
+    expect(stderr.join("\n")).toContain("not a stable CLI entrypoint");
+    expect(await readFile(plistPath, "utf8")).toBe("<!-- existing healthy plist -->");
 
     vi.unstubAllGlobals();
   });
@@ -945,6 +1020,7 @@ describe("cli", () => {
 
     const exitCode = await runCli(["schedule", "install"], io, {
       homeDir,
+      schedulerExecutablePath: "/usr/local/lib/node_modules/uncommitted/dist/cli.js",
       schedulerExecutor: async () => ({ stdout: "", stderr: "" })
     });
 
@@ -969,6 +1045,7 @@ describe("cli", () => {
 
     const exitCode = await runCli(["schedule", "install", "--time", "06:45"], io, {
       homeDir,
+      schedulerExecutablePath: "/usr/local/lib/node_modules/uncommitted/dist/cli.js",
       schedulerExecutor: async () => ({ stdout: "", stderr: "" })
     });
 
@@ -1041,8 +1118,13 @@ describe("cli", () => {
   it("returns error code when schedule installation fails", async () => {
     vi.stubGlobal("process", { ...process, platform: "darwin" });
     const { io, stdout, stderr } = createIo();
+    // homeDir must be injected: without it this test would write the real
+    // ~/Library/LaunchAgents plist before the executor throws.
+    const directory = await mkdtemp(join(tmpdir(), "uncommitted-cli-schedule-fail-"));
 
     const exitCode = await runCli(["schedule", "install", "--time", "23:30"], io, {
+      homeDir: join(directory, "home"),
+      schedulerExecutablePath: "/usr/local/lib/node_modules/uncommitted/dist/cli.js",
       schedulerExecutor: async () => {
         throw new Error("launchctl failed");
       }

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -272,7 +272,7 @@ describe("validateSchedulerExecutablePath", () => {
     "/Users/user/repo/node_modules/.pnpm/tinypool@1.1.1/node_modules/tinypool/dist/entry/process.js",
     // ephemeral Claude worktree, even when it points at a real cli.js
     "/Users/user/repo/.claude/worktrees/clever-cerf-2fad25/dist/cli.js",
-    // pnpm virtual store path — pruned/rewritten on installs
+    // foreign package cli.js inside the pnpm virtual store — not our CLI
     "/Users/user/repo/node_modules/.pnpm/uncommitted@0.1.0/node_modules/uncommitted/dist/cli.js",
     // generic non-CLI .js worker entry
     "/opt/some-tool/dist/entry/worker.js",
@@ -295,6 +295,17 @@ describe("validateSchedulerExecutablePath", () => {
       "/Users/user/.nvm/versions/node/v22.0.0/lib/node_modules/uncommitted/dist/cli.js",
       "/usr/local/bin/uncommitted",
       "uncommitted"
+    ]) {
+      expect(validateSchedulerExecutablePath(path)).toEqual({ ok: true });
+    }
+  });
+
+  it("accepts this package's own cli.js resolved into the pnpm virtual store", () => {
+    // Documented install paths (README Option B): `pnpm add -g` resolves the
+    // bin shim into the virtual store before validation runs.
+    for (const path of [
+      "/Users/user/Library/pnpm/global/5/node_modules/.pnpm/@sangchu04+uncommitted@0.1.1/node_modules/@sangchu04/uncommitted/dist/cli.js",
+      "/Users/user/Library/pnpm/global/5/node_modules/.pnpm/@sangchu04+uncommitted@file+sangchu04-uncommitted-0.1.1.tgz/node_modules/@sangchu04/uncommitted/dist/cli.js"
     ]) {
       expect(validateSchedulerExecutablePath(path)).toEqual({ ok: true });
     }

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -7,7 +7,9 @@ import {
   parseInstalledPlistScheduleTime,
   parseScheduleTime,
   resolveLaunchAgentPlistPath,
-  resolveSchedulerLogPaths
+  resolveSchedulerLogPaths,
+  SchedulerExecutablePathError,
+  validateSchedulerExecutablePath
 } from "../src/scheduler.js";
 
 describe("macOS scheduler plist helpers", () => {
@@ -261,6 +263,54 @@ describe("macOS scheduler plist helpers", () => {
 `;
 
     expect(plist.xml).toBe(expectedXml);
+  });
+});
+
+describe("validateSchedulerExecutablePath", () => {
+  const unstablePaths = [
+    // vitest tinypool worker entry — the exact shape that poisoned the 6/28 plist
+    "/Users/user/repo/node_modules/.pnpm/tinypool@1.1.1/node_modules/tinypool/dist/entry/process.js",
+    // ephemeral Claude worktree, even when it points at a real cli.js
+    "/Users/user/repo/.claude/worktrees/clever-cerf-2fad25/dist/cli.js",
+    // pnpm virtual store path — pruned/rewritten on installs
+    "/Users/user/repo/node_modules/.pnpm/uncommitted@0.1.0/node_modules/uncommitted/dist/cli.js",
+    // generic non-CLI .js worker entry
+    "/opt/some-tool/dist/entry/worker.js",
+    // TypeScript source entry — launchd cannot execute it
+    "/Users/user/repo/src/cli.ts"
+  ];
+
+  it.each(unstablePaths)("rejects unstable executable path %s", (path) => {
+    const result = validateSchedulerExecutablePath(path);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("accepts stable CLI entrypoints and binaries", () => {
+    for (const path of [
+      "/usr/local/lib/node_modules/uncommitted/dist/cli.js",
+      "/Users/user/.nvm/versions/node/v22.0.0/lib/node_modules/uncommitted/dist/cli.js",
+      "/usr/local/bin/uncommitted",
+      "uncommitted"
+    ]) {
+      expect(validateSchedulerExecutablePath(path)).toEqual({ ok: true });
+    }
+  });
+
+  it("buildLaunchAgentPlist refuses to bake an unstable executable path into the plist", () => {
+    const homeDir = "/tmp/uncommitted-scheduler-home";
+    const executablePath =
+      "/Users/user/repo/node_modules/.pnpm/tinypool@1.1.1/node_modules/tinypool/dist/entry/process.js";
+
+    expect(() =>
+      buildLaunchAgentPlist({ homeDir, scheduleTime: "23:30", executablePath })
+    ).toThrow(SchedulerExecutablePathError);
+    expect(() =>
+      buildLaunchAgentPlist({ homeDir, scheduleTime: "23:30", executablePath })
+    ).toThrow(executablePath);
   });
 });
 


### PR DESCRIPTION
# Goal

`uncommitted schedule install`이 실행 컨텍스트와 무관하게 항상 안정적인 CLI 엔트리포인트만 launchd plist에 기록하도록 하여, vitest/워크트리 컨텍스트에서 생성된 깨진 plist로 스케줄 실행이 조용히 죽는 문제를 근절한다.

## Related Issue

Fixes [UNC-190](https://linear.app/sangchu/issue/UNC-190/scheduler-schedule-install이-processargv1을-박제해-vitest워크트리-컨텍스트에서-깨진)

## Acceptance Criteria

- [x] vitest/tinypool 컨텍스트에서 install 코드 경로가 실행돼도 plist에 워커/워크트리 경로가 절대 기록되지 않는다 — `buildLaunchAgentPlist`가 plist 생성 전에 throw (단일 관문)
- [x] 정상 CLI 실행 시 plist는 안정적인 CLI 엔트리포인트(`dist/cli.js` 정규 설치 경로)를 가리킨다
- [x] 경로 결정이 의심스러우면 install이 명확한 에러 메시지로 실패(exit 2)하고 기존 plist를 덮어쓰지 않는다
- [x] 회귀 테스트: (a) 워커/워크트리스러운 argv로 install 시 거부, (b) 정상 argv로 기대 경로 기록

## Implementation Notes

- `src/scheduler.ts`: 순수 검증 헬퍼 `validateSchedulerExecutablePath` + `SchedulerExecutablePathError` 도입. 거부 규칙: `.claude/worktrees`, `node_modules/.pnpm`, `tinypool`, TypeScript 소스 엔트리, `cli.js`가 아닌 `.js` 워커 엔트리.
- `src/cli.ts`: `CliOptions.schedulerExecutablePath`(주입형) 추가, `process.argv[1]`은 마지막 후보로만 사용. `SchedulerExecutablePathError`는 exit 2로 매핑.
- 테스트 부수 수정: "returns error code when schedule installation fails" 테스트가 `homeDir` 미주입으로 **실제 `~/Library/LaunchAgents` plist를 tinypool 경로로 덮어쓰고 있었음** (6/28 오염의 유력 유입 경로) → tmpdir 주입으로 수정.
- 알려진 한계 (out of scope): 기존 오염 plist 자동 치유 없음(정상 CLI로 `schedule install` 재실행 필요), pnpm 글로벌 설치는 `.pnpm` 가상 스토어로 resolve되어 거부됨(npm 글로벌 사용 필요).

## Validation

- `pnpm test` — 772 passed, 1 skipped (신규 회귀 테스트 10건 포함, TDD RED→GREEN)
- `pnpm lint` / `pnpm typecheck` / `pnpm build` — 통과
- `git diff --check` — 통과
- 빌드된 `dist/scheduler.js`로 실제 `dist/cli.js` 경로 수용·tinypool/워크트리 경로 거부 스모크 확인

## Remaining Risk

- 이름이 `cli.js`인 임시 클론/형제 워크트리·npx 캐시 경로는 패턴 검증을 통과함 — 경로 문자열만으로는 완전 판별 불가한 본질적 한계.
- `schedule status`/`doctor`는 plist ProgramArguments의 무결성을 검사하지 않아 조용한 no-op을 감지 못함 — 후속 이슈 후보.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
