### PR TITLE
🤖 chore(ci): migrate GitHub Actions off the deprecated Node 20 runtime (UNC-160) — single-issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,16 +13,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10.10.0
           run_install: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/release-artifact.yml
+++ b/.github/workflows/release-artifact.yml
@@ -17,16 +17,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10.10.0
           run_install: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm
@@ -57,7 +57,7 @@ jobs:
         run: echo "ref=$(echo '${{ github.ref_name }}' | tr '/' '-')" >> $GITHUB_OUTPUT
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: uncommitted-cli-${{ steps.sanitize.outputs.ref }}
           path: '*.tgz'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,16 +19,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10.10.0
           run_install: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm
@@ -66,7 +66,7 @@ jobs:
           echo "Tag version matches package.json: $PKG_VERSION"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
           generate_release_notes: true


### PR DESCRIPTION
🤖 **Auto-generated by Uncommitted Builder (Routine B v2 — single-issue path)**

## Issue
[UNC-160: chore(ci): migrate GitHub Actions off the deprecated Node 20 runtime](https://linear.app/sangchu/issue/UNC-160)

Routine A가 분해 불필요(single-issue)로 판정하여 sub-issue 없이 이 이슈를 그대로 단일 작업으로 처리했습니다.

## Change
Bumped every JavaScript GitHub Action to its lowest **Node 24-capable** major, clearing the "Node.js 20 actions are deprecated" CI warning. Version choice was verified against each action's upstream `action.yml` `runs.using` field and release notes:

| Action | Before (Node 20) | After (Node 24) | Notes |
|---|---|---|---|
| `actions/checkout` | v4 | **v5** | v5 = pure Node 24 bump |
| `actions/setup-node` | v4 | **v5** | explicit `cache: pnpm` unaffected by v5+ auto-cache change |
| `pnpm/action-setup` | v4 | **v5** | Node 24 |
| `actions/upload-artifact` | v4 | **v6** | ⚠️ v5 still runs on Node 20 — v6 required |
| `softprops/action-gh-release` | v2 | **v3** | v2 was Node 20 |

Applied consistently across all five workflow files: `ci.yml`, `claude.yml`, `claude-code-review.yml`, `release.yml`, `release-artifact.yml`. (No CodeQL workflow exists in the repo, despite the issue's speculative scope note.) Only `uses:` pins changed — no step, input, or matrix change. GitHub-hosted `ubuntu-latest` satisfies the new minimum runner (2.327.1).

**Stability rationale:** chose the *lowest* Node 24 major of each action rather than the absolute latest to minimize behavioral change surface for a CI chore. This durably resolves the Node 20 deprecation (Node 24 removal is not scheduled).

## Status
- Branch: `claude/UNC-160-ci-actions-node24`
- Tests: ✅ 773/774 (1 skipped) (vitest)
- Build: ✅
- Lint: ✅
- Type check: ✅
- `git diff --check`: ✅ clean
- YAML parse: ✅ all 5 files

## TDD trail
- Config-only change (GitHub Actions YAML) — no vitest RED test is applicable; correctness is verified by CI itself + upstream `runs.using` runtime evidence. Full existing suite re-run green to confirm no regression.

## Notes
- No dependency or lockfile changes (`pnpm install --frozen-lockfile` clean).
- No environment variables introduced.

## Review checklist
- [ ] Verify each action version runs on Node 24 (checkout v5, setup-node v5, pnpm v5, upload-artifact v6, gh-release v3)
- [ ] Confirm no lockfile changes
- [ ] Run `pnpm install && pnpm test && pnpm build` locally
- [ ] Confirm no auto-publish code introduced
- [ ] **single-issue 판정이 적절했는지 확인** — 사후 분해가 필요했다고 판단되면 PR 닫고 이슈에서 `single-issue` 라벨 제거 후 Decomposer 재실행 권장

---
이 PR은 자동 생성되었습니다. 머지 전 사람의 리뷰가 반드시 필요합니다.
