### PR TITLE
🤖 이메일 redaction 정규식 repo 전역 ReDoS 하드닝 + 공유 모듈 통합 (UNC-137) — single-issue

### DIFF
--- a/src/ai-provider.ts
+++ b/src/ai-provider.ts
@@ -1,6 +1,7 @@
 import process from "node:process";
 import { resolveConfigPaths } from "./config-paths.js";
 import { isRoastLevel, loadGlobalConfig } from "./global-config.js";
+import { emailPattern } from "./redaction.js";
 import { isRecord } from "./type-guards.js";
 import {
   BILLING_429_MESSAGE,
@@ -1038,7 +1039,7 @@ function redactSensitiveText(value: string): string {
       /\b(?:https?|ssh|git):\/\/\S+|git@[\w.-]+:[^\s]+/g,
       "[redacted-url]"
     )
-    .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, "[redacted-email]")
+    .replace(emailPattern("gi"), "[redacted-email]")
     .replace(
       /(^|[\s(["'])\/[^\s)"']+/g,
       "$1[redacted-path]"

--- a/src/diary-generator.ts
+++ b/src/diary-generator.ts
@@ -10,6 +10,7 @@ import type {
   JsonValue,
   SafeActivitySummary
 } from "./ai-provider.js";
+import { emailPattern } from "./redaction.js";
 import type {
   ProjectPersonaHint,
   StoryFormatPlan
@@ -765,7 +766,7 @@ function containsUnsafeText(value: string): boolean {
     /\bBearer\s+[A-Za-z0-9._~+/=-]+/i.test(value) ||
     /\bsk-[A-Za-z0-9_-]{8,}\b/.test(value) ||
     /\b(?:https?|ssh|git):\/\/\S+|git@[\w.-]+:[^\s]+/.test(value) ||
-    /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i.test(value) ||
+    emailPattern("i").test(value) ||
     /(^|[\s(["'])\/[^\s)"']+/.test(value)
   );
 }

--- a/src/git-activity-collector.ts
+++ b/src/git-activity-collector.ts
@@ -6,6 +6,7 @@ import { promisify } from "node:util";
 import type { ActivitySignal, EventSource } from "./event-source.js";
 import {
   categorizeRedactedSubject,
+  emailPattern,
   REDACTION_CATEGORY_ORDER,
   sanitizeText,
   type RedactionCategory,
@@ -360,14 +361,12 @@ function redactSensitiveText(value: string): RedactionResult {
   const categories = new Set<RedactionCategory>();
   let sanitized = value;
 
-  // Bounded quantifiers (see redaction.ts) keep email matching linear and
-  // clear the polynomial-ReDoS warning; real emails match identically.
-  if (/[A-Z0-9._%+-]{1,64}@[A-Z0-9.-]{1,255}\.[A-Z]{2,24}/i.test(sanitized)) {
+  // Bounded quantifiers (see emailPattern in redaction.ts) keep email
+  // matching linear and clear the polynomial-ReDoS warning; real emails
+  // match identically.
+  if (emailPattern("i").test(sanitized)) {
     categories.add("emails");
-    sanitized = sanitized.replace(
-      /[A-Z0-9._%+-]{1,64}@[A-Z0-9.-]{1,255}\.[A-Z]{2,24}/gi,
-      "[redacted-email]"
-    );
+    sanitized = sanitized.replace(emailPattern("gi"), "[redacted-email]");
   }
 
   if (/\b(?:https?|ssh|git):\/\/\S+|git@[\w.-]+:[^\s]+/.test(sanitized)) {

--- a/src/redaction.ts
+++ b/src/redaction.ts
@@ -31,6 +31,18 @@ export type RedactionResult = {
   categories: RedactionCategory[];
 };
 
+// Single source of the email-matching pattern for every redaction path.
+// Bounded quantifiers (RFC-5321-ish: local <=64, domain <=255, TLD 2-24) keep
+// matching linear and clear CodeQL's js/polynomial-redos; real emails match
+// identically to the previous unbounded form. Returns a FRESH RegExp each call
+// so callers never share lastIndex across .test()/.replace().
+const EMAIL_PATTERN_SOURCE =
+  "[A-Z0-9._%+-]{1,64}@[A-Z0-9.-]{1,255}\\.[A-Z]{2,24}";
+
+export function emailPattern(flags = "gi"): RegExp {
+  return new RegExp(EMAIL_PATTERN_SOURCE, flags);
+}
+
 /**
  * Full 4-rule sanitizer for raw text (commit subjects before collector
  * redaction, dirty-file paths, manual notes). Applies, in order, email →
@@ -41,15 +53,12 @@ export function sanitizeText(value: string): RedactionResult {
   const categories = new Set<RedactionCategory>();
   let sanitized = value;
 
-  // Quantifiers are bounded (RFC-5321-ish limits) to keep matching linear and
-  // avoid the polynomial-ReDoS CodeQL flags on the unbounded form. Real emails
-  // match identically.
-  if (/[A-Z0-9._%+-]{1,64}@[A-Z0-9.-]{1,255}\.[A-Z]{2,24}/i.test(sanitized)) {
+  // Bounded quantifiers (see emailPattern) keep matching linear and avoid the
+  // polynomial-ReDoS CodeQL flags on the unbounded form. Real emails match
+  // identically.
+  if (emailPattern("i").test(sanitized)) {
     categories.add("emails");
-    sanitized = sanitized.replace(
-      /[A-Z0-9._%+-]{1,64}@[A-Z0-9.-]{1,255}\.[A-Z]{2,24}/gi,
-      "[redacted-email]"
-    );
+    sanitized = sanitized.replace(emailPattern("gi"), "[redacted-email]");
   }
 
   if (/(^|[\s(["'])\/[^\s)"']+/.test(sanitized)) {

--- a/src/safety-report.ts
+++ b/src/safety-report.ts
@@ -1,3 +1,5 @@
+import { emailPattern } from "./redaction.js";
+
 export type SafetyStatus = "safe" | "warning" | "blocked";
 
 export type SafetyRiskCategory =
@@ -100,7 +102,7 @@ const detectionRules: DetectionRule[] = [
     severity: "warning",
     replacement: "[redacted-email]",
     message: "Email address was redacted.",
-    pattern: /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi
+    pattern: emailPattern("gi")
   },
   {
     category: "phone-number",

--- a/src/safety-report.ts
+++ b/src/safety-report.ts
@@ -102,6 +102,10 @@ const detectionRules: DetectionRule[] = [
     severity: "warning",
     replacement: "[redacted-email]",
     message: "Email address was redacted.",
+    // One shared instance is safe here: it is only ever consumed via
+    // String.replace (applyRule), which resets lastIndex before and after
+    // matching. Do NOT switch this to .test()/.exec(), which would carry
+    // lastIndex across calls. Use emailPattern() for a fresh instance instead.
     pattern: emailPattern("gi")
   },
   {

--- a/tests/redaction.test.ts
+++ b/tests/redaction.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { emailPattern } from "../src/redaction.js";
+
+describe("emailPattern", () => {
+  it("is a function exported from src/redaction.js", () => {
+    expect(typeof emailPattern).toBe("function");
+  });
+
+  it("defaults to the gi flags", () => {
+    expect(emailPattern().flags).toBe("gi");
+  });
+
+  it("returns a fresh RegExp instance on every call", () => {
+    expect(emailPattern("gi")).not.toBe(emailPattern("gi"));
+  });
+
+  it("honors requested flags", () => {
+    const pattern = emailPattern("i");
+    expect(pattern.global).toBe(false);
+    expect(pattern.ignoreCase).toBe(true);
+  });
+
+  it("matches representative real emails", () => {
+    expect(emailPattern("i").test("foo.bar+baz@sub.example.co.uk")).toBe(true);
+    expect(emailPattern("i").test("a@b.co")).toBe(true);
+    expect(emailPattern("i").test("USER_NAME@Example.COM")).toBe(true);
+  });
+
+  it("does not match non-email text", () => {
+    expect(emailPattern("i").test("not-an-email")).toBe(false);
+    expect(emailPattern("i").test("@nodomain")).toBe(false);
+  });
+
+  it("uses a bounded pattern source (no unbounded +/{2,} email quantifiers)", () => {
+    const source = emailPattern().source;
+    expect(source).toContain("{1,64}");
+    expect(source).toContain("{1,255}");
+    expect(source).toContain("{2,24}");
+  });
+});


### PR DESCRIPTION
🤖 **Auto-generated by Uncommitted Builder (Routine B v2 — single-issue path)**

## Issue
[UNC-137: 이메일 redaction 정규식 repo 전역 ReDoS 하드닝 + 공유 모듈 통합](https://linear.app/sangchu/issue/UNC-137)

Routine A가 분해 불필요(single-issue)로 판정하여 sub-issue 없이 이 이슈를 그대로 단일 작업으로 처리했습니다.

## What changed
Unbounded 이메일 정규식 `[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}` (CodeQL js/polynomial-redos)을 repo 전역에서 제거하고, bounded 패턴을 **단일 출처**로 통합했습니다.

- 신규 export `emailPattern(flags = "gi")` in `src/redaction.ts` — bounded source `[A-Z0-9._%+-]{1,64}@[A-Z0-9.-]{1,255}\.[A-Z]{2,24}` (PR #100과 동일: local ≤64, domain ≤255, TLD 2–24). 호출마다 **fresh RegExp** 반환 → `.test()`/`.replace()` 간 `lastIndex` 공유 위험 제거.
- 5개 사이트를 팩토리로 라우팅: `redaction.ts`(sanitizeText), `git-activity-collector.ts`(redactSensitiveText), `ai-provider.ts`, `diary-generator.ts`, `safety-report.ts`. 이메일 정규식 리터럴은 이제 `EMAIL_PATTERN_SOURCE` 단 하나만 존재.
- 실제 이메일 매칭 동작 불변 (bounded/unbounded 차이는 64자 초과 병리적 입력에서만 발생 — 실제 이메일 아님).
- 범위: 이메일 정규식 only. path/URL/secret/phone 정규식·redaction 카테고리/정책 미변경 (이슈에서 path/URL primitive 통합은 optional "가능하면" → 동작 drift 회피 위해 의도적으로 보류).

## Status
- Branch: `claude/UNC-137-email-redaction-redos`
- Tests: ✅ 784 passed / 1 skipped (vitest) — carousel smoke는 Playwright Chromium 설치 후 통과
- Build: ✅
- Type check: ✅
- Lint: ✅

## TDD trail
- `tests/redaction.test.ts` 신규 7 케이스: RED (`TypeError: emailPattern is not a function`) → GREEN (7/7). fresh-instance identity, 기본/지정 flags, 대표 이메일 매칭/비매칭, bounded-source 검증.
- Attempt 1: ✅ success

## Notes
- 신규 의존성/환경변수 없음. lockfile 변경 없음.
- CodeQL polynomial-ReDoS 경고는 bounded quantifier로 해소 (수용 기준: repo 전역 0).

## Review checklist
- [ ] Verify TDD test coverage (`tests/redaction.test.ts`)
- [ ] Confirm no lockfile changes (none)
- [ ] Run `pnpm install && pnpm test && pnpm build` locally (carousel smoke 실행 시 `pnpm exec playwright install chromium` 필요)
- [ ] Confirm no auto-publish code introduced (none)
- [ ] **single-issue 판정이 적절했는지 확인** — 사후에 분해가 필요했다고 판단되면 PR 닫고 이슈에서 `single-issue` 라벨 제거 후 Decomposer 재실행 권장

---
이 PR은 자동 생성되었습니다. 머지 전 사람의 리뷰가 반드시 필요합니다.
